### PR TITLE
fix: condition to center text with title

### DIFF
--- a/packages/components/src/components/NotificationCard/NotificationCard.tsx
+++ b/packages/components/src/components/NotificationCard/NotificationCard.tsx
@@ -66,7 +66,10 @@ export const NotificationCard = (props: NotificationCardProps) => {
   const hasCaption = Boolean(props.caption);
   const hasActions = Boolean(props.actions && props.actions.length > 0);
   const hasTitle = Boolean(props.title);
-  const shouldCenterVertically = !hasCaption && !hasActions && !hasTitle;
+  const shouldCenterVerticallyWithoutTitle =
+    !hasCaption && !hasActions && !hasTitle;
+  const shouldCenterVerticallyWithTitle =
+    !hasCaption && !hasActions && hasTitle;
   const shouldAddMinHeight = !hasCaption && !hasActions;
 
   return (
@@ -114,7 +117,11 @@ export const NotificationCard = (props: NotificationCardProps) => {
               flex: 1,
               minHeight: shouldAddMinHeight ? '40px' : 'auto',
               display: 'flex',
-              alignItems: shouldCenterVertically ? 'center' : 'flex-start',
+              alignItems: shouldCenterVerticallyWithoutTitle
+                ? 'center'
+                : shouldCenterVerticallyWithTitle
+                  ? 'center'
+                  : 'flex-start',
               textAlign: 'left',
             }}
           >


### PR DESCRIPTION
Arrumando condição para centralizar texto quando houver titulo mas não tiver nem botão de fechar ou legenda e ações

<img width="977" height="556" alt="image" src="https://github.com/user-attachments/assets/f7163b82-8357-4418-ad93-4803fb74515b" />
