### PR TITLE
Update export classe PrimaryKey from sequelize-typescript

### DIFF
--- a/packages/postgresdb/src/sequelize-typescript.ts
+++ b/packages/postgresdb/src/sequelize-typescript.ts
@@ -1,6 +1,7 @@
 /**
  * Exports the necessary classes from the sequelize-typescript package.
  */
+export type { ModelCtor, SequelizeOptions } from 'sequelize-typescript';
 export {
   BelongsTo,
   BelongsToMany,
@@ -16,7 +17,6 @@ export {
   PrimaryKey,
   Sequelize,
   Table,
+  Unique,
   UpdatedAt,
 } from 'sequelize-typescript';
-
-export type { ModelCtor, SequelizeOptions } from 'sequelize-typescript';

--- a/packages/postgresdb/src/sequelize-typescript.ts
+++ b/packages/postgresdb/src/sequelize-typescript.ts
@@ -13,6 +13,7 @@ export {
   HasOne,
   Index,
   Model,
+  PrimaryKey,
   Sequelize,
   Table,
   UpdatedAt,


### PR DESCRIPTION
Export class PrimaryKey from sequelize-typescript for postgresdb package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced support for defining primary key fields in database models, streamlining data structure configuration for improved consistency.
	- Added new exports: `PrimaryKey` and `Unique` types for broader usage in modules.
	- Reorganized export positions for `ModelCtor` and `SequelizeOptions` for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->