### PR TITLE
feat: add input tooltip in formfield component

### DIFF
--- a/docs/storybook/stories/forms/FormFieldCEP.stories.tsx
+++ b/docs/storybook/stories/forms/FormFieldCEP.stories.tsx
@@ -51,7 +51,16 @@ const Template: StoryFn = () => {
         <FormFieldCEP name="cepDisabled" label="CEP:" disabled />
       </Flex>
       <Flex sx={{ flexDirection: 'column', gap: 'md' }}>
-        <FormFieldCEP name="cepWarning" label="CEP:" warning={'WARNING'} />
+        <FormFieldCEP
+          name="cepWarning"
+          label="CEP:"
+          warning={'WARNING'}
+          inputTooltip={{
+            render: <div>DWADAFWAD</div>,
+            place: 'bottom',
+            variant: 'success',
+          }}
+        />
       </Flex>
       <Button sx={{ marginTop: 'lg' }} type="submit">
         Submit

--- a/docs/storybook/stories/forms/FormFieldCEP.stories.tsx
+++ b/docs/storybook/stories/forms/FormFieldCEP.stories.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 import { Form, useForm, yup, yupResolver } from '@ttoss/forms';
 import { FormFieldCEP } from '@ttoss/forms/brazil';
-import { Button, Flex, Link } from '@ttoss/ui';
+import { Box, Button, Flex, Link } from '@ttoss/ui';
 import * as React from 'react';
 
 export default {
@@ -56,9 +56,25 @@ const Template: StoryFn = () => {
           label="CEP:"
           warning={'WARNING'}
           inputTooltip={{
-            render: <div>DWADAFWAD</div>,
+            render: (
+              <Box sx={{ fontSize: 'sm' }}>
+                {`Lorem Ipsum is simply dummy text of the printing and typesetting
+                industry. Lorem Ipsum has been the industry's standard dummy
+                text ever since the 1500s, when an unknown printer took a galley
+                of type and scrambled it to make a type specimen book. It has
+                survived not only five centuries, but also the leap into
+                electronic typesetting, remaining essentially unchanged. It was
+                popularised in the 1960s with the release of Letraset sheets
+                containing Lorem Ipsum passages, and more recently with desktop
+                publishing software like Aldus PageMaker including versions of
+                Lorem Ipsum.`}
+              </Box>
+            ),
             place: 'bottom',
-            variant: 'success',
+            variant: 'warning',
+            sx: {
+              width: '400px',
+            },
           }}
         />
       </Flex>

--- a/packages/forms/src/Brazil/FormFieldCNPJ.tsx
+++ b/packages/forms/src/Brazil/FormFieldCNPJ.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@ttoss/ui';
+import { Input, SxProp, Theme, ThemeUIStyleObject } from '@ttoss/ui';
 import { PatternFormat, PatternFormatProps } from 'react-number-format';
 
 import { FormField } from '..';
@@ -7,6 +7,14 @@ export type FormFieldCNPJProps = {
   label: string;
   name: string;
   warning?: string | React.ReactNode;
+  inputTooltip?: {
+    render: string | React.ReactNode;
+    place: 'bottom' | 'top' | 'left' | 'right';
+    openOnClick?: boolean;
+    clickable?: boolean;
+    variant?: 'info' | 'warning' | 'success' | 'error';
+    sx?: ThemeUIStyleObject<Theme>;
+  } & SxProp;
 } & Partial<PatternFormatProps>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -75,6 +83,7 @@ export const FormFieldCNPJ = ({
       name={name}
       label={label}
       warning={patternFormatProps.warning}
+      inputTooltip={patternFormatProps.inputTooltip}
       render={({ field }) => {
         return (
           <PatternFormat

--- a/packages/forms/src/Brazil/FormFieldPhone.tsx
+++ b/packages/forms/src/Brazil/FormFieldPhone.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@ttoss/ui';
+import { Input, SxProp, Theme, ThemeUIStyleObject } from '@ttoss/ui';
 import { PatternFormat, PatternFormatProps } from 'react-number-format';
 
 import { FormField } from '../FormField';
@@ -7,6 +7,14 @@ export type FormFieldPhoneProps = {
   label: string;
   name: string;
   warning?: string | React.ReactNode;
+  inputTooltip?: {
+    render: string | React.ReactNode;
+    place: 'bottom' | 'top' | 'left' | 'right';
+    openOnClick?: boolean;
+    clickable?: boolean;
+    variant?: 'info' | 'warning' | 'success' | 'error';
+    sx?: ThemeUIStyleObject<Theme>;
+  } & SxProp;
 } & Partial<PatternFormatProps>;
 
 export const FormFieldPhone = ({
@@ -19,6 +27,7 @@ export const FormFieldPhone = ({
       name={name}
       label={label}
       warning={patternFormatProps.warning}
+      inputTooltip={patternFormatProps.inputTooltip}
       render={({ field }) => {
         const format =
           field.value?.length > 10 ? '(##) #####-####' : '(##) ####-#####';

--- a/packages/forms/src/FormField.tsx
+++ b/packages/forms/src/FormField.tsx
@@ -1,6 +1,13 @@
-'use client';
-
-import { Checkbox, Flex, Label, Switch, type SxProp, Tooltip } from '@ttoss/ui';
+import {
+  Checkbox,
+  Flex,
+  Label,
+  Switch,
+  type SxProp,
+  Theme,
+  ThemeUIStyleObject,
+  Tooltip,
+} from '@ttoss/ui';
 import * as React from 'react';
 import {
   type FieldPath,
@@ -34,7 +41,8 @@ export type FormFieldProps<
     openOnClick?: boolean;
     clickable?: boolean;
     variant?: 'info' | 'warning' | 'success' | 'error';
-  };
+    sx?: ThemeUIStyleObject<Theme>;
+  } & SxProp;
   warning?: string | React.ReactNode;
 } & SxProp;
 
@@ -47,7 +55,6 @@ type FormFieldCompleteProps<
   ) => React.ReactElement;
 } & FormFieldProps<TFieldValues, TName>;
 
-// Solução 1: Usando estado local e event listeners
 export const FormField = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
@@ -191,7 +198,7 @@ export const FormField = <
       return (
         <Flex
           sx={{
-            width: '100%',
+            width: 'full',
             flexDirection: 'column',
           }}
         >
@@ -218,6 +225,7 @@ export const FormField = <
                 clickable={inputTooltip.clickable}
                 isOpen={showInputTooltip}
                 variant={inputTooltip.variant}
+                sx={inputTooltip.sx}
               >
                 {inputTooltip.render}
               </Tooltip>

--- a/packages/forms/src/FormFieldInput.tsx
+++ b/packages/forms/src/FormFieldInput.tsx
@@ -27,6 +27,7 @@ export const FormFieldInput = <
       disabled={inputProps.disabled}
       tooltip={tooltip}
       warning={inputProps.warning}
+      inputTooltip={inputProps.inputTooltip}
       sx={sx}
       defaultValue={defaultValue as FieldPathValue<TFieldValues, TName>}
       render={({ field, fieldState }) => {

--- a/packages/forms/src/FormFieldNumericFormat.tsx
+++ b/packages/forms/src/FormFieldNumericFormat.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@ttoss/ui';
+import { Input, SxProp, Theme, ThemeUIStyleObject } from '@ttoss/ui';
 import * as React from 'react';
 import { NumericFormat, NumericFormatProps } from 'react-number-format';
 
@@ -14,6 +14,14 @@ export type FormFieldNumericFormatProps = {
     openOnClick?: boolean;
     clickable?: boolean;
   };
+  inputTooltip?: {
+    render: string | React.ReactNode;
+    place: 'bottom' | 'top' | 'left' | 'right';
+    openOnClick?: boolean;
+    clickable?: boolean;
+    variant?: 'info' | 'warning' | 'success' | 'error';
+    sx?: ThemeUIStyleObject<Theme>;
+  } & SxProp;
 } & NumericFormatProps;
 
 export const FormFieldNumericFormat = ({
@@ -21,6 +29,7 @@ export const FormFieldNumericFormat = ({
   name,
   warning,
   tooltip,
+  inputTooltip,
   ...numericFormatProps
 }: FormFieldNumericFormatProps) => {
   return (
@@ -29,6 +38,7 @@ export const FormFieldNumericFormat = ({
       name={name}
       warning={warning}
       tooltip={tooltip}
+      inputTooltip={inputTooltip}
       render={({ field }) => {
         return (
           <NumericFormat

--- a/packages/forms/src/FormFieldPassword.tsx
+++ b/packages/forms/src/FormFieldPassword.tsx
@@ -27,6 +27,7 @@ export const FormFieldPassword = <
       disabled={inputProps.disabled}
       tooltip={tooltip}
       warning={inputProps.warning}
+      inputTooltip={inputProps.inputTooltip}
       sx={sx}
       defaultValue={defaultValue as FieldPathValue<TFieldValues, TName>}
       render={({ field, fieldState }) => {

--- a/packages/forms/src/FormFieldPatternFormat.tsx
+++ b/packages/forms/src/FormFieldPatternFormat.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@ttoss/ui';
+import { Input, Theme, ThemeUIStyleObject } from '@ttoss/ui';
 import { PatternFormat, PatternFormatProps } from 'react-number-format';
 
 import { FormField } from './FormField';
@@ -13,6 +13,7 @@ export type FormFieldPatternFormatProps = {
     openOnClick?: boolean;
     clickable?: boolean;
     variant?: 'info' | 'warning' | 'success' | 'error';
+    sx?: ThemeUIStyleObject<Theme>;
   };
 } & PatternFormatProps;
 

--- a/packages/forms/src/FormFieldPatternFormat.tsx
+++ b/packages/forms/src/FormFieldPatternFormat.tsx
@@ -7,12 +7,20 @@ export type FormFieldPatternFormatProps = {
   label?: string;
   name: string;
   warning?: string | React.ReactNode;
+  inputTooltip?: {
+    render: string | React.ReactNode;
+    place: 'bottom' | 'top' | 'left' | 'right';
+    openOnClick?: boolean;
+    clickable?: boolean;
+    variant?: 'info' | 'warning' | 'success' | 'error';
+  };
 } & PatternFormatProps;
 
 export const FormFieldPatternFormat = ({
   label,
   name,
   warning,
+  inputTooltip,
   ...patternFormatProps
 }: FormFieldPatternFormatProps) => {
   return (
@@ -20,6 +28,7 @@ export const FormFieldPatternFormat = ({
       name={name}
       label={label}
       warning={warning}
+      inputTooltip={inputTooltip}
       render={({ field, fieldState }) => {
         return (
           <PatternFormat

--- a/packages/forms/src/FormFieldSelect.tsx
+++ b/packages/forms/src/FormFieldSelect.tsx
@@ -29,6 +29,7 @@ export const FormFieldSelect = <
       defaultValue={defaultValue}
       disabled={disabled}
       tooltip={tooltip}
+      inputTooltip={selectProps.inputTooltip}
       warning={selectProps.warning}
       sx={sx}
       css={css}

--- a/packages/forms/src/FormFieldTextarea.tsx
+++ b/packages/forms/src/FormFieldTextarea.tsx
@@ -1,4 +1,9 @@
-import { Textarea, type TextareaProps } from '@ttoss/ui';
+import {
+  Textarea,
+  type TextareaProps,
+  Theme,
+  ThemeUIStyleObject,
+} from '@ttoss/ui';
 import { FieldPath, FieldValues } from 'react-hook-form';
 
 import { FormField } from './FormField';
@@ -10,13 +15,21 @@ export const FormFieldTextarea = <
   label,
   name,
   warning,
-
+  inputTooltip,
   sx,
   ...textareaProps
 }: {
   label?: string;
   name: TName;
   warning?: string | React.ReactNode;
+  inputTooltip?: {
+    render: string | React.ReactNode;
+    place: 'bottom' | 'top' | 'left' | 'right';
+    openOnClick?: boolean;
+    clickable?: boolean;
+    variant?: 'info' | 'warning' | 'success' | 'error';
+    sx?: ThemeUIStyleObject<Theme>;
+  };
 } & TextareaProps) => {
   const id = `form-field-textarea-${name}`;
 
@@ -27,6 +40,7 @@ export const FormFieldTextarea = <
       id={id}
       sx={sx}
       warning={warning}
+      inputTooltip={inputTooltip}
       render={({ field, fieldState }) => {
         return (
           <Textarea

--- a/packages/forms/tests/unit/tests/FormFieldSelect.test.tsx
+++ b/packages/forms/tests/unit/tests/FormFieldSelect.test.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
-import { Button } from '@ttoss/ui';
-import { Form, FormFieldSelect, useForm, yup, yupResolver } from '../../../src';
 import { render, screen, userEvent } from '@ttoss/test-utils';
+import { Button } from '@ttoss/ui';
+import * as React from 'react';
+
+import { Form, FormFieldSelect, useForm, yup, yupResolver } from '../../../src';
 
 const OPTIONS = [
   { value: 'ferrari', label: 'Ferrari' },
@@ -121,14 +122,14 @@ test('should display error messages and error icon', async () => {
 
   await user.click(screen.getByText('Submit'));
 
+  expect(await screen.findByText('Car is required')).toBeInTheDocument();
+
   const icons = await screen.findAllByTestId('iconify-icon');
 
   const errorIcon = icons.find((iconEl) => {
     return iconEl.parentElement?.className.includes('error-icon');
   });
-
   expect(errorIcon).toHaveAttribute('icon', 'warning-alt');
-  expect(await screen.findByText('Car is required')).toBeInTheDocument();
 });
 
 test('should set a default value', async () => {

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -2,9 +2,13 @@
 import { type ITooltip } from 'react-tooltip';
 import { Tooltip as TooltipReact } from 'react-tooltip';
 
-import { Box } from '..';
+import { Box, SxProp } from '..';
 
-export const Tooltip = ({ variant = 'info', ...props }: ITooltip) => {
+export const Tooltip = ({
+  variant = 'info',
+  sx,
+  ...props
+}: ITooltip & SxProp) => {
   const className = `tooltip-component tooltip-${variant}`;
 
   const getVariantStyles = (variantType: string) => {
@@ -62,6 +66,7 @@ export const Tooltip = ({ variant = 'info', ...props }: ITooltip) => {
               lineHeight: 'normal',
             },
             ...variantStyles,
+            ...sx,
           },
           [`&.tooltip-${variant}`]: variantStyles,
         };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1c27ab95-afbf-44ca-8e15-8f4ce422b6b7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizable tooltips directly on input fields across various form components, including text, password, numeric, select, textarea, and specialized Brazilian fields (CNPJ, Phone, etc.).
  - Tooltips can display rich content, be positioned on any side, and support different visual variants and custom styles.
- **Documentation**
  - Updated stories to demonstrate the new input tooltip functionality.
- **Style**
  - Enhanced tooltip components to accept and apply custom styling.
- **Tests**
  - Minor improvements to testing order for error message assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->