### PR TITLE
fix: add main header,main body and main foot in collapse layout

### DIFF
--- a/docs/storybook/stories/layouts/SidebarCollapseLayout.stories.tsx
+++ b/docs/storybook/stories/layouts/SidebarCollapseLayout.stories.tsx
@@ -55,21 +55,24 @@ const SidebarCollapseLayoutTemplate = ({
           <Flex>Sidebar item 9 </Flex>
         </Flex>
       </Layout.Sidebar>
-      <Layout.Main.Header
-        sx={{
-          borderBottom: '1px solid gray',
-        }}
-      >
-        Main Header
-      </Layout.Main.Header>
-      <Layout.Main>{mainContent}</Layout.Main>
-      <Layout.Main.Footer
-        sx={{
-          borderTop: '1px solid gray',
-        }}
-      >
-        Main Footer
-      </Layout.Main.Footer>
+
+      <Layout.Main>
+        <Layout.Main.Header
+          sx={{
+            borderBottom: '1px solid gray',
+          }}
+        >
+          Main Header
+        </Layout.Main.Header>
+        <Layout.Main.Body>{mainContent}</Layout.Main.Body>
+        <Layout.Main.Footer
+          sx={{
+            borderTop: '1px solid gray',
+          }}
+        >
+          Main Footer
+        </Layout.Main.Footer>
+      </Layout.Main>
     </SidebarCollapseLayout>
   );
 };
@@ -235,7 +238,11 @@ export const WithNotificationsMenu: Story = {
             <Flex>Sidebar item 6 </Flex>
           </Flex>
         </Layout.Sidebar>
-        <Layout.Main>{args.content || 'Main starts here'}</Layout.Main>
+        <Layout.Main>
+          <Layout.Main.Body>
+            {args.content || 'Main starts here'}
+          </Layout.Main.Body>
+        </Layout.Main>
       </SidebarCollapseLayout>
     );
   },
@@ -271,10 +278,12 @@ export const WithHeaderNotifications: Story = {
             </Flex>
           </Layout.Sidebar>
           <Layout.Main>
-            <Box sx={{ p: '4' }}>
-              <p>Clique no botão do header para adicionar uma notificação!</p>
-              <p>A notificação aparecerá no topo da página.</p>
-            </Box>
+            <Layout.Main.Body>
+              <Box sx={{ p: '4' }}>
+                <p>Clique no botão do header para adicionar uma notificação!</p>
+                <p>A notificação aparecerá no topo da página.</p>
+              </Box>
+            </Layout.Main.Body>
           </Layout.Main>
         </SidebarCollapseLayout>
       </NotificationsProvider>

--- a/docs/storybook/stories/layouts/StackedLayout.stories.tsx
+++ b/docs/storybook/stories/layouts/StackedLayout.stories.tsx
@@ -15,7 +15,11 @@ const Header = () => {
 Header.displayName = Layout.Header.displayName;
 
 const Main = () => {
-  return <Layout.Main sx={{}}>Main</Layout.Main>;
+  return (
+    <Layout.Main sx={{}}>
+      <Layout.Main.Body>Main</Layout.Main.Body>
+    </Layout.Main>
+  );
 };
 
 Main.displayName = Layout.Main.displayName;

--- a/packages/layouts/README.md
+++ b/packages/layouts/README.md
@@ -37,9 +37,11 @@ const Dashboard = () => (
   <SidebarCollapseLayout>
     <Layout.Header showSidebarButton>App Header with Menu Toggle</Layout.Header>
     <Layout.Sidebar>Navigation Menu</Layout.Sidebar>
-    <Layout.Main.Header>Page Title & Actions</Layout.Main.Header>
-    <Layout.Main>Dashboard Content</Layout.Main>
-    <Layout.Main.Footer>Status Bar</Layout.Main.Footer>
+    <Layout.Main>
+      <Layout.Main.Header>Page Title & Actions</Layout.Main.Header>
+      <Layout.Main.Body>Dashboard Content</Layout.Main.Body>
+      <Layout.Main.Footer>Status Bar</Layout.Main.Footer>
+    </Layout.Main>
   </SidebarCollapseLayout>
 );
 ```
@@ -48,22 +50,37 @@ const Dashboard = () => (
 
 ### Layout.Main Sub-Components
 
-Enhanced main content area with optional header and footer sections.
+The Main component provides a structured content area with three distinct sections:
 
 ```tsx
-<Layout.Main.Header>
-  <h1>Page Title</h1>
-  <button>Action Button</button>
-</Layout.Main.Header>
-
 <Layout.Main>
-  Main content with consistent padding and overflow handling
-</Layout.Main>
+  <Layout.Main.Header>
+    <h1>Page Title</h1>
+    <button>Action Button</button>
+  </Layout.Main.Header>
 
-<Layout.Main.Footer>
-  <span>Last updated: Today</span>
-</Layout.Main.Footer>
+  <Layout.Main.Body>
+    Main content with consistent padding and scroll handling
+  </Layout.Main.Body>
+
+  <Layout.Main.Footer>
+    <span>Last updated: Today</span>
+  </Layout.Main.Footer>
+</Layout.Main>
 ```
+
+**Key Features:**
+
+- **Main.Header**: Page-level header with title and actions
+- **Main.Body**: Scrollable content area with auto overflow handling
+- **Main.Footer**: Status bar or secondary actions
+
+**Benefits of This Structure:**
+
+- **Clear Content Hierarchy**: Separates page header, content, and footer concerns
+- **Automatic Scroll Management**: Body handles overflow while keeping header/footer fixed
+- **Consistent Spacing**: Each section has optimized padding and layout
+- **Accessibility**: Proper semantic HTML elements (`<header>`, `<main>`, `<footer>`)
 
 ## Automatic Layout Composition
 
@@ -88,15 +105,15 @@ const AppLayout = () => (
 
 // pages/Dashboard.tsx - Page-specific components
 const Dashboard = () => (
-  <>
+  <Layout.Main>
     <Layout.Main.Header>
       <h1>Dashboard</h1>
     </Layout.Main.Header>
-    <Layout.Main>
+    <Layout.Main.Body>
       <DashboardCharts />
-    </Layout.Main>
+    </Layout.Main.Body>
     <Layout.Main.Footer>Last updated: {lastUpdate}</Layout.Main.Footer>
-  </>
+  </Layout.Main>
 );
 ```
 
@@ -106,12 +123,17 @@ The layout **automatically composes** itself by finding components with matching
 
 ```tsx
 // These components can be anywhere in your component tree:
-<Layout.Header />     // → Detected as "Header"
-<Layout.Sidebar />    // → Detected as "Sidebar"
-<Layout.Main />       // → Detected as "Main"
-<Layout.Footer />     // → Detected as "Footer"
-<Layout.Main.Header />  // → Detected as "MainHeader"
-<Layout.Main.Footer />  // → Detected as "MainFooter"
+<Layout.Header />        // → Detected as "Header"
+<Layout.Sidebar />       // → Detected as "Sidebar"
+<Layout.Main />          // → Detected as "Main"
+<Layout.Footer />        // → Detected as "Footer"
+
+// Main sub-components are contained within Main:
+<Layout.Main>
+  <Layout.Main.Header />  // → Detected as "MainHeader"
+  <Layout.Main.Body />    // → Detected as "MainBody"
+  <Layout.Main.Footer />  // → Detected as "MainFooter"
+</Layout.Main>
 ```
 
 ## Component Properties
@@ -127,14 +149,17 @@ The layout **automatically composes** itself by finding components with matching
 All components integrate seamlessly with `@ttoss/ui` theme system via `sx` prop:
 
 ```tsx
-<Layout.Header
-  sx={{
-    backgroundColor: 'brand.primary',
-    borderBottom: '2px solid',
-  }}
->
-  Custom styled header
-</Layout.Header>
+<Layout.Main>
+  <Layout.Main.Header
+    sx={{
+      backgroundColor: 'brand.primary',
+      borderBottom: '2px solid',
+    }}
+  >
+    Custom styled header
+  </Layout.Main.Header>
+  <Layout.Main.Body>Content</Layout.Main.Body>
+</Layout.Main>
 ```
 
 ## Advanced Usage

--- a/packages/layouts/src/components/Main.tsx
+++ b/packages/layouts/src/components/Main.tsx
@@ -1,29 +1,26 @@
-import { Box, BoxProps } from '@ttoss/ui';
+import { BoxProps, Stack } from '@ttoss/ui';
 
+import { MainBody } from './MainBody';
 import { MainFooter } from './MainFooter';
 import { MainHeader } from './MainHeader';
 
 export const Main = (props: BoxProps) => {
   return (
-    <Box
+    <Stack
       variant="layout.main"
-      {...props}
-      as="main"
       sx={{
-        paddingX: '10',
-        paddingY: '6',
-        overflowY: 'auto',
-        width: 'full',
+        flex: 1,
         height: 'full',
-        ...props.sx,
+        overflow: 'hidden',
       }}
     >
       {props.children}
-    </Box>
+    </Stack>
   );
 };
 
 Main.displayName = 'Main';
 
 Main.Header = MainHeader;
+Main.Body = MainBody;
 Main.Footer = MainFooter;

--- a/packages/layouts/src/components/MainBody.tsx
+++ b/packages/layouts/src/components/MainBody.tsx
@@ -1,0 +1,23 @@
+import { Box, BoxProps } from '@ttoss/ui';
+
+export const MainBody = (props: BoxProps) => {
+  return (
+    <Box
+      variant="layout.main.body"
+      {...props}
+      as="main"
+      sx={{
+        paddingX: '10',
+        paddingY: '6',
+        overflowY: 'auto',
+        width: 'full',
+        height: 'full',
+        ...props.sx,
+      }}
+    >
+      {props.children}
+    </Box>
+  );
+};
+
+MainBody.displayName = 'MainBody';

--- a/packages/layouts/src/components/SidebarCollapseLayout.tsx
+++ b/packages/layouts/src/components/SidebarCollapseLayout.tsx
@@ -7,7 +7,7 @@ export const SidebarCollapseLayout = ({
   children,
   ...props
 }: React.PropsWithChildren<StackProps>) => {
-  const { header, main, sidebar, mainFooter, mainHeader } = getSematicElements({
+  const { header, main, sidebar } = getSematicElements({
     children,
   });
 
@@ -32,17 +32,7 @@ export const SidebarCollapseLayout = ({
           }}
         >
           {sidebar}
-          <Stack
-            sx={{
-              flex: 1,
-              height: 'full',
-              overflow: 'hidden',
-            }}
-          >
-            {mainHeader}
-            {main}
-            {mainFooter}
-          </Stack>
+          {main}
         </Flex>
       </Stack>
     </LayoutProvider>

--- a/packages/layouts/src/getSemanticElements.ts
+++ b/packages/layouts/src/getSemanticElements.ts
@@ -6,6 +6,7 @@ const semanticComponents = {
   Footer: 'footer',
   Main: 'main',
   MainHeader: 'mainHeader',
+  MainBody: 'mainBody',
   MainFooter: 'mainFooter',
 } as const;
 

--- a/packages/layouts/tests/unit/tests/MainComponents.test.tsx
+++ b/packages/layouts/tests/unit/tests/MainComponents.test.tsx
@@ -19,3 +19,12 @@ describe('MainFooter', () => {
     expect(footer).toBeInTheDocument();
   });
 });
+
+describe('MainBody', () => {
+  test('should render MainBody with correct semantic element', () => {
+    render(<Layout.Main.Body>Main Body Content</Layout.Main.Body>);
+
+    const body = screen.getByText('Main Body Content');
+    expect(body).toBeInTheDocument();
+  });
+});

--- a/packages/layouts/tests/unit/tests/SidebarCollapseLayout.test.tsx
+++ b/packages/layouts/tests/unit/tests/SidebarCollapseLayout.test.tsx
@@ -10,7 +10,9 @@ test('should render layout from SidebarCollapseLayout component', () => {
   render(
     <SidebarCollapseLayout>
       <Layout.Header>Header</Layout.Header>
-      <Layout.Main>Main</Layout.Main>
+      <Layout.Main>
+        <Layout.Main.Body>Main</Layout.Main.Body>
+      </Layout.Main>
       <Layout.Sidebar>Sidebar</Layout.Sidebar>
       <div>Extra</div>
     </SidebarCollapseLayout>
@@ -30,7 +32,9 @@ test('should toggle sidebar visibility with proper accessibility', async () => {
   render(
     <SidebarCollapseLayout>
       <Layout.Header showSidebarButton>Header</Layout.Header>
-      <Layout.Main>Main</Layout.Main>
+      <Layout.Main>
+        <Layout.Main.Body>Main</Layout.Main.Body>
+      </Layout.Main>
       <Layout.Sidebar>Sidebar</Layout.Sidebar>
     </SidebarCollapseLayout>
   );
@@ -60,7 +64,9 @@ test('should support keyboard navigation', async () => {
   render(
     <SidebarCollapseLayout>
       <Layout.Header showSidebarButton>Header</Layout.Header>
-      <Layout.Main>Main</Layout.Main>
+      <Layout.Main>
+        <Layout.Main.Body>Main</Layout.Main.Body>
+      </Layout.Main>
       <Layout.Sidebar>Sidebar</Layout.Sidebar>
     </SidebarCollapseLayout>
   );

--- a/packages/layouts/tests/unit/tests/StackedLayout.test.tsx
+++ b/packages/layouts/tests/unit/tests/StackedLayout.test.tsx
@@ -5,7 +5,9 @@ test('should render stacked layout from StackedLayout components', () => {
   render(
     <StackedLayout>
       <Layout.Header>Header</Layout.Header>
-      <Layout.Main>Main</Layout.Main>
+      <Layout.Main>
+        <Layout.Main.Body>Main</Layout.Main.Body>
+      </Layout.Main>
       <Layout.Footer>Footer</Layout.Footer>
       <div>Extra</div>
     </StackedLayout>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Main.Body subcomponent for main content.

* **Refactor**
  * Main now consistently wraps Header, Body, and Footer; main content moved into Main.Body.
  * Simplified layout so the main area renders directly alongside header and sidebar.

* **Documentation**
  * Updated Storybook and README examples to demonstrate the new Main/Header/Body/Footer structure.

* **Tests**
  * Added/updated unit tests to cover Main.Body and the revised compositions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Como ficou depois das alterações:
<img width="1146" height="896" alt="image" src="https://github.com/user-attachments/assets/b8cfa89f-d752-4631-bfcf-5b9fdcabbd8f" />
<img width="1451" height="883" alt="image" src="https://github.com/user-attachments/assets/0b68f715-4b2a-47be-9824-39fea63c8ea6" />

- Como era:
<img width="1434" height="843" alt="image" src="https://github.com/user-attachments/assets/58af2e76-0b1d-481c-926e-a04a3a184524" />
<img width="1440" height="930" alt="image" src="https://github.com/user-attachments/assets/c349af3d-81d0-4901-a1f9-e0a36274dfcd" />
