### PR TITLE
fix: no matching export SelectProps

### DIFF
--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Icon, Text } from '..';
-import { SelectProps, Select as SelectUi } from 'theme-ui';
+import { type SelectProps, Select as SelectUi } from 'theme-ui';
 
 export { SelectProps };
 


### PR DESCRIPTION
While building, the compiler includes this import as a value.

By adding the type annotation, the compiler will includes this as a type declaration, while ignoring it on final bundler.