### PR TITLE
feat(http-server): re-export Context, Next, and Middleware types from koa

### DIFF
--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -6,6 +6,7 @@ import App from 'koa';
 import serve from 'koa-static';
 
 export { App, bodyParser, cors, multer, Router, serve };
+export type { Context, Middleware, Next } from 'koa';
 
 export * from './addHealthCheck';
 export type { File as MulterFile } from '@koa/multer';

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -6,10 +6,9 @@ import App from 'koa';
 import serve from 'koa-static';
 
 export { App, bodyParser, cors, multer, Router, serve };
-export type { Context, Middleware, Next } from 'koa';
-
 export * from './addHealthCheck';
 export type { File as MulterFile } from '@koa/multer';
+export type { Context, Middleware, Next } from 'koa';
 
 /**
  * Export types to avoid The inferred type of cannot be named without a reference to


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Re-exports `Context`, `Next`, and `Middleware` types from `koa` in `@ttoss/http-server/src/index.ts`
- Consumers writing typed Koa middleware no longer need to add `koa` or `@types/koa` as a direct dependency

## Test plan

- [ ] Verify that a package importing `type { Context, Next, Middleware } from '@ttoss/http-server'` compiles without errors
- [ ] Run `pnpm turbo run build --filter=...@ttoss/http-server` and confirm no DTS errors

https://claude.ai/code/session_01UmnHUH9H85VJ9RC5sq7uFR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmnHUH9H85VJ9RC5sq7uFR)_