### PR TITLE
Update postgres-cli getDbDynamically.ts

### DIFF
--- a/packages/postgresdb-cli/src/erd.ts
+++ b/packages/postgresdb-cli/src/erd.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
-import { getDbDynamically } from './getDbDynamically';
+
 import sequelizeErd from 'sequelize-erd';
+
+import { getDbDynamically } from './getDbDynamically';
 
 export const erd = async ({ dbPath }: { dbPath: string }) => {
   // eslint-disable-next-line no-console

--- a/packages/postgresdb-cli/src/getDbDynamically.ts
+++ b/packages/postgresdb-cli/src/getDbDynamically.ts
@@ -1,7 +1,12 @@
 import 'dotenv/config';
 
-import * as esbuild from 'esbuild';
+import * as builtinModules from 'node:module';
 import path from 'node:path';
+
+import * as esbuild from 'esbuild';
+
+// Get all Node.js built-in modules - using the modern approach
+const nodeBuiltins = builtinModules.builtinModules;
 
 export const getDbDynamically = async ({ dbPath }: { dbPath: string }) => {
   const lastEntryPointName = dbPath.split('/').pop();
@@ -12,7 +17,7 @@ export const getDbDynamically = async ({ dbPath }: { dbPath: string }) => {
   const result = esbuild.buildSync({
     bundle: true,
     entryPoints: [entryPoint],
-    external: ['@ttoss/postgresdb', 'fs', 'path', 'dotenv'],
+    external: ['@ttoss/postgresdb', ...nodeBuiltins],
     format: 'esm',
     outfile,
     platform: 'node',

--- a/packages/postgresdb-cli/src/getDbDynamically.ts
+++ b/packages/postgresdb-cli/src/getDbDynamically.ts
@@ -12,7 +12,7 @@ export const getDbDynamically = async ({ dbPath }: { dbPath: string }) => {
   const result = esbuild.buildSync({
     bundle: true,
     entryPoints: [entryPoint],
-    external: ['@ttoss/postgresdb'],
+    external: ['@ttoss/postgresdb', 'fs', 'path', 'dotenv'],
     format: 'esm',
     outfile,
     platform: 'node',

--- a/packages/postgresdb-cli/src/index.ts
+++ b/packages/postgresdb-cli/src/index.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
+
+import pkg from '../package.json';
 import { erd } from './erd';
 import { sync } from './sync';
-import pkg from '../package.json';
 
 const program = new Command();
 


### PR DESCRIPTION
Fixed issues related to using dynamic require in ESM environments. Adjusted esbuild to exclude fs, path, dotenv modules as externals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to improve handling of Node.js built-in modules during bundling. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->