### PR TITLE
fix: zindex notifications menu

### DIFF
--- a/packages/components/src/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/packages/components/src/components/NotificationsMenu/NotificationsMenu.tsx
@@ -163,7 +163,7 @@ export const NotificationsMenu = ({
                 width: ['90vw', '550px'],
                 maxHeight: '400px',
                 overflowY: 'auto',
-                zIndex: 10,
+                zIndex: 'modal',
                 padding: 0,
                 boxShadow: 'xl',
                 borderRadius: '2xl',


### PR DESCRIPTION
Esta PR trás o NotificationsMenu mais para frente em relação ao SideBar.

<img width="469" height="396" alt="image" src="https://github.com/user-attachments/assets/6f09e7db-073a-441f-ad5f-46ba37df3feb" />

SideBar com zindex = overlay
<img width="852" height="408" alt="image" src="https://github.com/user-attachments/assets/f61e8be8-ca81-4a21-abba-b5ffdbaa58da" />

NotificationsMenu com zindex = modal
<img width="1019" height="419" alt="image" src="https://github.com/user-attachments/assets/ac2b457d-2d54-4329-b708-04a78eb7a400" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the Notifications menu consistently appears above other page elements and overlays, preventing it from being hidden or clipped.
* **Style**
  * Aligned the menu’s layering with design system tokens for more consistent stacking behavior across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->