### PR TITLE
fix: termsAndConditions props

### DIFF
--- a/docs/storybook/stories/react-auth/AuthSignUp.stories.tsx
+++ b/docs/storybook/stories/react-auth/AuthSignUp.stories.tsx
@@ -20,7 +20,7 @@ export const WithRequiredTerms = Template.bind({});
 WithRequiredTerms.args = {
   signUpTerms: {
     isRequired: true,
-    termsAndConditions: [
+    terms: [
       {
         label: 'Terms and Conditions',
         url: 'https://example.com/terms',
@@ -37,7 +37,7 @@ export const WithOptionalTerms = Template.bind({});
 WithOptionalTerms.args = {
   signUpTerms: {
     isRequired: false,
-    termsAndConditions: [
+    terms: [
       {
         label: 'Terms and Conditions',
         url: 'https://example.com/terms',

--- a/packages/react-auth/src/AuthSignUp.tsx
+++ b/packages/react-auth/src/AuthSignUp.tsx
@@ -140,7 +140,7 @@ export const AuthSignUp = (props: AuthSignUpProps) => {
   }, [props.signUpTerms, signUpTermsLabel]);
 
   const formMethods = useForm<OnSignUpInput>({
-    mode: 'onBlur',
+    mode: 'all',
     resolver: yupResolver(schema),
   });
 

--- a/packages/react-auth/src/AuthSignUp.tsx
+++ b/packages/react-auth/src/AuthSignUp.tsx
@@ -21,7 +21,7 @@ export type AuthSignUpProps = {
   onReturnToSignIn: () => void;
   signUpTerms?: {
     isRequired: boolean;
-    termsAndConditions: {
+    terms: {
       label: string;
       url: string;
     }[];
@@ -105,21 +105,18 @@ export const AuthSignUp = (props: AuthSignUpProps) => {
         'By signing up, you agree to the following Terms and Conditions.',
     });
 
-    const termsLinks = props.signUpTerms.termsAndConditions.map(
-      (term, index, termsAndConditions) => {
-        const finalPunctuation =
-          index === termsAndConditions.length - 1 ? '.' : ', ';
+    const termsLinks = props.signUpTerms.terms.map((term, index, terms) => {
+      const finalPunctuation = index === terms.length - 1 ? '.' : ', ';
 
-        return (
-          <React.Fragment key={index}>
-            <Link key={index} href={term.url} target="_blank" rel="noreferrer">
-              {term.label}
-            </Link>
-            {finalPunctuation}
-          </React.Fragment>
-        );
-      }
-    );
+      return (
+        <React.Fragment key={index}>
+          <Link key={index} href={term.url} target="_blank" rel="noreferrer">
+            {term.label}
+          </Link>
+          {finalPunctuation}
+        </React.Fragment>
+      );
+    });
 
     const label = (
       <Text>
@@ -143,7 +140,7 @@ export const AuthSignUp = (props: AuthSignUpProps) => {
   }, [props.signUpTerms, signUpTermsLabel]);
 
   const formMethods = useForm<OnSignUpInput>({
-    mode: 'all',
+    mode: 'onBlur',
     resolver: yupResolver(schema),
   });
 

--- a/packages/react-auth/tests/unit/tests/AuthSignUp.test.tsx
+++ b/packages/react-auth/tests/unit/tests/AuthSignUp.test.tsx
@@ -68,7 +68,7 @@ describe('sign up terms', () => {
             onReturnToSignIn,
             signUpTerms: {
               isRequired,
-              termsAndConditions: [
+              terms: [
                 {
                   label: 'Terms and Conditions',
                   url: 'https://example.com/terms',
@@ -83,13 +83,10 @@ describe('sign up terms', () => {
         />
       );
 
-      const termsAndConditions = screen.getByText('Terms and Conditions');
+      const terms = screen.getByText('Terms and Conditions');
 
-      expect(termsAndConditions).toBeInTheDocument();
-      expect(termsAndConditions).toHaveAttribute(
-        'href',
-        'https://example.com/terms'
-      );
+      expect(terms).toBeInTheDocument();
+      expect(terms).toHaveAttribute('href', 'https://example.com/terms');
 
       const privacyPolicy = screen.getByText('Privacy Policy');
 
@@ -111,7 +108,7 @@ describe('sign up terms', () => {
           onReturnToSignIn,
           signUpTerms: {
             isRequired: true,
-            termsAndConditions: [
+            terms: [
               {
                 label: 'Terms and Conditions',
                 url: 'https://example.com/terms',
@@ -146,7 +143,7 @@ describe('sign up terms', () => {
           onReturnToSignIn,
           signUpTerms: {
             isRequired: true,
-            termsAndConditions: [
+            terms: [
               {
                 label: 'Terms and Conditions',
                 url: 'https://example.com/terms',
@@ -183,7 +180,7 @@ describe('sign up terms', () => {
           onReturnToSignIn,
           signUpTerms: {
             isRequired: false,
-            termsAndConditions: [
+            terms: [
               {
                 label: 'Terms and Conditions',
                 url: 'https://example.com/terms',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Renamed `termsAndConditions` property to `terms` in sign-up component and related files
	- Updated form validation to trigger `onBlur` instead of `all`

- **Documentation**
	- Updated Storybook stories to reflect property name change

- **Tests**
	- Modified test cases to use new `terms` property name
<!-- end of auto-generated comment: release notes by coderabbit.ai -->