### PR TITLE
fix: cloud auth permissions

### DIFF
--- a/packages/cloud-auth/src/template.ts
+++ b/packages/cloud-auth/src/template.ts
@@ -468,25 +468,6 @@ export const createAuthTemplate = ({
     }
 
     for (const [key, lambdaTrigger] of Object.entries(LambdaConfig)) {
-      const functionName = (() => {
-        if (typeof lambdaTrigger === 'string') {
-          return lambdaTrigger;
-        }
-
-        if ('Fn::GetAtt' in lambdaTrigger) {
-          const getAtt = lambdaTrigger['Fn::GetAtt'];
-          if (Array.isArray(getAtt) && getAtt.length > 0) {
-            return getAtt[0];
-          }
-        }
-
-        return null;
-      })();
-
-      if (!functionName) {
-        continue;
-      }
-
       const permissionLogicalId =
         `${key}PermissionFor${CognitoUserPoolLogicalId}`.slice(0, 255);
 

--- a/packages/cloud-auth/tests/unit/template.test.ts
+++ b/packages/cloud-auth/tests/unit/template.test.ts
@@ -733,24 +733,5 @@ describe('lambda triggers', () => {
       expect(template.Resources[postConfirmationKey]).toBeDefined();
       expect(template.Resources[customMessageKey]).toBeDefined();
     });
-
-    test('trigger is not string neither getAtt', () => {
-      const template = createAuthTemplate({
-        lambdaTriggers: {
-          preSignUp: { Ref: 'PreSignUpFunction' } as unknown as string,
-          postConfirmation: {
-            'Fn::GetAtt': 'arn',
-          } as unknown as string,
-        },
-      });
-
-      const permissionResources = Object.keys(template.Resources).filter(
-        (key) => {
-          return template.Resources[key].Type === 'AWS::Lambda::Permission';
-        }
-      );
-
-      expect(permissionResources).toHaveLength(0);
-    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically creates AWS Lambda permission resources for Cognito User Pool triggers when configured, ensuring correct invoke permissions, principal, function references (string or GetAtt), and source ARN. Supports multiple triggers and trigger names with special characters.

- Tests
  - Added comprehensive unit tests covering single and multiple triggers, CloudFormation references, special characters, all supported trigger types, absence/empty configurations, and mixed definitions to validate correct permission generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->