### PR TITLE
fix(@ttoss/config): add topLevelVar to tsdown output to prevent TDZ ReferenceError

### DIFF
--- a/packages/config/src/tsdown.ts
+++ b/packages/config/src/tsdown.ts
@@ -126,6 +126,15 @@ export const defaultConfig = {
   },
   plugins: [formatjsPlugin, injectReactImport()],
   target: typescriptConfig.target,
+  /**
+   * Rewrite top-level `let`/`const` to `var` in CJS output so that
+   * TypeScript's `typeof X === "undefined"` guard (emitted by
+   * `emitDecoratorMetadata`) works correctly when circular imports cause a
+   * class to be referenced before its initializer runs. With `let`/`const`,
+   * `typeof X` throws a ReferenceError (TDZ); with `var`, it safely returns
+   * `"undefined"` and the guard falls through to `Object` as intended.
+   */
+  outputOptions: { topLevelVar: true },
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

- Adds `outputOptions: { topLevelVar: true }` to the default tsdown config in `@ttoss/config`
- This rewrites top-level `let`/`const` declarations to `var` in CJS output, preventing `ReferenceError` when TypeScript's `emitDecoratorMetadata` guard (`typeof X === "undefined"`) is evaluated while `X` is in the Temporal Dead Zone due to circular imports bundled by rolldown

## Test plan

- [ ] All existing unit tests in `@ttoss/config` pass (19/19)
- [ ] Build packages that have circular deps + `emitDecoratorMetadata: true` and verify no `ReferenceError` on `require()`

Fixes #1020

https://claude.ai/code/session_01Xf7WeMnfcT22pV9wx1XcZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf7WeMnfcT22pV9wx1XcZ4)_