### PR TITLE
feat(@ttoss/http-server-mcp): add OAuth/JWT authentication support

### DIFF
--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -127,6 +127,137 @@ const data = await apiCall('GET', 'https://partner.api.com/data', {
 
 `apiCall` throws with a clear message when called with a relative path and no `apiBaseUrl` is configured in the context.
 
+## Authentication
+
+`createMcpRouter` supports OAuth 2.0 Bearer token authentication via the `auth` option. Every incoming MCP request must include a valid `Authorization: Bearer <token>` header — invalid or missing tokens receive a `401 Unauthorized` response.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant MCP Server
+    participant Verifier
+
+    Client->>MCP Server: POST /mcp + Authorization: Bearer &lt;token&gt;
+    MCP Server->>Verifier: verify(token)
+    alt valid token
+        Verifier-->>MCP Server: identity payload
+        MCP Server->>MCP Server: run tool (identity available via getIdentity())
+        MCP Server-->>Client: 200 OK
+    else invalid or missing token
+        Verifier-->>MCP Server: error
+        MCP Server-->>Client: 401 Unauthorized
+    end
+```
+
+### Amazon Cognito
+
+Pass `cognitoUserPool` and the router creates a `CognitoJwtVerifier` (from `@ttoss/auth-core`) internally:
+
+```typescript
+import { createMcpRouter, McpServer } from '@ttoss/http-server-mcp';
+
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: {
+      userPoolId: process.env.COGNITO_USER_POOL_ID!,
+      clientId: process.env.COGNITO_CLIENT_ID!,
+      tokenUse: 'access', // default
+    },
+  },
+});
+```
+
+### Custom verifier
+
+Pass an async `verifyToken` function for any other provider (Auth0, Keycloak, etc.):
+
+```typescript
+import { createMcpRouter } from '@ttoss/http-server-mcp';
+import { jwtVerify, createRemoteJWKSet } from 'jose';
+
+const JWKS = createRemoteJWKSet(
+  new URL('https://your-auth-server/.well-known/jwks.json')
+);
+
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    verifyToken: async (token) => {
+      const { payload } = await jwtVerify(token, JWKS);
+      return payload;
+    },
+  },
+});
+```
+
+### Accessing the verified identity
+
+Inside any tool handler, call `getIdentity()` to retrieve the verified JWT payload:
+
+```typescript
+import { getIdentity, createMcpRouter, McpServer } from '@ttoss/http-server-mcp';
+
+mcpServer.registerTool(
+  'get-profile',
+  { description: 'Return the caller's profile', inputSchema: {} },
+  async () => {
+    const identity = getIdentity() as { sub: string; email: string };
+    return {
+      content: [{ type: 'text', text: `Hello, ${identity.email}` }],
+    };
+  }
+);
+```
+
+### Scope enforcement
+
+Scopes can be enforced at two levels.
+
+**Router-level** — gate the entire MCP endpoint. Any token missing a required scope receives a `403 Forbidden` before any tool runs:
+
+```typescript
+createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: { userPoolId: '...', clientId: '...' },
+    requiredScopes: ['mcp:access'],
+  },
+});
+```
+
+**Per-tool** — use `checkScopes()` inside individual handlers for fine-grained control. It throws an error that the MCP SDK returns as a tool error to the client:
+
+```typescript
+import { checkScopes, getIdentity } from '@ttoss/http-server-mcp';
+
+mcpServer.registerTool(
+  'delete-user',
+  { description: 'Delete a user', inputSchema: { userId: z.string() } },
+  async ({ userId }) => {
+    checkScopes(['admin', 'write:users']); // throws if either scope is missing
+
+    const identity = getIdentity() as { sub: string };
+    // proceed with deletion...
+    return { content: [{ type: 'text', text: `Deleted ${userId}` }] };
+  }
+);
+```
+
+Cognito encodes scopes as a space-separated string in `payload.scope` (e.g. `"openid mcp:access admin"`).
+
+### OAuth Protected Resource Metadata
+
+For MCP clients that support OAuth auto-discovery, add `resourceServerUrl` and `authorizationServerUrl` to expose the `/.well-known/oauth-protected-resource` endpoint (RFC 9728):
+
+```typescript
+createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: { userPoolId: '...', clientId: '...' },
+    resourceServerUrl: 'https://mcp.example.com',
+    authorizationServerUrl:
+      'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxx',
+  },
+});
+```
+
 ## API Reference
 
 ### `createMcpRouter(server, options?)`
@@ -135,14 +266,19 @@ Creates a Koa router configured to handle MCP protocol requests.
 
 **Parameters:**
 
-- `server` (`McpServer`) - MCP server instance with registered tools and resources
-- `options` (`McpRouterOptions`) - Optional configuration
-  - `path` (`string`) - HTTP path for MCP endpoint (default: `'/mcp'`)
-  - `sessionIdGenerator` (`() => string`) - Session ID generator for stateful servers (default: `undefined` for stateless)
-  - `apiBaseUrl` (`string`) - Base URL prepended to relative paths in `apiCall`
-  - `getApiHeaders` (`(ctx: Context) => Record<string, string>`) - Return headers to inject into every `apiCall` for this request (auth tokens, API keys, trace headers, etc.)
+- `server` (`McpServer`) — MCP server instance with registered tools and resources
+- `options` (`McpRouterOptions`) — Optional configuration
+  - `path` (`string`) — HTTP path for MCP endpoint (default: `'/mcp'`)
+  - `sessionIdGenerator` (`() => string`) — Session ID generator for stateful servers (default: `undefined` for stateless)
+  - `apiBaseUrl` (`string`) — Base URL prepended to relative paths in `apiCall`
+  - `getApiHeaders` (`(ctx: Context) => Record<string, string>`) — Return headers to inject into every `apiCall` for this request
+  - `auth` (`McpAuthOptions`) — OAuth/JWT authentication; see [Authentication](#authentication)
+    - `auth.cognitoUserPool` — Cognito user pool config (`userPoolId`, `clientId`, `tokenUse`)
+    - `auth.verifyToken` — Custom async token verifier `(token: string) => Promise<unknown>`
+    - `auth.requiredScopes` — Router-level scope guard; returns 403 if any scope is missing
+    - `auth.resourceServerUrl` + `auth.authorizationServerUrl` — Enable `/.well-known/oauth-protected-resource`
 
-**Returns:** `Router` - Koa router instance
+**Returns:** `Router` — Koa router instance
 
 ### `apiCall(method, url, options?)`
 
@@ -150,12 +286,26 @@ Generic HTTP helper for use inside MCP tool handlers.
 
 **Parameters:**
 
-- `method` (`string`) - HTTP method (`'GET'`, `'POST'`, `'PUT'`, `'DELETE'`, …)
-- `url` (`string`) - Full URL **or** a path starting with `/` (prepended with `apiBaseUrl`)
-- `options.body` (`unknown`, optional) - Request body, serialised as JSON
-- `options.headers` (`Record<string, string>`, optional) - Per-call header overrides; merged on top of context-injected headers
+- `method` (`string`) — HTTP method (`'GET'`, `'POST'`, `'PUT'`, `'DELETE'`, …)
+- `url` (`string`) — Full URL **or** a path starting with `/` (prepended with `apiBaseUrl`)
+- `options.body` (`unknown`, optional) — Request body, serialised as JSON
+- `options.headers` (`Record<string, string>`, optional) — Per-call header overrides; merged on top of context-injected headers
 
-**Returns:** `Promise<unknown>` - Parsed JSON response body
+**Returns:** `Promise<unknown>` — Parsed JSON response body
+
+### `getIdentity()`
+
+Returns the verified JWT payload for the current MCP request. Only available inside a tool handler when `auth` is configured. Returns `undefined` when called outside an authenticated context.
+
+**Returns:** `unknown` — Verified token payload (cast to your expected shape)
+
+### `checkScopes(required)`
+
+Asserts that the current request token contains all required scopes. Throws `Error: Insufficient scopes. Required: …` if any scope is missing — the MCP SDK catches this and returns a tool error to the client.
+
+**Parameters:**
+
+- `required` (`string[]`) — Scope strings that must all be present in `payload.scope`
 
 ### `registerToolFromSchema(server, params)`
 
@@ -165,11 +315,11 @@ Use this when tool definitions are shared between the MCP server and an AI SDK a
 
 **Parameters:**
 
-- `server` (`McpServer`) - The MCP server instance
-- `params.name` (`string`) - Unique tool name
-- `params.description` (`string`, optional) - Human-readable description
-- `params.inputSchema` (`JsonObjectSchema`, optional) - Plain JSON Schema object (defaults to `{ type: 'object', properties: {} }`)
-- `params.handler` (`(args: Record<string, unknown>) => CallToolResult | Promise<CallToolResult>`) - Tool handler receiving the raw request arguments
+- `server` (`McpServer`) — The MCP server instance
+- `params.name` (`string`) — Unique tool name
+- `params.description` (`string`, optional) — Human-readable description
+- `params.inputSchema` (`JsonObjectSchema`, optional) — Plain JSON Schema object (defaults to `{ type: 'object', properties: {} }`)
+- `params.handler` (`(args: Record<string, unknown>) => CallToolResult | Promise<CallToolResult>`) — Tool handler receiving the raw request arguments
 
 **Returns:** `void`
 

--- a/packages/http-server-mcp/package.json
+++ b/packages/http-server-mcp/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@ttoss/auth-core": "workspace:^",
     "@ttoss/http-server": "workspace:^",
     "zod": "^4.3.6"
   },

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { CognitoJwtVerifier } from '@ttoss/auth-core/amazon-cognito';
 import { Router } from '@ttoss/http-server';
 import type Koa from 'koa';
 import { z } from 'zod';
@@ -12,6 +13,7 @@ type Context = Koa.Context;
 interface RequestContext {
   apiBaseUrl?: string;
   apiHeaders: Record<string, string>;
+  identity?: unknown;
 }
 
 const requestContextStore = new AsyncLocalStorage<RequestContext>();
@@ -155,6 +157,94 @@ export const apiCall = async (
 };
 
 /**
+ * Returns the verified JWT payload for the current MCP request.
+ * Only available inside a tool handler when `auth` is configured on the router.
+ */
+export const getIdentity = (): unknown => {
+  return requestContextStore.getStore()?.identity;
+};
+
+/**
+ * Asserts that the current request's token contains all required scopes.
+ * Throws if any scope is missing — the MCP SDK catches this and returns a
+ * tool error to the client. Use inside tool handlers for per-tool authorization.
+ *
+ * Cognito tokens carry scopes as a space-separated string in `payload.scope`.
+ *
+ * @example
+ * ```typescript
+ * server.tool('delete-user', schema, async (args) => {
+ *   checkScopes(['admin', 'write:users']);
+ *   // proceed only if caller has both scopes
+ * });
+ * ```
+ */
+export const checkScopes = (required: string[]): void => {
+  const identity = getIdentity() as { scope?: string } | undefined;
+  const tokenScopes = (identity?.scope ?? '').split(' ');
+  const missing = required.filter((s) => {
+    return !tokenScopes.includes(s);
+  });
+  if (missing.length > 0) {
+    throw new Error(`Insufficient scopes. Required: ${required.join(', ')}`);
+  }
+};
+
+/** Amazon Cognito user pool configuration for JWT verification. */
+export interface CognitoUserPoolConfig {
+  /** The Cognito User Pool ID (e.g. `us-east-1_abc123`). */
+  userPoolId: string;
+  /**
+   * Which token type to verify.
+   * @default 'access'
+   */
+  tokenUse?: 'access' | 'id';
+  /** The app client ID registered in the User Pool. */
+  clientId: string;
+}
+
+/**
+ * Authentication options for the MCP router.
+ *
+ * Supply either `cognitoUserPool` (uses `CognitoJwtVerifier` from
+ * `@ttoss/auth-core`) or a custom `verifyToken` function — not both.
+ */
+export interface McpAuthOptions {
+  /**
+   * Amazon Cognito user pool config. When provided, the router creates a
+   * `CognitoJwtVerifier` and validates every incoming Bearer token against it.
+   */
+  cognitoUserPool?: CognitoUserPoolConfig;
+  /**
+   * Custom token verifier for non-Cognito providers (Auth0, Keycloak, …).
+   * Receives the raw Bearer token string. Should resolve with the verified
+   * payload or reject/throw on failure.
+   */
+  verifyToken?: (token: string) => Promise<unknown>;
+  /**
+   * Router-level scope guard. All listed scopes must be present on the token
+   * for any MCP request to be allowed. Returns 403 if any scope is missing.
+   *
+   * Cognito encodes scopes as a space-separated string in `payload.scope`.
+   *
+   * @example ['mcp:access']
+   */
+  requiredScopes?: string[];
+  /**
+   * URL of this MCP server, used in the OAuth Protected Resource Metadata
+   * response (`/.well-known/oauth-protected-resource`). Both this field and
+   * `authorizationServerUrl` must be provided to enable the endpoint.
+   */
+  resourceServerUrl?: string;
+  /**
+   * URL of the OAuth Authorization Server that issues tokens for this resource.
+   * Enables `/.well-known/oauth-protected-resource` for MCP client auto-discovery
+   * (RFC 9728) when combined with `resourceServerUrl`.
+   */
+  authorizationServerUrl?: string;
+}
+
+/**
  * Options for configuring the MCP router
  */
 export interface McpRouterOptions {
@@ -206,7 +296,108 @@ export interface McpRouterOptions {
    * ```
    */
   getApiHeaders?: (ctx: Context) => Record<string, string>;
+
+  /**
+   * OAuth / JWT authentication configuration for the MCP endpoint.
+   *
+   * When set, every incoming MCP request must include a valid Bearer token in
+   * the `Authorization` header. Invalid or missing tokens receive a `401`
+   * response with `WWW-Authenticate: Bearer`. Tokens that fail a
+   * `requiredScopes` check receive `403`.
+   *
+   * The verified token payload is accessible inside tool handlers via
+   * {@link getIdentity}. Fine-grained per-tool scope checks can be done with
+   * {@link checkScopes}.
+   *
+   * @example Cognito
+   * ```typescript
+   * createMcpRouter(server, {
+   *   auth: {
+   *     cognitoUserPool: { userPoolId: 'us-east-1_xxx', clientId: 'yyy' },
+   *     requiredScopes: ['mcp:access'],
+   *   },
+   * });
+   * ```
+   *
+   * @example Custom verifier
+   * ```typescript
+   * createMcpRouter(server, {
+   *   auth: {
+   *     verifyToken: async (token) => myJwtLib.verify(token),
+   *   },
+   * });
+   * ```
+   */
+  auth?: McpAuthOptions;
 }
+
+const buildTokenVerifier = (
+  auth: McpAuthOptions
+): ((token: string) => Promise<unknown>) => {
+  if (auth.cognitoUserPool) {
+    const v = CognitoJwtVerifier.create({
+      tokenUse: 'access',
+      ...auth.cognitoUserPool,
+    });
+    return (t) => {
+      return v.verify(t);
+    };
+  }
+  if (auth.verifyToken) {
+    return auth.verifyToken;
+  }
+  throw new Error(
+    'McpAuthOptions requires either cognitoUserPool or verifyToken'
+  );
+};
+
+const registerAuthRoutes = (
+  router: InstanceType<typeof Router>,
+  path: string,
+  auth: McpAuthOptions,
+  tokenVerifier: (token: string) => Promise<unknown>
+): void => {
+  router.use(path, async (ctx: Context, next) => {
+    const authHeader = ctx.headers.authorization;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+
+    let identity: unknown;
+    try {
+      identity = await tokenVerifier(token);
+    } catch {
+      ctx.status = 401;
+      ctx.set('WWW-Authenticate', 'Bearer');
+      ctx.body = 'Unauthorized';
+      return;
+    }
+
+    if (auth.requiredScopes?.length) {
+      const tokenScopes = ((identity as { scope?: string })?.scope ?? '').split(
+        ' '
+      );
+      const missing = auth.requiredScopes.filter((s) => {
+        return !tokenScopes.includes(s);
+      });
+      if (missing.length > 0) {
+        ctx.status = 403;
+        ctx.body = 'Forbidden';
+        return;
+      }
+    }
+
+    (ctx.state as { identity?: unknown }).identity = identity;
+    await next();
+  });
+
+  if (auth.resourceServerUrl && auth.authorizationServerUrl) {
+    router.get('/.well-known/oauth-protected-resource', (ctx: Context) => {
+      ctx.body = {
+        resource: auth.resourceServerUrl,
+        authorization_servers: [auth.authorizationServerUrl],
+      };
+    });
+  }
+};
 
 /**
  * Creates a Koa router configured to handle MCP protocol requests
@@ -255,9 +446,13 @@ export const createMcpRouter = (
     sessionIdGenerator,
     apiBaseUrl,
     getApiHeaders,
+    auth,
   } = options;
   const isStateful = sessionIdGenerator !== undefined;
-  const needsContext = apiBaseUrl !== undefined || getApiHeaders !== undefined;
+  const needsContext =
+    apiBaseUrl !== undefined ||
+    getApiHeaders !== undefined ||
+    auth !== undefined;
 
   // Stateful mode: single shared transport connected once at startup
   let sharedTransport: StreamableHTTPServerTransport | undefined;
@@ -286,11 +481,16 @@ export const createMcpRouter = (
 
   const router = new Router();
 
+  if (auth) {
+    registerAuthRoutes(router, path, auth, buildTokenVerifier(auth));
+  }
+
   const handleWithContext = async (
     ctx: Context,
     body?: unknown
   ): Promise<void> => {
     const apiHeaders = getApiHeaders ? getApiHeaders(ctx) : {};
+    const identity = (ctx.state as { identity?: unknown }).identity;
 
     const runRequest = async (
       transport: StreamableHTTPServerTransport
@@ -304,9 +504,12 @@ export const createMcpRouter = (
     if (isStateful && sharedTransport) {
       // Stateful mode: reuse the shared transport
       if (needsContext) {
-        await requestContextStore.run({ apiBaseUrl, apiHeaders }, () => {
-          return runRequest(sharedTransport!);
-        });
+        await requestContextStore.run(
+          { apiBaseUrl, apiHeaders, identity },
+          () => {
+            return runRequest(sharedTransport!);
+          }
+        );
       } else {
         await runRequest(sharedTransport);
       }
@@ -323,9 +526,12 @@ export const createMcpRouter = (
         try {
           await server.connect(transport);
           if (needsContext) {
-            await requestContextStore.run({ apiBaseUrl, apiHeaders }, () => {
-              return runRequest(transport);
-            });
+            await requestContextStore.run(
+              { apiBaseUrl, apiHeaders, identity },
+              () => {
+                return runRequest(transport);
+              }
+            );
           } else {
             await runRequest(transport);
           }

--- a/packages/http-server-mcp/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp/tests/unit/jest.config.ts
@@ -4,10 +4,10 @@ export default {
   ...jestUnitConfig(),
   coverageThreshold: {
     global: {
-      statements: 85,
-      branches: 75,
-      functions: 83,
-      lines: 85,
+      statements: 89.9,
+      branches: 80.1,
+      functions: 87.9,
+      lines: 89.75,
     },
   },
 };

--- a/packages/http-server-mcp/tests/unit/tests/auth.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/auth.test.ts
@@ -1,0 +1,416 @@
+import { CognitoJwtVerifier } from '@ttoss/auth-core/amazon-cognito';
+import { App, bodyParser } from '@ttoss/http-server';
+import {
+  checkScopes,
+  createMcpRouter,
+  getIdentity,
+  McpServer,
+  z,
+} from 'src/index';
+import request from 'supertest';
+
+jest.mock('@ttoss/auth-core/amazon-cognito', () => {
+  return {
+    CognitoJwtVerifier: {
+      create: jest.fn(),
+    },
+  };
+});
+
+const MCP_ACCEPT = 'application/json, text/event-stream';
+
+const makeMcpRequest = (method: string, params: unknown, id: number) => {
+  return {
+    jsonrpc: '2.0',
+    method,
+    params,
+    id,
+  };
+};
+
+const initializeParams = {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'test-client', version: '1.0.0' },
+};
+
+describe('auth — no config', () => {
+  test('requests pass through when auth is not configured', async () => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    const app = new App();
+    app.use(bodyParser());
+    app.use(createMcpRouter(mcpServer).routes());
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT);
+
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe('auth — verifyToken', () => {
+  const buildApp = (
+    verifyToken: (token: string) => Promise<unknown>,
+    requiredScopes?: string[]
+  ) => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+
+    mcpServer.registerTool(
+      'whoami',
+      { description: 'Returns identity', inputSchema: {} },
+      async () => {
+        const identity = getIdentity();
+        return {
+          content: [{ type: 'text', text: JSON.stringify(identity) }],
+        };
+      }
+    );
+
+    mcpServer.registerTool(
+      'admin-only',
+      { description: 'Requires admin scope', inputSchema: { x: z.string() } },
+      async () => {
+        checkScopes(['admin']);
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }
+    );
+
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: { verifyToken, requiredScopes },
+      }).routes()
+    );
+    return app;
+  };
+
+  test('returns 401 when no Authorization header is sent', async () => {
+    const app = buildApp(() => {
+      return Promise.reject(new Error('invalid'));
+    });
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT);
+
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toBe('Bearer');
+  });
+
+  test('returns 401 when verifyToken rejects', async () => {
+    const app = buildApp(() => {
+      return Promise.reject(new Error('bad token'));
+    });
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer bad-token');
+
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toBe('Bearer');
+  });
+
+  test('allows request and sets identity when verifyToken resolves', async () => {
+    const payload = { sub: 'user-123', scope: 'openid' };
+    const app = buildApp(() => {
+      return Promise.resolve(payload);
+    });
+
+    const initRes = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(initRes.status).toBe(200);
+  });
+
+  test('getIdentity() returns verified payload inside tool handler', async () => {
+    const payload = { sub: 'user-abc', email: 'user@example.com' };
+    const app = buildApp(() => {
+      return Promise.resolve(payload);
+    });
+
+    const callback = app.callback();
+
+    await request(callback)
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    const toolRes = await request(callback)
+      .post('/mcp')
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 2))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    expect(toolRes.status).toBe(200);
+    const body = toolRes.body;
+    const text = body?.result?.content?.[0]?.text;
+    expect(JSON.parse(text)).toEqual(payload);
+  });
+
+  test('returns 403 when requiredScopes are not satisfied', async () => {
+    const payload = { sub: 'u1', scope: 'openid profile' };
+    const app = buildApp(() => {
+      return Promise.resolve(payload);
+    }, ['mcp:access']);
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    expect(res.status).toBe(403);
+  });
+
+  test('allows request when requiredScopes are satisfied', async () => {
+    const payload = { sub: 'u1', scope: 'openid mcp:access profile' };
+    const app = buildApp(() => {
+      return Promise.resolve(payload);
+    }, ['mcp:access']);
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    expect(res.status).toBe(200);
+  });
+
+  test('checkScopes() throws when scope is missing from token', async () => {
+    const payload = { sub: 'u1', scope: 'openid' };
+    const app = buildApp(() => {
+      return Promise.resolve(payload);
+    });
+
+    const callback = app.callback();
+
+    await request(callback)
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    const toolRes = await request(callback)
+      .post('/mcp')
+      .send(
+        makeMcpRequest(
+          'tools/call',
+          { name: 'admin-only', arguments: { x: 'y' } },
+          2
+        )
+      )
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    // MCP SDK returns 200 but marks it as an error
+    expect(toolRes.status).toBe(200);
+    expect(toolRes.body?.result?.isError).toBe(true);
+    expect(toolRes.body?.result?.content?.[0]?.text).toContain(
+      'Insufficient scopes'
+    );
+  });
+
+  test('checkScopes() passes when all scopes are present', async () => {
+    const payload = { sub: 'u1', scope: 'openid admin write:users' };
+    const app = buildApp(() => {
+      return Promise.resolve(payload);
+    });
+
+    const callback = app.callback();
+
+    await request(callback)
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    const toolRes = await request(callback)
+      .post('/mcp')
+      .send(
+        makeMcpRequest(
+          'tools/call',
+          { name: 'admin-only', arguments: { x: 'y' } },
+          2
+        )
+      )
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    expect(toolRes.status).toBe(200);
+    expect(toolRes.body?.result?.isError).toBeFalsy();
+  });
+
+  test('throws at startup when neither cognitoUserPool nor verifyToken is provided', () => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    expect(() => {
+      createMcpRouter(mcpServer, { auth: {} });
+    }).toThrow('McpAuthOptions requires either cognitoUserPool or verifyToken');
+  });
+});
+
+describe('auth — OAuth Protected Resource metadata endpoint', () => {
+  test('serves /.well-known/oauth-protected-resource when configured', async () => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          verifyToken: () => {
+            return Promise.resolve({ sub: 'u' });
+          },
+          resourceServerUrl: 'https://mcp.example.com',
+          authorizationServerUrl: 'https://auth.example.com',
+        },
+      }).routes()
+    );
+
+    const res = await request(app.callback()).get(
+      '/.well-known/oauth-protected-resource'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      resource: 'https://mcp.example.com',
+      authorization_servers: ['https://auth.example.com'],
+    });
+  });
+
+  test('does not serve metadata endpoint when urls are not configured', async () => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          verifyToken: () => {
+            return Promise.resolve({ sub: 'u' });
+          },
+        },
+      }).routes()
+    );
+
+    const res = await request(app.callback()).get(
+      '/.well-known/oauth-protected-resource'
+    );
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('auth — cognitoUserPool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates a CognitoJwtVerifier and returns 401 when token is invalid', async () => {
+    const mockVerify = jest.fn().mockRejectedValue(new Error('invalid token'));
+    jest.mocked(CognitoJwtVerifier.create).mockReturnValue({
+      verify: mockVerify,
+    } as never);
+
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          cognitoUserPool: {
+            userPoolId: 'us-east-1_test',
+            clientId: 'client123',
+          },
+        },
+      }).routes()
+    );
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer bad-token');
+
+    expect(res.status).toBe(401);
+    expect(mockVerify).toHaveBeenCalledWith('bad-token');
+  });
+
+  test('creates a CognitoJwtVerifier and allows valid token', async () => {
+    const payload = { sub: 'cognito-user', scope: 'openid' };
+    const mockVerify = jest.fn().mockResolvedValue(payload);
+    jest.mocked(CognitoJwtVerifier.create).mockReturnValue({
+      verify: mockVerify,
+    } as never);
+
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          cognitoUserPool: {
+            userPoolId: 'us-east-1_test',
+            clientId: 'client123',
+            tokenUse: 'access',
+          },
+        },
+      }).routes()
+    );
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(mockVerify).toHaveBeenCalledWith('valid-token');
+  });
+
+  test('passes tokenUse and clientId to CognitoJwtVerifier.create', () => {
+    jest.mocked(CognitoJwtVerifier.create).mockReturnValue({
+      verify: jest.fn(),
+    } as never);
+
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    createMcpRouter(mcpServer, {
+      auth: {
+        cognitoUserPool: {
+          userPoolId: 'us-east-1_abc',
+          clientId: 'myclient',
+          tokenUse: 'id',
+        },
+      },
+    });
+
+    expect(CognitoJwtVerifier.create).toHaveBeenCalledWith({
+      tokenUse: 'id',
+      userPoolId: 'us-east-1_abc',
+      clientId: 'myclient',
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,7 +706,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -1220,6 +1220,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      '@ttoss/auth-core':
+        specifier: workspace:^
+        version: link:../auth-core
       '@ttoss/http-server':
         specifier: workspace:^
         version: link:../http-server
@@ -21787,7 +21790,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -21798,7 +21801,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -21806,11 +21809,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -21819,13 +21822,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -21833,7 +21836,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@ts-morph/common@0.29.0':
@@ -31904,7 +31907,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
## Summary

- Adds an `auth` option to `createMcpRouter` for Bearer token authentication on the MCP endpoint
- Supports **Amazon Cognito** via `cognitoUserPool` (uses `CognitoJwtVerifier` from `@ttoss/auth-core`) or any **custom `verifyToken`** function for other providers (Auth0, Keycloak, etc.)
- Router-level `requiredScopes` guard returns 403 if the token is missing any listed scope
- New `getIdentity()` export — reads the verified JWT payload inside tool handlers via `AsyncLocalStorage`
- New `checkScopes(required)` export — per-tool scope assertion; throws an error the MCP SDK surfaces as a tool error
- Optional `/.well-known/oauth-protected-resource` endpoint (RFC 9728) for MCP client auto-discovery when `resourceServerUrl` + `authorizationServerUrl` are configured
- 15 new tests covering all auth paths; coverage thresholds raised to match new coverage

## Test plan

- [ ] All 48 tests pass (`pnpm run test` inside `packages/http-server-mcp`)
- [ ] Lint passes (pre-commit hook verified on commit)
- [ ] Build passes (`pnpm turbo run build --filter=...@ttoss/http-server-mcp`)
- [ ] Smoke-test with Cognito: configure `cognitoUserPool`, send a request without a Bearer token → expect 401; send with a valid Cognito access token → expect 200 and `getIdentity()` returning the JWT payload inside a tool handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)