### PR TITLE
ci: fix turbo cache miss

### DIFF
--- a/.cicd/commands/main.sh
+++ b/.cicd/commands/main.sh
@@ -25,6 +25,12 @@ yarn lerna version --yes --no-push
 # https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces
 yarn turbo run lint build test --filter=...[$LATEST_TAG]
 
+# Undo all files that were changed by the build command—this happens because
+# the build can change files with different linting rules, or modify some
+# auto-generated docs. We don't want these changes becaues it will cause
+# turbo cache missing. https://turbo.build/repo/docs/core-concepts/caching#missing-the-cache
+git checkout -- .
+
 # Publish packages
 yarn lerna publish from-git --yes
 


### PR DESCRIPTION
Fix PR fixes turbo cache miss because our `build` command generates files without lint and auto-generated docs. When this happens, turbo misses all packages when we run `deploy`.

Example after running `build`:

![image](https://user-images.githubusercontent.com/16626980/208319368-018adf18-8927-4de3-b40e-2c39cb7f3997.png)

![image](https://user-images.githubusercontent.com/16626980/208319447-7c623aed-6098-4154-9015-2089e254841c.png)
