### PR TITLE
Criação de Header interno opcional no componente Main

### DIFF
--- a/packages/layouts/src/components/Main.tsx
+++ b/packages/layouts/src/components/Main.tsx
@@ -1,21 +1,25 @@
 import { Box, BoxProps } from '@ttoss/ui';
 
-export const Main = (props: BoxProps) => {
+export interface MainProps extends BoxProps {
+  Header?: React.ReactNode;
+}
+
+export const Main = (props: MainProps) => {
+  const { Header, children, sx, ...rest } = props;
   return (
     <Box
       variant="layout.main"
-      {...props}
+      {...rest}
       as="main"
       sx={{
-        paddingX: '10',
-        paddingY: '6',
         overflowY: 'auto',
         width: 'full',
         height: 'full',
-        ...props.sx,
+        ...sx,
       }}
     >
-      {props.children}
+      {Header && <>{Header}</>}
+      <Box sx={{ paddingX: '10', paddingY: '6' }}>{children}</Box>
     </Box>
   );
 };


### PR DESCRIPTION
Alteração no componente Main: inclusão de um header interno a ser recebido como parâmetro. Quando informado resultará na exibição deste header dentro do componente Main.

Exemplos de quando o Header opcional está presente:

<img width="1916" height="962" alt="Captura de tela 2025-09-16 103120" src="https://github.com/user-attachments/assets/cb5262f3-d2b9-4735-acd5-a32cf2c78ca1" />
<img width="1913" height="953" alt="Captura de tela 2025-09-16 103008" src="https://github.com/user-attachments/assets/0f01c1fb-d399-47a2-a427-71be5c64804f" />

Exemplo de uso do Main quando o Header está ausente:

<img width="1918" height="964" alt="Captura de tela 2025-09-16 103141" src="https://github.com/user-attachments/assets/ba0c7adf-827e-4d6f-ad0e-8da37a9e0e6d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Main layout now supports an optional Header slot rendered at the top.
  - Component accepts a new prop shape while preserving existing layout-style props for compatibility.

- Refactor
  - Content is wrapped in an inner container with standardized padding for consistent spacing.
  - Outer container no longer applies default padding; spacing is handled by the inner container.
  - Custom styles via sx continue to apply to the outer container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->