### PR TITLE
fix: postgresdb cli external

### DIFF
--- a/packages/postgresdb-cli/package.json
+++ b/packages/postgresdb-cli/package.json
@@ -25,7 +25,6 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@ttoss/postgresdb": "workspace:^",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "esbuild": "^0.24.0",

--- a/packages/postgresdb-cli/src/getDbDynamically.ts
+++ b/packages/postgresdb-cli/src/getDbDynamically.ts
@@ -12,12 +12,7 @@ export const getDbDynamically = async ({ dbPath }: { dbPath: string }) => {
   const result = esbuild.buildSync({
     bundle: true,
     entryPoints: [entryPoint],
-    /**
-     * ttoss packages cannot be market as external because it'd break the CI.
-     * On CI, ttoss packages point to the TS main file, not the compiled
-     * ones. See more details here https://github.com/ttoss/ttoss/issues/541.
-     */
-    external: ['pg', 'sequelize', 'sequelize-typescript'],
+    external: ['@ttoss/postgresdb'],
     format: 'esm',
     outfile,
     platform: 'node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1256,9 +1256,6 @@ importers:
 
   packages/postgresdb-cli:
     dependencies:
-      '@ttoss/postgresdb':
-        specifier: workspace:^
-        version: link:../postgresdb
       commander:
         specifier: ^12.1.0
         version: 12.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed dependency on `@ttoss/postgresdb` from the `@ttoss/postgresdb-cli` package.
	- Updated external dependencies in the build configuration to streamline the handling of packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->