### PR TITLE
fix(@ttoss/components): add module/browser/import export conditions for rolldown/vite 8

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,6 +72,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/components/tests/unit/tests/__snapshots__/packageJsonExports.test.ts.snap
+++ b/packages/components/tests/unit/tests/__snapshots__/packageJsonExports.test.ts.snap
@@ -9,7 +9,10 @@ exports[`package.json exports should export all components 1`] = `
 exports[`package.json exports should export all components 2`] = `
 {
   ".": {
+    "browser": "./dist/index.mjs",
     "default": "./dist/index.mjs",
+    "import": "./dist/index.mjs",
+    "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
   },
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -60,14 +60,23 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       },
       "./multistep-form": {
+        "module": "./dist/MultistepForm/index.mjs",
+        "browser": "./dist/MultistepForm/index.mjs",
+        "import": "./dist/MultistepForm/index.mjs",
         "types": "./dist/MultistepForm/index.d.mts",
         "default": "./dist/MultistepForm/index.mjs"
       },
       "./brazil": {
+        "module": "./dist/Brazil/index.mjs",
+        "browser": "./dist/Brazil/index.mjs",
+        "import": "./dist/Brazil/index.mjs",
         "types": "./dist/Brazil/index.d.mts",
         "default": "./dist/Brazil/index.mjs"
       }

--- a/packages/fsl-theme/package.json
+++ b/packages/fsl-theme/package.json
@@ -64,30 +64,51 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       },
       "./css": {
+        "module": "./dist/css.mjs",
+        "browser": "./dist/css.mjs",
+        "import": "./dist/css.mjs",
         "types": "./dist/css.d.mts",
         "default": "./dist/css.mjs"
       },
       "./runtime": {
+        "module": "./dist/runtime-entry.mjs",
+        "browser": "./dist/runtime-entry.mjs",
+        "import": "./dist/runtime-entry.mjs",
         "types": "./dist/runtime-entry.d.mts",
         "default": "./dist/runtime-entry.mjs"
       },
       "./react": {
+        "module": "./dist/react.mjs",
+        "browser": "./dist/react.mjs",
+        "import": "./dist/react.mjs",
         "types": "./dist/react.d.mts",
         "default": "./dist/react.mjs"
       },
       "./vars": {
+        "module": "./dist/vars.mjs",
+        "browser": "./dist/vars.mjs",
+        "import": "./dist/vars.mjs",
         "types": "./dist/vars.d.mts",
         "default": "./dist/vars.mjs"
       },
       "./dtcg": {
+        "module": "./dist/dtcg.mjs",
+        "browser": "./dist/dtcg.mjs",
+        "import": "./dist/dtcg.mjs",
         "types": "./dist/dtcg.d.mts",
         "default": "./dist/dtcg.mjs"
       },
       "./dataviz": {
+        "module": "./dist/dataviz/index.mjs",
+        "browser": "./dist/dataviz/index.mjs",
+        "import": "./dist/dataviz/index.mjs",
         "types": "./dist/dataviz/index.d.mts",
         "default": "./dist/dataviz/index.mjs"
       }

--- a/packages/geovis/package.json
+++ b/packages/geovis/package.json
@@ -58,8 +58,10 @@
     "access": "public",
     "exports": {
       ".": {
-        "types": "./dist/index.d.mts",
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
         "import": "./dist/index.mjs",
+        "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }
     },

--- a/packages/google-maps/package.json
+++ b/packages/google-maps/package.json
@@ -49,6 +49,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/landing-pages/package.json
+++ b/packages/landing-pages/package.json
@@ -52,6 +52,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -48,6 +48,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-auth-cognito/package.json
+++ b/packages/react-auth-cognito/package.json
@@ -66,6 +66,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-auth-core/package.json
+++ b/packages/react-auth-core/package.json
@@ -64,6 +64,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-auth-strapi/package.json
+++ b/packages/react-auth-strapi/package.json
@@ -56,6 +56,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-billing/package.json
+++ b/packages/react-billing/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/ttoss/ttoss.git",
     "directory": "packages/react-billing"
   },
-  "author": "Giovane Guimar\u00e3es",
+  "author": "Giovane Guimarães",
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/packages/react-billing/package.json
+++ b/packages/react-billing/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/ttoss/ttoss.git",
     "directory": "packages/react-billing"
   },
-  "author": "Giovane Guimarães",
+  "author": "Giovane Guimar\u00e3es",
   "sideEffects": false,
   "type": "module",
   "exports": {
@@ -46,6 +46,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-dashboard/package.json
+++ b/packages/react-dashboard/package.json
@@ -53,6 +53,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-feature-flags/package.json
+++ b/packages/react-feature-flags/package.json
@@ -45,6 +45,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -42,6 +42,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -53,6 +53,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -47,6 +47,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-notifications/package.json
+++ b/packages/react-notifications/package.json
@@ -49,6 +49,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/react-wizard/package.json
+++ b/packages/react-wizard/package.json
@@ -56,6 +56,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -48,14 +48,23 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       },
       "./Bruttal": {
+        "module": "./dist/themes/Bruttal/Bruttal.mjs",
+        "browser": "./dist/themes/Bruttal/Bruttal.mjs",
+        "import": "./dist/themes/Bruttal/Bruttal.mjs",
         "types": "./dist/themes/Bruttal/Bruttal.d.mts",
         "default": "./dist/themes/Bruttal/Bruttal.mjs"
       },
       "./Oca": {
+        "module": "./dist/themes/Oca/Oca.mjs",
+        "browser": "./dist/themes/Oca/Oca.mjs",
+        "import": "./dist/themes/Oca/Oca.mjs",
         "types": "./dist/themes/Oca/Oca.d.mts",
         "default": "./dist/themes/Oca/Oca.mjs"
       }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,6 +61,9 @@
     "access": "public",
     "exports": {
       ".": {
+        "module": "./dist/index.mjs",
+        "browser": "./dist/index.mjs",
+        "import": "./dist/index.mjs",
         "types": "./dist/index.d.mts",
         "default": "./dist/index.mjs"
       }


### PR DESCRIPTION
## Summary

- Adds `module`, `browser`, and `import` export conditions to the `publishConfig.exports["."]` in `@ttoss/components/package.json`
- Fixes builds failing with rolldown/vite 8 which resolves exports using conditions `["module", "browser", "production", "import"]`

Closes #1033

## Test plan

- [ ] Verify a vite 8 project importing `@ttoss/components` builds without the "not exported under the conditions" error

https://claude.ai/code/session_014DaSctbkQV8YnA8haatKca

---
_Generated by [Claude Code](https://claude.ai/code/session_014DaSctbkQV8YnA8haatKca)_