### PR TITLE
fix: resolve issue with graphql-api compiler, closes #501

### DIFF
--- a/challenge/packages/api-graphql-with-dynamodb/tsconfig.json
+++ b/challenge/packages/api-graphql-with-dynamodb/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@ttoss/config/tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
-      "src/*": ["./src/*"]
+      "src/*": ["src/*"]
     }
   }
 }

--- a/packages/graphql-api/README.md
+++ b/packages/graphql-api/README.md
@@ -18,6 +18,21 @@ pnpm add @ttoss/graphql-api graphql
 
 This library uses [`graphql-compose`](https://graphql-compose.github.io/) to create the GraphQL schema. It re-export all the [`graphql-compose`](https://graphql-compose.github.io/) types and methods, so you can use it directly from this package.
 
+## On `tsconfig.json` Schema
+
+This library uses the `tsconfig.json` file from the target package it is being applied on. In order to interpret the path aliases that it relies on, it uses [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths) to resolve the modules that uses such paths. Therefore, the `tsconfig.json` file must have the [`baseUrl`](https://www.typescriptlang.org/tsconfig#baseUrl) and the [`paths`](https://www.typescriptlang.org/tsconfig#paths) properties filled accordingly. An example that follows such recommendations is given below:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  }
+}
+```
+
 ### Type Creation
 
 For more examples about how to create types, check the [`graphql-compose`](https://graphql-compose.github.io/docs/basics/understanding-types.html) documentation.

--- a/packages/graphql-api/README.md
+++ b/packages/graphql-api/README.md
@@ -18,21 +18,6 @@ pnpm add @ttoss/graphql-api graphql
 
 This library uses [`graphql-compose`](https://graphql-compose.github.io/) to create the GraphQL schema. It re-export all the [`graphql-compose`](https://graphql-compose.github.io/) types and methods, so you can use it directly from this package.
 
-## On `tsconfig.json` Schema
-
-This library uses the `tsconfig.json` file from the target package it is being applied on. In order to interpret the path aliases that it relies on, it uses [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths) to resolve the modules that uses such paths. Therefore, the `tsconfig.json` file must have the [`baseUrl`](https://www.typescriptlang.org/tsconfig#baseUrl) and the [`paths`](https://www.typescriptlang.org/tsconfig#paths) properties filled accordingly. An example that follows such recommendations is given below:
-
-```json
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "src/*": ["src/*"]
-    }
-  }
-}
-```
-
 ### Type Creation
 
 For more examples about how to create types, check the [`graphql-compose`](https://graphql-compose.github.io/docs/basics/understanding-types.html) documentation.
@@ -47,6 +32,19 @@ const UserTC = schemaComposer.createObjectTC({
     name: 'String!',
   },
 });
+```
+
+This library uses the `tsconfig.json` file from the target package it is being applied on. If you are using relative imports in your package you can skip this section, but, if you use path aliases in your typescript code by leveraging the [`paths`](https://www.typescriptlang.org/tsconfig#paths) property, the [`baseUrl`](https://www.typescriptlang.org/tsconfig#baseUrl) must be filled accordingly.This is needed because in order to interpret the path aliases, `ts-node` uses [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths) to resolve the modules that uses this config, and `tsconfig-paths` needs both `baseUrl` and `paths` values to be non-null. A `tsconfig.json` example that follows such recommendations is given below:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  }
+}
 ```
 
 ### Resolvers

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -37,6 +37,7 @@
     "graphql-shield": "^7.6.5",
     "npmlog": "^7.0.1",
     "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
@@ -47,7 +48,6 @@
     "@types/yargs": "^17.0.32",
     "graphql": "^16.8.1",
     "jest": "^29.7.0",
-    "tsconfig-paths": "^4.2.0",
     "tsup": "^8.0.2"
   },
   "keywords": [

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -47,6 +47,7 @@
     "@types/yargs": "^17.0.32",
     "graphql": "^16.8.1",
     "jest": "^29.7.0",
+    "tsconfig-paths": "^4.2.0",
     "tsup": "^8.0.2"
   },
   "keywords": [

--- a/packages/graphql-api/src/cli.ts
+++ b/packages/graphql-api/src/cli.ts
@@ -12,23 +12,24 @@ import yargs from 'yargs';
 const logPrefix = 'graphql-api';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const tsConfig = require(path.resolve(process.cwd(), 'tsconfig.json'));
+let cleanup = () => {};
 try {
   const baseUrl = tsConfig.compilerOptions.baseUrl;
   const paths = tsConfig.compilerOptions.paths;
-  if (!baseUrl || !paths) {
+  if ((baseUrl && !paths) || (!baseUrl && paths)) {
     throw new Error(
       "tsconfig.json must have 'baseUrl' and 'paths' properties."
     );
   }
+  cleanup = registerTsPaths({
+    baseUrl: tsConfig.compilerOptions.baseUrl,
+    paths: tsConfig.compilerOptions.paths,
+  });
 } catch (error: unknown) {
   error instanceof Error && log.error(logPrefix, error.message);
   process.exit(1);
 }
 
-const cleanup = registerTsPaths({
-  baseUrl: tsConfig.compilerOptions.baseUrl,
-  paths: tsConfig.compilerOptions.paths,
-});
 register({
   transpileOnly: true,
   compilerOptions: {

--- a/packages/graphql-api/src/cli.ts
+++ b/packages/graphql-api/src/cli.ts
@@ -14,17 +14,19 @@ const logPrefix = 'graphql-api';
 const tsConfig = require(path.resolve(process.cwd(), 'tsconfig.json'));
 let cleanup = () => {};
 try {
-  const baseUrl = tsConfig.compilerOptions.baseUrl;
-  const paths = tsConfig.compilerOptions.paths;
+  const baseUrl = tsConfig?.compilerOptions?.baseUrl;
+  const paths = tsConfig?.compilerOptions?.paths;
   if ((baseUrl && !paths) || (!baseUrl && paths)) {
     throw new Error(
       "tsconfig.json must have 'baseUrl' and 'paths' properties."
     );
   }
-  cleanup = registerTsPaths({
-    baseUrl: tsConfig.compilerOptions.baseUrl,
-    paths: tsConfig.compilerOptions.paths,
-  });
+  if (baseUrl && paths) {
+    cleanup = registerTsPaths({
+      baseUrl: tsConfig.compilerOptions.baseUrl,
+      paths: tsConfig.compilerOptions.paths,
+    });
+  }
 } catch (error: unknown) {
   error instanceof Error && log.error(logPrefix, error.message);
   process.exit(1);

--- a/packages/graphql-api/src/cli.ts
+++ b/packages/graphql-api/src/cli.ts
@@ -12,6 +12,19 @@ import yargs from 'yargs';
 const logPrefix = 'graphql-api';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const tsConfig = require(path.resolve(process.cwd(), 'tsconfig.json'));
+try {
+  const baseUrl = tsConfig.compilerOptions.baseUrl;
+  const paths = tsConfig.compilerOptions.paths;
+  if (!baseUrl || !paths) {
+    throw new Error(
+      "tsconfig.json must have 'baseUrl' and 'paths' properties."
+    );
+  }
+} catch (error: unknown) {
+  error instanceof Error && log.error(logPrefix, error.message);
+  process.exit(1);
+}
+
 const cleanup = registerTsPaths({
   baseUrl: tsConfig.compilerOptions.baseUrl,
   paths: tsConfig.compilerOptions.paths,

--- a/packages/graphql-api/src/cli.ts
+++ b/packages/graphql-api/src/cli.ts
@@ -5,11 +5,17 @@ import { codegen } from '@graphql-codegen/core';
 import { hideBin } from 'yargs/helpers';
 import { parse } from 'graphql';
 import { register } from 'ts-node';
+import { register as registerTsPaths } from 'tsconfig-paths';
 import log from 'npmlog';
 import yargs from 'yargs';
 
 const logPrefix = 'graphql-api';
-
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const tsConfig = require(path.resolve(process.cwd(), 'tsconfig.json'));
+const cleanup = registerTsPaths({
+  baseUrl: tsConfig.compilerOptions.baseUrl,
+  paths: tsConfig.compilerOptions.paths,
+});
 register({
   transpileOnly: true,
   compilerOptions: {
@@ -77,7 +83,7 @@ const buildSchema = async ({ directory }: { directory: string }) => {
     'schema/types.ts',
     `${typesOutputIgnore}\n${typesOutput}`
   );
-
+  cleanup();
   log.info(logPrefix, 'Schema and types generated!');
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,6 +947,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.20)(ts-node@10.9.2)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(ts-node@10.9.2)(typescript@5.2.2)
@@ -25675,7 +25678,6 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-    dev: false
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -26354,6 +26356,15 @@ packages:
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: false
+
+  /tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+    dev: true
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -931,6 +931,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.11.20)(typescript@5.2.2)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -947,9 +950,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.20)(ts-node@10.9.2)
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(ts-node@10.9.2)(typescript@5.2.2)
@@ -25678,6 +25678,7 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+    dev: false
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -26364,7 +26365,7 @@ packages:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
-    dev: true
+    dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}


### PR DESCRIPTION
Issue #501 clarifies what was done. But, to sum it up, it add tsconfig-paths to interpret to correctly resolve import paths as configured in a specific tsconfig.json. The only thing is that the property `baseUrl` must be configured on the target `tsconfig.json`.