### PR TITLE
Revert "carlin deploy: add `envExport` to export CloudFormation outputs as env vars to CI/CD runner"

### DIFF
--- a/docs/website/docs/carlin/05-commands/deploy.mdx
+++ b/docs/website/docs/carlin/05-commands/deploy.mdx
@@ -263,55 +263,6 @@ To overcome this problem, destroy will only delete the resources if termination 
 
 After deployment, outputs are saved to `.carlin/$STACK_NAME.json` and `.carlin/latest-deploy.json`. Use [`carlin deploy report`](/docs/carlin/commands/deploy-report) to print them to stdout or publish them to a channel (e.g. a GitHub PR comment).
 
-## Exporting Outputs to the CI/CD Environment (`envExport`)
-
-When deploying a backend package that exports CloudFormation outputs (e.g. `AppSyncApiGraphQLUrl`), downstream packages built in the same CI pipeline often need those values as specific environment variable names before their build step runs.
-
-Use the `envExport` option in your `carlin.ts` to declare this mapping once. After a successful deployment, carlin reads the stack outputs and exports the mapped variables to the runner environment automatically — no manual `jq` parsing or shell variable wiring needed.
-
-```ts title="carlin.ts"
-export default {
-  envExport: {
-    AppSyncApiGraphQLUrl: 'VITE_APPSYNC_GRAPHQL_ENDPOINT',
-    AppSyncApiArn: 'APPSYNC_API_ARN',
-  },
-};
-```
-
-### CI/CD Behavior
-
-| Runner             | Behavior                                                                                        |
-| ------------------ | ----------------------------------------------------------------------------------------------- |
-| **GitHub Actions** | Appends `KEY=VALUE` lines to `$GITHUB_ENV`, making variables available to all subsequent steps. |
-| **Generic shell**  | Prints `export KEY=VALUE` lines to stdout so the output can be `eval`-ed.                       |
-
-### Pipeline Example
-
-```sh
-# 1. Deploy graph-api — carlin reads envExport, writes to $GITHUB_ENV
-carlin deploy --environment Staging
-# → VITE_APPSYNC_GRAPHQL_ENDPOINT is now available to subsequent steps
-
-# 2. Build app — Vite picks up the exported variable automatically
-pnpm turbo run build --filter=app
-```
-
-### Per-environment Override
-
-`envExport` composes with per-environment configuration:
-
-```ts title="carlin.ts"
-export default {
-  environments: {
-    Staging: {
-      envExport: {
-        AppSyncApiGraphQLUrl: 'VITE_APPSYNC_GRAPHQL_ENDPOINT',
-      },
-    },
-  },
-};
-```
-
 ## API
 
 ### Options

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,10 +6,10 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 67.5,
-      branches: 57.59,
-      functions: 68.13,
-      lines: 67.47,
+      statements: 67.23,
+      branches: 57.51,
+      lines: 67.15,
+      functions: 68.26,
     },
   },
   moduleNameMapper: {

--- a/packages/carlin/src/deploy/cloudformation.core.ts
+++ b/packages/carlin/src/deploy/cloudformation.core.ts
@@ -246,78 +246,6 @@ const saveEnvironmentOutput = async ({
 };
 
 /**
- * Export CloudFormation stack outputs as environment variables to the CI/CD
- * runner environment.
- *
- * - **GitHub Actions**: appends `KEY=VALUE` lines to the file at `$GITHUB_ENV`,
- *   making the variables available to all subsequent steps.
- * - **Generic shell**: prints `export KEY=VALUE` lines to stdout so the output
- *   can be `eval`-ed by the calling shell.
- *
- * @example
- * ```ts
- * // carlin.ts
- * export default {
- *   envExport: {
- *     AppSyncApiGraphQLUrl: 'VITE_APPSYNC_GRAPHQL_ENDPOINT',
- *     AppSyncApiArn: 'APPSYNC_API_ARN',
- *   },
- * };
- * ```
- */
-export const exportEnvVars = async ({
-  outputs,
-  envExport,
-}: {
-  outputs: AWS.CloudFormation.Output[];
-  envExport: Record<string, string>;
-}) => {
-  const githubEnvFile = process.env.GITHUB_ENV;
-
-  for (const [cfOutputKey, envVarName] of Object.entries(envExport)) {
-    const output = outputs.find(({ OutputKey }) => {
-      return OutputKey === cfOutputKey;
-    });
-
-    if (!output?.OutputValue) {
-      log.warn(
-        logPrefix,
-        `envExport: CloudFormation output "${cfOutputKey}" not found or has no value. Skipping export of "${envVarName}".`
-      );
-      continue;
-    }
-
-    const value = output.OutputValue;
-
-    if (githubEnvFile) {
-      /**
-       * GitHub Actions environment file format: each variable is written on a
-       * separate line as `KEY=VALUE`. Values with newlines must use the
-       * heredoc delimiter syntax; for simplicity we warn and skip those.
-       */
-      if (value.includes('\n')) {
-        log.warn(
-          logPrefix,
-          `envExport: value for "${cfOutputKey}" contains newlines and cannot be exported to GITHUB_ENV safely. Skipping.`
-        );
-        continue;
-      }
-
-      await fs.promises.appendFile(githubEnvFile, `${envVarName}=${value}\n`);
-      log.info(logPrefix, `envExport: wrote ${envVarName} to GITHUB_ENV`);
-    } else {
-      /**
-       * Escape single quotes in the value so the shell `export` statement
-       * remains syntactically correct (POSIX: replace each `'` with `'\''`).
-       */
-      const escapedValue = value.replace(/'/g, `'\\''`);
-      process.stdout.write(`export ${envVarName}='${escapedValue}'\n`);
-      log.info(logPrefix, `envExport: printed export ${envVarName} to stdout`);
-    }
-  }
-};
-
-/**
  * After deployment, Carlin prints the outputs defined in your CloudFormation
  * template and saves them in two files:
  *
@@ -330,16 +258,11 @@ export const exportEnvVars = async ({
  * to access the outputs of the last deployment, but don't have access to the
  * stack name. It's useful for end-to-end tests that need to access the outputs
  * of the last deployment and test the application.
- *
- * If `envExport` is provided, carlin also exports the mapped CloudFormation
- * outputs as environment variables to the CI/CD runner (see `exportEnvVars`).
  */
 export const printStackOutputsAfterDeploy = async ({
   stackName,
-  envExport,
 }: {
   stackName: string;
-  envExport?: Record<string, string>;
 }) => {
   const {
     EnableTerminationProtection,
@@ -364,10 +287,6 @@ export const printStackOutputsAfterDeploy = async ({
         '',
       ].join('\n')
     );
-  }
-
-  if (envExport && Object.keys(envExport).length > 0) {
-    await exportEnvVars({ outputs: Outputs, envExport });
   }
 };
 
@@ -471,11 +390,9 @@ export const defaultTemplatePaths = ['ts', 'js', 'yaml', 'yml', 'json'].map(
  */
 export const deploy = async ({
   terminationProtection = false,
-  envExport,
   ...paramsAndTemplate
 }: {
   terminationProtection?: boolean;
-  envExport?: Record<string, string>;
   params: CreateStackCommandInput | UpdateStackCommandInput;
   template: CloudFormationTemplate;
 }) => {
@@ -520,7 +437,7 @@ export const deploy = async ({
     await enableTerminationProtection({ stackName });
   }
 
-  await printStackOutputsAfterDeploy({ stackName, envExport });
+  await printStackOutputsAfterDeploy({ stackName });
 
   return describeStack({ stackName });
 };

--- a/packages/carlin/src/deploy/cloudformation.ts
+++ b/packages/carlin/src/deploy/cloudformation.ts
@@ -2,7 +2,7 @@ import {
   type CloudFormationTemplate,
   findAndReadCloudFormationTemplate,
 } from '@ttoss/cloudformation';
-import type AWS from 'aws-sdk';
+import AWS from 'aws-sdk';
 import log from 'npmlog';
 
 import { getEnvironment, getPackageName, getProjectName } from '../utils';
@@ -84,7 +84,6 @@ export const deployCloudFormation = async (cliOptions: {
   }[];
   templatePath?: string;
   template?: CloudFormationTemplate;
-  envExport?: Record<string, string>;
 }) => {
   try {
     const {
@@ -98,7 +97,6 @@ export const deployCloudFormation = async (cliOptions: {
       parameters,
       template,
       templatePath,
-      envExport,
     } = cliOptions;
 
     const { stackName } = await handleDeployInitialization({ logPrefix });
@@ -273,7 +271,6 @@ export const deployCloudFormation = async (cliOptions: {
     const output = await deploy({
       params,
       template: cloudFormationTemplate,
-      envExport,
     });
 
     return output;

--- a/packages/carlin/src/deploy/command.ts
+++ b/packages/carlin/src/deploy/command.ts
@@ -191,56 +191,6 @@ export const options = {
     describe: 'Set the stack name.',
     type: 'string',
   },
-  /**
-   * Mapping of CloudFormation output keys to environment variable names.
-   * After a successful deployment, carlin reads the stack outputs and exports
-   * the mapped variables to the CI/CD runner environment:
-   *
-   * - **GitHub Actions**: appends `KEY=VALUE` lines to `$GITHUB_ENV`.
-   * - **Generic shell**: prints `export KEY=VALUE` lines to stdout.
-   *
-   * Configure in your `carlin.ts`:
-   *
-   * ```ts
-   * export default {
-   *   envExport: {
-   *     AppSyncApiGraphQLUrl: 'VITE_APPSYNC_GRAPHQL_ENDPOINT',
-   *     AppSyncApiArn: 'APPSYNC_API_ARN',
-   *   },
-   * };
-   * ```
-   *
-   * Can also be combined with per-environment config:
-   *
-   * ```ts
-   * export default {
-   *   environments: {
-   *     Staging: {
-   *       envExport: {
-   *         AppSyncApiGraphQLUrl: 'VITE_APPSYNC_GRAPHQL_ENDPOINT',
-   *       },
-   *     },
-   *   },
-   * };
-   * ```
-   */
-  'env-export': {
-    describe:
-      'Mapping of CloudFormation output keys to environment variable names to export after deployment.',
-    coerce: (arg: unknown) => {
-      if (
-        typeof arg === 'object' &&
-        arg !== null &&
-        !Array.isArray(arg) &&
-        Object.values(arg).every((v) => {
-          return typeof v === 'string';
-        })
-      ) {
-        return arg as Record<string, string>;
-      }
-      return undefined;
-    },
-  },
   'template-path': {
     alias: 't',
     describe: 'Path to the CloudFormation template.',

--- a/packages/carlin/tests/unit/command.test.ts
+++ b/packages/carlin/tests/unit/command.test.ts
@@ -214,16 +214,12 @@ describe('handlers', () => {
     );
   });
 
-  test('should pass envExport to deployCloudFormation', async () => {
-    const envExport = {
-      AppSyncApiGraphQLUrl: 'VITE_APPSYNC_GRAPHQL_ENDPOINT',
-      AppSyncApiArn: 'APPSYNC_API_ARN',
-    };
-
-    await parse('deploy', { envExport });
-
+  test('should pass default lambda-runtime to deployCloudFormation', async () => {
+    await parse('deploy', {});
     expect(deployCloudFormation).toHaveBeenCalledWith(
-      expect.objectContaining({ envExport })
+      expect.objectContaining({
+        lambdaRuntime: 'nodejs24.x',
+      })
     );
   });
 });

--- a/packages/carlin/tests/unit/deploy/cloudformation.core.test.ts
+++ b/packages/carlin/tests/unit/deploy/cloudformation.core.test.ts
@@ -1,5 +1,7 @@
-import type { DescribeStacksOutput } from '@aws-sdk/client-cloudformation';
-import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import {
+  DescribeStacksCommand,
+  DescribeStacksOutput,
+} from '@aws-sdk/client-cloudformation';
 import { faker } from '@ttoss/test-utils/faker';
 
 const MockDescribeStacksCommand = DescribeStacksCommand;
@@ -83,7 +85,6 @@ import {
   describeStack,
   describeStacks,
   doesStackExist,
-  exportEnvVars,
   getStackOutput,
   printStackOutputsAfterDeploy,
 } from 'src/deploy/cloudformation.core';
@@ -95,7 +96,6 @@ jest.mock('fs', () => {
     promises: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...(jest.requireActual('fs').promises as any),
-      appendFile: jest.fn().mockResolvedValue(undefined),
       mkdir: jest.fn(),
       writeFile: jest.fn().mockResolvedValue(undefined),
     },
@@ -129,169 +129,6 @@ describe('printStackOutputsAfterDeploy', () => {
           mockDescribeStacksOutput.Stacks[0].Outputs[1],
       },
     });
-  });
-
-  test('should call exportEnvVars when envExport is provided', async () => {
-    const stackName = mockDescribeStacksOutput.Stacks[0].StackName;
-    const [firstOutput, secondOutput] =
-      mockDescribeStacksOutput.Stacks[0].Outputs;
-
-    const envExport = {
-      [firstOutput.OutputKey]: 'FIRST_VAR',
-      [secondOutput.OutputKey]: 'SECOND_VAR',
-    };
-
-    const appendFileMock = jest
-      .spyOn(fs.promises, 'appendFile')
-      .mockResolvedValue(undefined);
-
-    const originalGithubEnv = process.env.GITHUB_ENV;
-    process.env.GITHUB_ENV = '/tmp/github_env_test';
-
-    try {
-      await printStackOutputsAfterDeploy({ stackName, envExport });
-
-      expect(appendFileMock).toHaveBeenCalledTimes(2);
-      expect(appendFileMock).toHaveBeenCalledWith(
-        '/tmp/github_env_test',
-        `FIRST_VAR=${firstOutput.OutputValue}\n`
-      );
-      expect(appendFileMock).toHaveBeenCalledWith(
-        '/tmp/github_env_test',
-        `SECOND_VAR=${secondOutput.OutputValue}\n`
-      );
-    } finally {
-      process.env.GITHUB_ENV = originalGithubEnv;
-    }
-  });
-});
-
-describe('exportEnvVars', () => {
-  const outputs = mockDescribeStacksOutput.Stacks[0].Outputs.map((o) => {
-    return { OutputKey: o.OutputKey, OutputValue: o.OutputValue };
-  });
-
-  const [firstOutput, secondOutput] = outputs;
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-    delete process.env.GITHUB_ENV;
-  });
-
-  test('should append KEY=VALUE lines to GITHUB_ENV when GITHUB_ENV is set', async () => {
-    process.env.GITHUB_ENV = '/tmp/github_env_test';
-
-    const appendFileMock = jest
-      .spyOn(fs.promises, 'appendFile')
-      .mockResolvedValue(undefined);
-
-    await exportEnvVars({
-      outputs,
-      envExport: {
-        [firstOutput.OutputKey]: 'MY_FIRST_VAR',
-        [secondOutput.OutputKey]: 'MY_SECOND_VAR',
-      },
-    });
-
-    expect(appendFileMock).toHaveBeenCalledTimes(2);
-    expect(appendFileMock).toHaveBeenCalledWith(
-      '/tmp/github_env_test',
-      `MY_FIRST_VAR=${firstOutput.OutputValue}\n`
-    );
-    expect(appendFileMock).toHaveBeenCalledWith(
-      '/tmp/github_env_test',
-      `MY_SECOND_VAR=${secondOutput.OutputValue}\n`
-    );
-  });
-
-  test('should print export statements to stdout when GITHUB_ENV is not set', async () => {
-    delete process.env.GITHUB_ENV;
-
-    const stdoutWriteMock = jest
-      .spyOn(process.stdout, 'write')
-      .mockImplementation(() => {
-        return true;
-      });
-
-    await exportEnvVars({
-      outputs,
-      envExport: {
-        [firstOutput.OutputKey]: 'MY_FIRST_VAR',
-        [secondOutput.OutputKey]: 'MY_SECOND_VAR',
-      },
-    });
-
-    expect(stdoutWriteMock).toHaveBeenCalledTimes(2);
-    expect(stdoutWriteMock).toHaveBeenCalledWith(
-      `export MY_FIRST_VAR='${firstOutput.OutputValue}'\n`
-    );
-    expect(stdoutWriteMock).toHaveBeenCalledWith(
-      `export MY_SECOND_VAR='${secondOutput.OutputValue}'\n`
-    );
-  });
-
-  test('should warn and skip when a CloudFormation output key is not found', async () => {
-    delete process.env.GITHUB_ENV;
-
-    const stdoutWriteMock = jest
-      .spyOn(process.stdout, 'write')
-      .mockImplementation(() => {
-        return true;
-      });
-
-    await exportEnvVars({
-      outputs,
-      envExport: {
-        NonExistentKey: 'MISSING_VAR',
-        [firstOutput.OutputKey]: 'FOUND_VAR',
-      },
-    });
-
-    expect(stdoutWriteMock).toHaveBeenCalledTimes(1);
-    expect(stdoutWriteMock).toHaveBeenCalledWith(
-      `export FOUND_VAR='${firstOutput.OutputValue}'\n`
-    );
-  });
-  test('should escape single quotes in values for generic shell output', async () => {
-    delete process.env.GITHUB_ENV;
-
-    const outputsWithQuote = [
-      { OutputKey: 'MyKey', OutputValue: "it's a value" },
-    ];
-
-    const stdoutWriteMock = jest
-      .spyOn(process.stdout, 'write')
-      .mockImplementation(() => {
-        return true;
-      });
-
-    await exportEnvVars({
-      outputs: outputsWithQuote,
-      envExport: { MyKey: 'MY_VAR' },
-    });
-
-    expect(stdoutWriteMock).toHaveBeenCalledWith(
-      `export MY_VAR='it'\\''s a value'\n`
-    );
-  });
-
-  test('should warn and skip when value contains newlines in GitHub Actions', async () => {
-    process.env.GITHUB_ENV = '/tmp/github_env_test';
-
-    const outputsWithNewline = [
-      { OutputKey: 'MultilineKey', OutputValue: 'line1\nline2' },
-    ];
-
-    const appendFileMock = jest
-      .spyOn(fs.promises, 'appendFile')
-      .mockResolvedValue(undefined);
-
-    await exportEnvVars({
-      outputs: outputsWithNewline,
-      envExport: { MultilineKey: 'MY_MULTILINE_VAR' },
-    });
-
-    expect(appendFileMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Reverts ttoss/ttoss#916