### PR TITLE
fix: notifications provider and add header story

### DIFF
--- a/docs/storybook/stories/layouts/SidebarCollapseLayout.stories.tsx
+++ b/docs/storybook/stories/layouts/SidebarCollapseLayout.stories.tsx
@@ -4,7 +4,12 @@ import {
   NotificationsMenu,
 } from '@ttoss/components/NotificationsMenu';
 import { Layout, SidebarCollapseLayout } from '@ttoss/layouts';
+import {
+  NotificationsProvider,
+  useNotifications,
+} from '@ttoss/react-notifications';
 import { Box, Flex, Image, Stack } from '@ttoss/ui';
+import * as React from 'react';
 
 export default {
   title: 'Layouts/SidebarCollapseLayout',
@@ -52,6 +57,23 @@ const SidebarCollapseLayoutTemplate = ({
       </Layout.Sidebar>
       <Layout.Main>{mainContent}</Layout.Main>
     </SidebarCollapseLayout>
+  );
+};
+
+const HeaderWithNotifications = () => {
+  const { addNotification } = useNotifications();
+
+  React.useEffect(() => {
+    addNotification({
+      message: 'Esta notificação aparece automaticamente no header!',
+      type: 'info',
+      viewType: 'header',
+      title: 'Notificação Automática',
+    });
+  }, [addNotification]);
+
+  return (
+    <Flex sx={{ alignItems: 'center', width: '100%' }}>Header starts here</Flex>
   );
 };
 
@@ -201,6 +223,47 @@ export const WithNotificationsMenu: Story = {
         </Layout.Sidebar>
         <Layout.Main>{args.content || 'Main starts here'}</Layout.Main>
       </SidebarCollapseLayout>
+    );
+  },
+  args: {
+    showSidebarButton: true,
+    sidebarSlot: terezinhaLogo,
+  },
+};
+
+export const WithHeaderNotifications: Story = {
+  name: 'With Header Notifications',
+  render: (args) => {
+    return (
+      <NotificationsProvider>
+        <SidebarCollapseLayout>
+          <Layout.Header
+            showSidebarButton={args.showSidebarButton}
+            sidebarSlot={args.sidebarSlot}
+          >
+            <HeaderWithNotifications />
+          </Layout.Header>
+          <Layout.Sidebar
+            showSidebarButtonInDrawer={true}
+            drawerSlot={args.sidebarSlot}
+          >
+            <Flex sx={{ flexDirection: 'column', gap: '6' }}>
+              <Flex>Sidebar item 1 </Flex>
+              <Flex>Sidebar item 2 </Flex>
+              <Flex>Sidebar item 3 </Flex>
+              <Flex>Sidebar item 4 </Flex>
+              <Flex>Sidebar item 5 </Flex>
+              <Flex>Sidebar item 6 </Flex>
+            </Flex>
+          </Layout.Sidebar>
+          <Layout.Main>
+            <Box sx={{ p: '4' }}>
+              <p>Clique no botão do header para adicionar uma notificação!</p>
+              <p>A notificação aparecerá no topo da página.</p>
+            </Box>
+          </Layout.Main>
+        </SidebarCollapseLayout>
+      </NotificationsProvider>
     );
   },
   args: {

--- a/packages/react-notifications/src/Provider.tsx
+++ b/packages/react-notifications/src/Provider.tsx
@@ -118,33 +118,27 @@ export const NotificationsProvider = (props: NotificationsProviderProps) => {
       });
 
       setNotifications((prevNotifications = []) => {
-        /**
-         * Remove old notifications with same id and keep the new ones.
-         */
-        const oldNotifications = prevNotifications.filter(
-          (prevNotification) => {
-            const newNotification = newNotifications.find((newNotification) => {
-              return newNotification.id === prevNotification.id;
-            });
-
-            if (newNotification) {
-              if (newNotification.viewType === 'toast') {
-                return false;
-              }
-
-              if (
-                !newNotification.viewType &&
-                props.defaultViewType === 'toast'
-              ) {
-                return false;
-              }
+        const nonToastNewNotifications = newNotifications.filter(
+          (notification) => {
+            if (notification.viewType === 'toast') {
+              return false;
             }
-
+            if (!notification.viewType && props.defaultViewType === 'toast') {
+              return false;
+            }
             return true;
           }
         );
 
-        return [...oldNotifications, ...newNotifications];
+        const oldNotifications = prevNotifications.filter(
+          (prevNotification) => {
+            return !nonToastNewNotifications.some((newNotification) => {
+              return newNotification.id === prevNotification.id;
+            });
+          }
+        );
+
+        return [...oldNotifications, ...nonToastNewNotifications];
       });
     },
     [prefix, props.defaultViewType, removeNotification]


### PR DESCRIPTION
## 🐛 Fix: Notifications Provider State Filtering + Header Notifications Story

### Problem
The `NotificationsProvider` had a bug where notifications with `viewType` of `'header'`, `'box'`, and `'modal'` were not being displayed, while `'toast'` notifications worked correctly.

**Root Cause:** The state filtering logic in `setNotifications` was incorrectly handling non-toast notifications, preventing them from being stored in the notifications state that components like `NotificationsHeader`, `NotificationsBox`, etc. depend on.

### Solution

#### 1. Fixed NotificationsProvider State Logic
- **Before:** All notifications (including toast) were being added to the state
- **After:** Only non-toast notifications are stored in the state
- **Toast notifications:** Continue working via direct `toast()` calls
- **Header/Box/Modal notifications:** Now properly stored in state for consumption by their respective components

#### 2. Added Storybook Story
- Created `WithHeaderNotifications` story in `SidebarCollapseLayout.stories.tsx`
- Demonstrates header notifications functionality
- Auto-triggers a header notification on story load
- Wrapped with `NotificationsProvider` for proper context

### Changes Made

#### `/packages/react-notifications/src/Provider.tsx`
```tsx
// Fixed the filtering logic to exclude toast notifications from state
const nonToastNewNotifications = newNotifications.filter((notification) => {
  if (notification.viewType === 'toast') {
    return false; // Toast notifications don't go to state
  }
  if (!notification.viewType && props.defaultViewType === 'toast') {
    return false; // Default toast notifications don't go to state  
  }
  return true; // Header/Box/Modal notifications go to state
});