### PR TITLE
feat(@ttoss/cloud-auth): accept roles arn

### DIFF
--- a/packages/cloud-auth/README.md
+++ b/packages/cloud-auth/README.md
@@ -1,9 +1,11 @@
 # @ttoss/cloud-auth
 
+It's a library for creating AWS Cognito resources. It creates an user pool, an identity pool and a client application.
+
 ## Installation
 
 ```bash
-yarn install @ttoss/cloud-auth
+pnpm add @ttoss/cloud-auth
 ```
 
 ## Quickstart
@@ -16,4 +18,74 @@ import { createAuthTemplate } from '@ttoss/cloud-auth';
 const template = createAuthTemplate();
 
 export default template;
+```
+
+## Usage
+
+### Identity Pool
+
+#### Create an basic identity pool
+
+```typescript
+const template = createAuthTemplate({
+  identityPool: {
+    enabled: true, // false by default
+    name: 'MyIdentityPool',
+    allowUnauthenticatedIdentities: false, // false by default
+  },
+});
+```
+
+#### Create an identity pool with external roles
+
+```typescript
+const template = createAuthTemplate({
+  identityPool: {
+    enabled: true,
+    authenticatedRoleArn:
+      'arn:aws:iam::123456789012:role/MyIdentityPool_AuthenticatedRole',
+    unauthenticatedRoleArn:
+      'arn:aws:iam::123456789012:role/MyIdentityPool_UnauthenticatedRole',
+  },
+});
+```
+
+#### Create an identity pool with defined policies
+
+```typescript
+const template = createAuthTemplate({
+  identityPool: {
+    enabled: true,
+    authenticatedPolicies: [
+      {
+        policyName: 'MyIdentityPool_AuthenticatedPolicy',
+        policyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: ['mobileanalytics:PutEvents', 'cognito-sync:*'],
+              Resource: ['*'],
+            },
+          ],
+        },
+      },
+    ],
+    unauthenticatedPolicies: [
+      {
+        policyName: 'MyIdentityPool_UnauthenticatedPolicy',
+        policyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Deny',
+              Action: ['*'],
+              Resource: ['*'],
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
 ```


### PR DESCRIPTION
Added `authenticatedRoleArn` and `unauthenticatedRoleArn`

```typescript
const template = createAuthTemplate({
  identityPool: {
    enabled: true,
    authenticatedRoleArn:
      'arn:aws:iam::123456789012:role/MyIdentityPool_AuthenticatedRole',
    unauthenticatedRoleArn:
      'arn:aws:iam::123456789012:role/MyIdentityPool_UnauthenticatedRole',
  },
});