### PR TITLE
feat: fixing the responsiveness of the notifications menu

### DIFF
--- a/packages/components/src/components/NotificationCard/NotificationCard.tsx
+++ b/packages/components/src/components/NotificationCard/NotificationCard.tsx
@@ -147,6 +147,7 @@ export const NotificationCard = (props: NotificationCardProps) => {
             <Text
               sx={{
                 fontSize: ['sm', 'md'],
+                wordBreak: 'break-word',
               }}
             >
               {props.message}

--- a/packages/components/src/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/packages/components/src/components/NotificationsMenu/NotificationsMenu.tsx
@@ -120,7 +120,7 @@ export const NotificationsMenu = ({
                 '.EZDrawer__container': {
                   position: 'fixed',
                   height: 'full',
-                  backgroundColor: 'display.background.primary.default',
+                  backgroundColor: 'display.background.secondary.default',
                   width: 'full',
                   maxWidth: '2',
                   boxShadow: '4',

--- a/packages/components/src/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/packages/components/src/components/NotificationsMenu/NotificationsMenu.tsx
@@ -1,7 +1,15 @@
 import { Icon } from '@ttoss/react-icons';
-import { Box, Button, Card, Flex, IconButton, Text } from '@ttoss/ui';
+import {
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  Text,
+  useResponsiveValue,
+} from '@ttoss/ui';
 import * as React from 'react';
 
+import { Drawer } from '../Drawer';
 import {
   NotificationCard,
   NotificationCardProps,
@@ -17,7 +25,6 @@ type Props = {
   defaultOpen?: boolean;
   hasMore?: boolean;
   count: number;
-  onLoadMore?: () => void;
   onOpenChange?: (isOpen: boolean) => void;
   onClose?: () => void;
   onClearAll?: () => void;
@@ -27,23 +34,17 @@ export const NotificationsMenu = ({
   notifications,
   defaultOpen = false,
   hasMore = false,
-  onLoadMore,
   onOpenChange,
   count,
   onClose,
   onClearAll,
 }: Props) => {
   const [isOpen, setIsOpen] = React.useState(defaultOpen);
-  const [menuWidth, setMenuWidth] = React.useState(600); // Default width, will be adjusted
-  const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
-  const [menuLeft, setMenuLeft] = React.useState(0);
-  const [menuTop, setMenuTop] = React.useState(0);
 
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const menuWidth = useResponsiveValue(['100%', '600px']);
   const loadMoreRef = React.useRef<HTMLDivElement | null>(null);
 
-  const [showCount, setShowCount] = React.useState(true);
+  const [showCount] = React.useState(true);
 
   const togglePanel = () => {
     setIsOpen((prev) => {
@@ -53,116 +54,16 @@ export const NotificationsMenu = ({
     });
   };
 
-  React.useEffect(() => {
-    const handleResize = () => {
-      return setWindowWidth(window.innerWidth);
-    };
-    window.addEventListener('resize', handleResize);
-    return () => {
-      return window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
-  React.useEffect(() => {
-    if (!isOpen || !buttonRef.current) return;
-
-    const rect = buttonRef.current.getBoundingClientRect();
-    const margin = 12;
-    const desiredWidth = notifications.length === 0 ? 300 : 600;
-    const buttonCenterX = rect.left + rect.width / 2;
-
-    if (
-      window.innerWidth <= 480 ||
-      desiredWidth + margin * 2 > window.innerWidth
-    ) {
-      const newWidth = Math.max(window.innerWidth - margin * 2, 320);
-      const left = Math.round((window.innerWidth - newWidth) / 2);
-      setMenuLeft(left);
-      setMenuTop(Math.round(rect.bottom + 8));
-      setMenuWidth(newWidth);
-      setShowCount(false);
-      return;
-    }
-
-    const centeredLeft = Math.round(buttonCenterX - desiredWidth / 2);
-    const fitsWhenCentered =
-      centeredLeft >= margin &&
-      centeredLeft + desiredWidth <= window.innerWidth - margin;
-
-    let newWidth = desiredWidth;
-
-    if (!fitsWhenCentered) {
-      const spaceRight = window.innerWidth - rect.right;
-      const spaceLeft = rect.left;
-
-      const available = Math.max(spaceLeft, spaceRight);
-      newWidth = Math.min(desiredWidth, Math.max(available - margin, 300));
-    }
-
-    let left = Math.round(buttonCenterX - newWidth / 2);
-    left = Math.max(
-      margin,
-      Math.min(left, window.innerWidth - newWidth - margin)
-    );
-
-    setMenuLeft(left);
-    setMenuTop(Math.round(rect.bottom + 8));
-    setMenuWidth(newWidth);
-    setShowCount(false);
-  }, [isOpen, notifications.length, windowWidth]);
-
-  React.useEffect(() => {
-    if (!hasMore || !onLoadMore || !loadMoreRef.current) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          onLoadMore();
-        }
-      },
-      {
-        root: null,
-        rootMargin: '0px',
-        threshold: 1.0,
-      }
-    );
-
-    observer.observe(loadMoreRef.current);
-
-    return () => {
-      if (loadMoreRef.current) {
-        observer.unobserve(loadMoreRef.current);
-      }
-    };
-  }, [hasMore, onLoadMore, notifications.length]);
-
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node) &&
-        buttonRef.current &&
-        !buttonRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-        onOpenChange?.(false);
-        onClose?.();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen, onOpenChange, onClose]);
-
   return (
-    <Flex sx={{ position: 'relative', justifyContent: 'flex-start' }}>
+    <Flex
+      sx={{
+        position: 'relative',
+        justifyContent: 'flex-start',
+        zIndex: 'modal',
+      }}
+    >
       <Box sx={{ position: 'relative' }}>
         <IconButton
-          ref={buttonRef}
           variant="ghost"
           sx={{
             position: 'relative',
@@ -204,41 +105,63 @@ export const NotificationsMenu = ({
         </IconButton>
 
         {isOpen && (
-          <div ref={containerRef}>
-            <Card
+          <>
+            <Drawer
+              size={menuWidth}
+              direction="right"
+              open={isOpen}
+              overlayOpacity={0}
+              onClose={() => {
+                setIsOpen(false);
+                onOpenChange?.(false);
+                onClose?.();
+              }}
               sx={{
-                position: 'fixed',
-                top: `${menuTop}px`,
-                left: `${menuLeft}px`,
-                right: 'auto',
-                width: `${menuWidth}px`,
-                maxHeight: '550px',
-                overflowY: 'auto',
-                zIndex: 'modal',
-                padding: 0,
-                boxShadow: 'xl',
-                borderRadius: '2xl',
-                backgroundColor: 'display.background.secondary.default',
+                '.EZDrawer__container': {
+                  position: 'fixed',
+                  height: 'full',
+                  backgroundColor: 'display.background.primary.default',
+                  width: 'full',
+                  maxWidth: '2',
+                  boxShadow: '4',
+                  borderLeft: '1px solid',
+                  borderColor: 'display.border.primary.default',
+                  paddingX: '5',
+                  paddingTop: '4',
+                  paddingBottom: '4',
+                  transformOrigin: 'top right',
+                },
               }}
             >
-              <Box sx={{ width: '100%' }}>
-                <Flex sx={{ flexDirection: 'column', gap: 4 }}>
-                  {notifications.length > 0 && onClearAll && (
-                    <Flex
-                      sx={{
-                        justifyContent: 'flex-end',
-                        p: 2,
-                        marginBottom: -2,
-                      }}
-                    >
+              <Box
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Flex
+                  sx={{
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    marginBottom: 4,
+                    flexShrink: 0,
+                  }}
+                >
+                  <Text sx={{ fontSize: 'lg', fontWeight: 'bold' }}>
+                    Notificações
+                  </Text>
+                  <Flex sx={{ alignItems: 'center', gap: 2 }}>
+                    {notifications.length > 0 && onClearAll && (
                       <Button
                         variant="ghost"
                         sx={{
                           borderRadius: 'md',
                           padding: 1,
-                          paddingLeft: 10,
-                          paddingRight: 10,
-                          fontSize: 'md',
+                          paddingLeft: 3,
+                          paddingRight: 3,
+                          fontSize: 'sm',
                           color: 'display.text.muted.default',
                           border: '1px solid',
                           borderColor: 'display.border.default',
@@ -256,16 +179,41 @@ export const NotificationsMenu = ({
                         <Icon icon="delete" width={16} height={16} />
                         <Text
                           sx={{
-                            ml: -1,
-                            marginTop: -0.4,
+                            ml: 1,
                             fontSize: 'sm',
                           }}
                         >
                           Limpar Tudo
                         </Text>
                       </Button>
-                    </Flex>
-                  )}
+                    )}
+                    <IconButton
+                      variant="ghost"
+                      sx={{
+                        borderRadius: 'full',
+                        padding: 1,
+                        '&:hover': {
+                          backgroundColor: 'display.background.muted.default',
+                        },
+                      }}
+                      onClick={() => {
+                        setIsOpen(false);
+                        onOpenChange?.(false);
+                        onClose?.();
+                      }}
+                    >
+                      <Icon icon="close" width={20} height={20} />
+                    </IconButton>
+                  </Flex>
+                </Flex>
+                <Flex
+                  sx={{
+                    flexDirection: 'column',
+                    gap: 4,
+                    flex: 1,
+                    overflowY: 'auto',
+                  }}
+                >
                   {notifications.length === 0 ? (
                     <Text
                       sx={{
@@ -293,8 +241,8 @@ export const NotificationsMenu = ({
                   {hasMore && <div ref={loadMoreRef} style={{ height: 1 }} />}
                 </Flex>
               </Box>
-            </Card>
-          </div>
+            </Drawer>
+          </>
         )}
       </Box>
     </Flex>


### PR DESCRIPTION
Esta PR altera o menu que carrega as notificações para usar um drawer, posicionado agora ao lado direito permitindo uma área maior para visualizar as notificações em desktop além de permitir o uso de tela cheia para notificações para resoluções mobile.

<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/fbd0a074-903f-473e-9cce-2e94867f31b6" />

<img width="1917" height="916" alt="image" src="https://github.com/user-attachments/assets/0b749c60-a888-482b-ac24-c526c5433cdc" />

<img width="1918" height="909" alt="image" src="https://github.com/user-attachments/assets/71d2dc67-58a9-4e73-b234-eb095754382d" />

<img width="1917" height="907" alt="image" src="https://github.com/user-attachments/assets/073ab24a-319d-4774-8199-bc22759ab07e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now open in a right-anchored drawer with fixed positioning, responsive width, improved overlay, and a header containing title, clear-all action, and close button.
  * Notification messages now wrap long words to avoid layout breakage.

* **Bug Fixes**
  * Prevents menu overflow and keeps the panel visible while scrolling or resizing.

* **Behavior Changes**
  * Infinite "load more" on scroll removed; open/close flow simplified and overlay layering improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->