### PR TITLE
fix: re-enable SLSA provenance in publish pipeline

### DIFF
--- a/.cicd/commands/main.sh
+++ b/.cicd/commands/main.sh
@@ -103,7 +103,7 @@ if pnpm lerna changed; then
   # `pnpm -r publish` reads versions from package.json and skips packages already
   # on the registry, so retries never re-publish already-published packages.
   for attempt in 1 2 3; do
-    pnpm -r publish --no-git-checks && break
+    pnpm -r publish --no-git-checks --provenance && break
     if [ "$attempt" -lt 3 ]; then
       echo "Publish attempt $attempt failed, retrying in 30 seconds..."
       sleep 30


### PR DESCRIPTION
## Summary

- pnpm does not read `publishConfig.provenance` from `package.json` — that field is npm-only and silently ignored by pnpm
- The fix adds `--provenance` explicitly to the `pnpm -r publish` command in `.cicd/commands/main.sh`
- No other changes needed: the workflow already has `permissions: id-token: write` and all 46 packages already have `"provenance": true` in their `publishConfig`

## Test plan

- [ ] Verify the next publish run generates provenance attestations visible on the npm registry package pages
- [ ] Consumers can verify with `npm audit signatures` after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)