### PR TITLE
feat: add persist option to notifications

### DIFF
--- a/docs/storybook/stories/react-notifications/Modal.stories.tsx
+++ b/docs/storybook/stories/react-notifications/Modal.stories.tsx
@@ -34,6 +34,7 @@ const schema = yup.object().shape({
   type: yup.string().required(),
   viewType: yup.string().required(),
   boxId: yup.string(),
+  persist: yup.string(),
 });
 
 export const Notifications: StoryFn = () => {
@@ -47,6 +48,7 @@ export const Notifications: StoryFn = () => {
       type: 'info',
       viewType: 'box',
       boxId: '',
+      persist: 'false',
     },
   });
 
@@ -58,6 +60,7 @@ export const Notifications: StoryFn = () => {
       type: values.type,
       viewType: values.viewType,
       boxId: values.boxId,
+      persist: values.persist === 'true',
     });
   };
 
@@ -128,6 +131,21 @@ export const Notifications: StoryFn = () => {
               {
                 label: 'Success',
                 value: 'success',
+              },
+            ]}
+          />
+
+          <FormFieldRadio
+            name="persist"
+            label="Persist"
+            options={[
+              {
+                label: 'No',
+                value: 'false',
+              },
+              {
+                label: 'Yes',
+                value: 'true',
               },
             ]}
           />

--- a/packages/react-notifications/README.md
+++ b/packages/react-notifications/README.md
@@ -202,10 +202,91 @@ const Header = () => {
 };
 ```
 
+### Persistent Notifications
+
+You can create persistent notifications that will not be removed when `clearNotifications()` is called by setting the `persist` property to `true`. This is useful for important notifications that should remain visible until manually dismissed.
+
+```tsx
+import { useNotifications } from '@ttoss/react-notifications';
+import { Box, Button } from '@ttoss/ui';
+
+const Component = () => {
+  const { addNotification, clearNotifications } = useNotifications();
+
+  return (
+    <Box>
+      <Button
+        onClick={() =>
+          addNotification({
+            message: "I'm a persistent notification",
+            type: 'warning',
+            persist: true, // This notification will not be cleared by clearNotifications()
+          })
+        }
+      >
+        Add Persistent Notification
+      </Button>
+      <Button
+        onClick={() =>
+          addNotification({
+            message: "I'm a regular notification",
+            type: 'info',
+            persist: false, // This notification will be cleared by clearNotifications()
+          })
+        }
+      >
+        Add Regular Notification
+      </Button>
+      <Button onClick={clearNotifications}>
+        Clear All Non-Persistent Notifications
+      </Button>
+    </Box>
+  );
+};
+```
+
+        Show Header Notification
+      </Button>
+    </Box>
+
+);
+};
+
+```
+
 #### Recommendation
 
 "You can place the `NotificationsBox` component at the root of your application to handle notifications rendering automatically, eliminating the need to manage it manually elsewhere. If you need a specific `NotificationsBox`, simply render the `NotificationsBox` in the desired location and use the `boxId` property to differentiate it."
 
+## API
+
+### Notification Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `id` | `string \| number` | Auto-generated | Unique identifier for the notification |
+| `title` | `string` | - | Optional title for the notification |
+| `message` | `string` | **Required** | The notification message content |
+| `type` | `'warning' \| 'error' \| 'info' \| 'success'` | **Required** | The type of notification |
+| `viewType` | `'toast' \| 'modal' \| 'box' \| 'header'` | `'box'` | Where the notification should be displayed |
+| `toast` | `ToastOptions` | - | Additional options for toast notifications |
+| `boxId` | `string \| number` | - | ID of the specific NotificationsBox to display the notification |
+| `persist` | `boolean` | `false` | Whether the notification should persist when `clearNotifications()` is called |
+
+### useNotifications Hook
+
+The `useNotifications` hook returns an object with the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `notifications` | `Notification[]` | Array of current notifications |
+| `addNotification` | `(notification: Notification \| Notification[]) => void` | Function to add one or more notifications |
+| `removeNotification` | `(id: string \| number) => void` | Function to remove a specific notification by ID |
+| `clearNotifications` | `() => void` | Function to clear all non-persistent notifications |
+| `isLoading` | `boolean` | Current loading state |
+| `setLoading` | `(loading: boolean) => void` | Function to set the loading state |
+
 ## License
 
 [MIT](https://github.com/ttoss/ttoss/blob/main/LICENSE)
+```

--- a/packages/react-notifications/src/Provider.tsx
+++ b/packages/react-notifications/src/Provider.tsx
@@ -20,6 +20,7 @@ export type Notification = {
   viewType?: ViewType;
   toast?: ToastOptions;
   boxId?: string | number;
+  persist?: boolean;
 };
 
 const NotificationsContext = React.createContext<{
@@ -151,7 +152,11 @@ export const NotificationsProvider = (props: NotificationsProviderProps) => {
   );
 
   const clearNotifications = React.useCallback(() => {
-    setNotifications(undefined);
+    setNotifications((prevNotifications) => {
+      return prevNotifications?.filter((notification) => {
+        return notification.persist === true;
+      });
+    });
   }, []);
 
   return (

--- a/packages/react-notifications/tests/unit/tests/Provider.test.tsx
+++ b/packages/react-notifications/tests/unit/tests/Provider.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, userEvent } from '@ttoss/test-utils';
+import { NotificationsProvider, useNotifications } from 'src/index';
+
+const PERSISTENT_MESSAGE = 'persistent notification';
+const REGULAR_MESSAGE = 'regular notification';
+
+describe('NotificationsProvider - clearNotifications with persist', () => {
+  const user = userEvent.setup({ delay: null });
+
+  const TestComponent = () => {
+    const { addNotification, clearNotifications, notifications } =
+      useNotifications();
+
+    return (
+      <div>
+        <button
+          onClick={() => {
+            addNotification({
+              message: REGULAR_MESSAGE,
+              type: 'info',
+              persist: false,
+            });
+          }}
+          data-testid="add-regular"
+          type="button"
+        />
+
+        <button
+          onClick={() => {
+            addNotification({
+              message: PERSISTENT_MESSAGE,
+              type: 'info',
+              persist: true,
+            });
+          }}
+          data-testid="add-persistent"
+          type="button"
+        />
+
+        <button
+          onClick={clearNotifications}
+          data-testid="clear-all"
+          type="button"
+        />
+
+        <div data-testid="notifications-count">
+          {notifications?.length || 0}
+        </div>
+
+        <div data-testid="notifications-list">
+          {notifications?.map((notification) => {
+            return (
+              <div
+                key={notification.id}
+                data-testid={`notification-${notification.id}`}
+              >
+                {notification.message}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  test('should remove only non-persistent notifications when clearNotifications is called', async () => {
+    render(
+      <NotificationsProvider>
+        <TestComponent />
+      </NotificationsProvider>
+    );
+
+    await user.click(screen.getByTestId('add-regular'));
+
+    await user.click(screen.getByTestId('add-persistent'));
+
+    expect(screen.getByTestId('notifications-count')).toHaveTextContent('2');
+    expect(screen.getByText(REGULAR_MESSAGE)).toBeInTheDocument();
+    expect(screen.getByText(PERSISTENT_MESSAGE)).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('clear-all'));
+
+    expect(screen.getByTestId('notifications-count')).toHaveTextContent('1');
+    expect(screen.queryByText(REGULAR_MESSAGE)).not.toBeInTheDocument();
+    expect(screen.getByText(PERSISTENT_MESSAGE)).toBeInTheDocument();
+  });
+
+  test('should remove all notifications when none are persistent', async () => {
+    render(
+      <NotificationsProvider>
+        <TestComponent />
+      </NotificationsProvider>
+    );
+
+    await user.click(screen.getByTestId('add-regular'));
+    await user.click(screen.getByTestId('add-regular'));
+
+    expect(screen.getByTestId('notifications-count')).toHaveTextContent('2');
+
+    await user.click(screen.getByTestId('clear-all'));
+
+    expect(screen.getByTestId('notifications-count')).toHaveTextContent('0');
+    expect(screen.queryByText(REGULAR_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  test('should keep all notifications when all are persistent', async () => {
+    render(
+      <NotificationsProvider>
+        <TestComponent />
+      </NotificationsProvider>
+    );
+
+    await user.click(screen.getByTestId('add-persistent'));
+    await user.click(screen.getByTestId('add-persistent'));
+
+    expect(screen.getByTestId('notifications-count')).toHaveTextContent('2');
+
+    await user.click(screen.getByTestId('clear-all'));
+
+    expect(screen.getByTestId('notifications-count')).toHaveTextContent('2');
+    expect(screen.getAllByText(PERSISTENT_MESSAGE)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## ✨ Add persistent notifications feature

Adds a new `persist` property to notifications that prevents them from being removed when `clearNotifications()` is called.

### 🔧 Changes
- Added `persist?: boolean` property to `Notification` type
- Updated `clearNotifications()` to only remove non-persistent notifications
- Added Storybook controls to test the persist functionality
- Created comprehensive unit tests for the new behavior
- Updated README documentation with API reference and examples

### 🧪 Testing
- Notifications with `persist: true` remain visible after `clearNotifications()`
- Notifications with `persist: false` or undefined are cleared normally
- All existing functionality remains unchanged

### 📚 Usage
```tsx
addNotification({
  message: "Important notification",
  type: "warning",
  persist: true // Won't be cleared by clearNotifications()
});

### 🪡 Image
![image](https://github.com/user-attachments/assets/df914758-ef49-4c13-92b9-6ead42efa71b)
