### PR TITLE
fix: remove import star from sequelize-typescript

### DIFF
--- a/packages/postgresdb/src/ModelColumns.ts
+++ b/packages/postgresdb/src/ModelColumns.ts
@@ -1,4 +1,4 @@
-import { Model } from 'sequelize-typescript';
+import { Model } from './sequelize-typescript';
 
 export type ModelColumns<T> = Omit<T, keyof Model> &
   Pick<Model, 'id' | 'createdAt' | 'updatedAt'>;

--- a/packages/postgresdb/src/index.ts
+++ b/packages/postgresdb/src/index.ts
@@ -1,3 +1,4 @@
-export * from 'sequelize-typescript';
+export * from './sequelize-typescript';
 export { initialize } from './initialize';
 export type { ModelColumns } from './ModelColumns';
+export { Op } from 'sequelize';

--- a/packages/postgresdb/src/initialize.ts
+++ b/packages/postgresdb/src/initialize.ts
@@ -3,7 +3,7 @@ import {
   type ModelCtor,
   Sequelize,
   type SequelizeOptions,
-} from 'sequelize-typescript';
+} from './sequelize-typescript';
 
 let sequelize: Sequelize;
 

--- a/packages/postgresdb/src/sequelize-typescript.ts
+++ b/packages/postgresdb/src/sequelize-typescript.ts
@@ -1,0 +1,21 @@
+/**
+ * Exports the necessary classes from the sequelize-typescript package.
+ */
+export {
+  BelongsTo,
+  BelongsToMany,
+  Column,
+  CreatedAt,
+  DataType,
+  DeletedAt,
+  ForeignKey,
+  HasMany,
+  HasOne,
+  Index,
+  Model,
+  Sequelize,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript';
+
+export type { ModelCtor, SequelizeOptions } from 'sequelize-typescript';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for local exports of classes and types related to Sequelize.
	- Added export for `Op` from the Sequelize module.

- **Bug Fixes**
	- Updated import paths for `Model` and `Sequelize` to ensure local module usage without affecting functionality.

- **Documentation**
	- Enhanced clarity on the structure of exported classes and types from the new local module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->