### PR TITLE
Feat/export onError

### DIFF
--- a/packages/react-i18n/i18n/lang/en.json
+++ b/packages/react-i18n/i18n/lang/en.json
@@ -3,6 +3,10 @@
     "defaultMessage": "My name is {name}.",
     "description": "My name is"
   },
+  "JyBnk6": {
+    "defaultMessage": "Untranslated Message",
+    "description": "Untranslated Message"
+  },
   "tPkQ38": {
     "defaultMessage": "Other message",
     "description": "Other message"

--- a/packages/react-i18n/src/i18Provider.tsx
+++ b/packages/react-i18n/src/i18Provider.tsx
@@ -10,6 +10,7 @@ export type I18nProviderProps = {
   locale?: string;
   loadLocaleData?: LoadLocaleData;
   children?: React.ReactNode;
+  onError?: (err: Error) => void;
 };
 
 /**


### PR DESCRIPTION
Format.js error messages can be very annoying, specially when you have a certain quantity of messages that are not translated, and shows these error messages in every rerender:

![image](https://github.com/ttoss/ttoss/assets/2249213/bd3cdab1-f932-41ab-9702-a1ae99d2dae3)

By exporting the onError function, the user can define and configure the provider behavior when these errors occurs. The test provides a good example that intercepts completely error messages (by making nothing with it);