### PR TITLE
fix: notification card

### DIFF
--- a/packages/components/src/components/NotificationCard/NotificationCard.tsx
+++ b/packages/components/src/components/NotificationCard/NotificationCard.tsx
@@ -103,7 +103,6 @@ export const NotificationCard = (props: NotificationCardProps) => {
         <Box
           sx={{
             display: 'flex',
-            minHeight: shouldAddMinHeight ? '40px' : 'auto',
             justifyContent: 'space-between',
             alignItems: 'flex-start',
             width: '100%',


### PR DESCRIPTION
Alterações no notification card

- Centralização do texto na vertical quando o componente só tem o corpo (sem título, sem meta info ...);
- Se o componente possuir não possuir caption actions ou title, seta uma altura minima para o componente não ficar do tamanho do texto apenas;
- Remove o espaço em branco em baixo do texto quando não há nada em baixo, como meta info ou botão de fechar, deixando somente uma linha.

<img width="1261" height="938" alt="image" src="https://github.com/user-attachments/assets/fe8368b7-3bdf-4268-a57d-61d3f08f9227" />

<img width="981" height="485" alt="image" src="https://github.com/user-attachments/assets/e018fe79-6ad3-45b2-ad44-03bf83889a62" />

<img width="975" height="388" alt="image" src="https://github.com/user-attachments/assets/634dc6fb-aaf0-4ec9-ace6-1067b4bc684c" />

Notifications mantem igual
<img width="979" height="557" alt="image" src="https://github.com/user-attachments/assets/d5725328-c74f-47cd-ad59-f5987acdb5ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Notification card layout refined: content now centers vertically when no title/caption/actions, and message area uses a conditional minimum height for consistent appearance. Caption only renders when provided; spacing and alignment improved. No public API changes.

* Bug Fixes
  * Removed empty caption container to eliminate unintended gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->