### PR TITLE
ci: monorepo turbo

### DIFF
--- a/.cicd/commands/main.sh
+++ b/.cicd/commands/main.sh
@@ -13,7 +13,7 @@ git fetch --tags --quiet
 git tag --points-at HEAD | grep -q . && { echo "There are tags in the current commit, exiting main workflow" && exit 0; }
 
 # Retrieve the latest tag
-LATEST_TAG=$(git describe --tags --abbrev=0)
+export LATEST_TAG=$(git describe --tags --abbrev=0)
 
 # Setup NPM token
 # Using ~/.npmrc instead of .npmrc because pnpm uses .npmrc and appending

--- a/.cicd/commands/main.sh
+++ b/.cicd/commands/main.sh
@@ -44,10 +44,7 @@ if pnpm lerna changed; then
   # https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces
   pnpm turbo run build test --filter=...[$LATEST_TAG]
 
-  # Undo all files that were changed by the build command—this happens because
-  # the build can change files with different linting rules, or modify some
-  # auto-generated docs. We don't want these changes becaues it will cause
-  # turbo cache missing. https://turbo.build/repo/docs/core-concepts/caching#missing-the-cache
+  # See description on pr.sh.
   git checkout -- .
 
   # Use Git to check for changes in the origin repository. If there are any

--- a/.cicd/commands/pr.sh
+++ b/.cicd/commands/pr.sh
@@ -1,3 +1,6 @@
+# Retrieve the latest tag
+export LATEST_TAG=$(git describe --tags --abbrev=0)
+
 # Test, build, and deploy all packages since main
 # and all the workspaces that depends on them.
 # https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces

--- a/.cicd/commands/pr.sh
+++ b/.cicd/commands/pr.sh
@@ -1,7 +1,13 @@
 # Retrieve the latest tag
 export LATEST_TAG=$(git describe --tags --abbrev=0)
 
-# Test, build, and deploy all packages since main
+# Test and build all packages since main
 # and all the workspaces that depends on them.
 # https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces
-pnpm turbo run build test deploy --filter=...[main]
+pnpm turbo run build test --filter=...[main]
+
+# Run deploy separately from command above because we don't want to deploy
+# packages with bug. As `test` isn't a dependsOn of `deploy` on turbo.json,
+# we need to run them separately. If we run them together and deploy is faster,
+# `deploy` will run even if `test` fails.
+pnpm turbo run deploy --filter=...[main]

--- a/.cicd/commands/pr.sh
+++ b/.cicd/commands/pr.sh
@@ -6,6 +6,12 @@ export LATEST_TAG=$(git describe --tags --abbrev=0)
 # https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces
 pnpm turbo run build test --filter=...[main]
 
+# Undo all files that were changed by the build command—this happens because
+# the build can change files with different linting rules, or modify some
+# auto-generated docs. We don't want these changes becaues it will cause
+# turbo cache missing. https://turbo.build/repo/docs/core-concepts/caching#missing-the-cache
+git checkout -- .
+
 # Run deploy separately from command above because we don't want to deploy
 # packages with bug. As `test` isn't a dependsOn of `deploy` on turbo.json,
 # we need to run them separately. If we run them together and deploy is faster,

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ For more information about each package, please, refer to the README of them.
 For contributing, building `config` is required, as this set some settings accross all the repository.
 
 1. Fork the repository
-2. Clone it
-3. Build `config`
+1. Clone it
+1. Install dependencies
 
-```sh
-pnpm build:config
-```
+   ```sh
+   pnpm install
+   ```
 
-4. Contribute ;)
+1. Build `config`
+
+   ```sh
+   pnpm build:config
+   ```
+
+1. Contribute ;)

--- a/packages/carlin/package.json
+++ b/packages/carlin/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src",
-    "test": "jest"
+    "test": "jest --changedSince=$LATEST_TAG"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.321.1",

--- a/turbo.json
+++ b/turbo.json
@@ -27,8 +27,12 @@
         "tests/**/*.tsx"
       ]
     },
+    "topoTest": {
+      "dependsOn": ["^topoTest", "^test"],
+      "outputs": []
+    },
     "deploy": {
-      "dependsOn": ["build", "test"],
+      "dependsOn": ["build", "test", "^topoTest", "^deploy"],
       "outputs": [".carlin/**"]
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,7 @@
       ]
     },
     "deploy": {
-      "dependsOn": ["build", "test", "^deploy"],
+      "dependsOn": ["build", "^deploy"],
       "outputs": [".carlin/**"]
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -27,12 +27,8 @@
         "tests/**/*.tsx"
       ]
     },
-    "topoTest": {
-      "dependsOn": ["^topoTest", "^test"],
-      "outputs": []
-    },
     "deploy": {
-      "dependsOn": ["build", "test", "^topoTest", "^deploy"],
+      "dependsOn": ["build", "test", "^deploy"],
       "outputs": [".carlin/**"]
     }
   }


### PR DESCRIPTION
- remove `test` from the `deploy` dependency on `turbo.json.` This way, Turbo doesn't run unnecessary tests.
- only execute carlin tests on modified files.