### PR TITLE
feat(@ttoss/auth-core): add JWT, one-time token, and API token primitives; harden password hashing

### DIFF
--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -87,6 +87,49 @@ const isValid = verifyApiToken({
 });
 ```
 
+## Encryption at rest
+
+AES-256-GCM helpers for storing sensitive values (e.g., third-party API
+keys) in a database. The ciphertext is a single base64 string containing
+the IV, auth tag, and payload. Decryption throws on a wrong key or
+tampered ciphertext.
+
+```ts
+import {
+  decryptValue,
+  encryptValue,
+  generateEncryptionKey,
+} from '@ttoss/auth-core';
+
+// Generate once and store in a secret manager:
+const key = generateEncryptionKey(); // 64-char hex (32 bytes)
+
+const ciphertext = encryptValue({ plaintext: 'third-party-api-key', key });
+const plaintext = decryptValue({ ciphertext, key });
+```
+
+## Webhook signatures
+
+HMAC-SHA256 payload signing using the common `sha256=<hex>` header
+convention (e.g., GitHub's `X-Hub-Signature-256`), with constant-time
+verification on the receiving side.
+
+```ts
+import {
+  generateWebhookSecret,
+  signWebhookPayload,
+  verifyWebhookSignature,
+} from '@ttoss/auth-core';
+
+// Sender:
+const secret = generateWebhookSecret();
+const signature = signWebhookPayload({ payload: body, secret });
+// send as a header, e.g. `X-Myapp-Signature: ${signature}`
+
+// Receiver:
+const isValid = verifyWebhookSignature({ payload: body, secret, signature });
+```
+
 ## Encoding helpers
 
 ```ts

--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -1,9 +1,97 @@
 # @ttoss/auth-core
 
-This package contains the core logic for authentication and authorization.
+Framework-agnostic authentication primitives for Node.js, with zero
+dependencies beyond `node:crypto` (Amazon Cognito verification excepted).
 
 ## Installation
 
 ```bash
 pnpm add @ttoss/auth-core
+```
+
+## Password hashing
+
+PBKDF2-HMAC-SHA256 with 600,000 iterations (OWASP recommendation) and
+constant-time comparison. Hashes are self-describing
+(`pbkdf2-sha256$<iterations>$<salt>$<hash>`), so iterations can be raised
+later without invalidating stored hashes. The legacy `salt:hash` format is
+still verified for backwards compatibility.
+
+```ts
+import { comparePassword, hashPassword, needsRehash } from '@ttoss/auth-core';
+
+const stored = await hashPassword('my-password');
+const isMatch = await comparePassword('my-password', stored);
+
+// On successful login, upgrade weak/legacy hashes:
+if (isMatch && needsRehash(stored)) {
+  await saveHash(await hashPassword('my-password'));
+}
+```
+
+## JWT (HS256)
+
+Sign and verify JWTs for self-hosted authentication, where the application
+owns the signing secret. `verifyJwt` returns `null` for malformed, badly
+signed, or expired tokens.
+
+```ts
+import { signJwt, verifyJwt } from '@ttoss/auth-core';
+
+const token = signJwt({
+  payload: { sub: 'user_123', email: 'user@example.com' },
+  secret: process.env.JWT_SECRET,
+  expiresInSeconds: 60 * 60 * 24 * 7, // 7 days
+});
+
+const payload = verifyJwt({ token, secret: process.env.JWT_SECRET });
+```
+
+For Amazon Cognito tokens, use `@ttoss/auth-core/amazon-cognito`, which
+re-exports [`aws-jwt-verify`](https://github.com/awslabs/aws-jwt-verify).
+
+## One-time tokens
+
+Building block for magic links, email verification, and password reset.
+Store only `tokenHash` and `expires`; send `token` to the user and destroy
+the record after a successful verification.
+
+```ts
+import { generateOneTimeToken, verifyOneTimeToken } from '@ttoss/auth-core';
+
+const { token, tokenHash, expires } = generateOneTimeToken({
+  expiresInSeconds: 60 * 60, // 1 hour, e.g. for password reset
+});
+
+// later, when the user clicks the link:
+const isValid = verifyOneTimeToken({ token: received, tokenHash, expires });
+```
+
+## API tokens
+
+Personal access tokens in the form `<prefix>_<hex>`, recognizable in logs and
+secret scanners. Show the plain token once; persist only the SHA-256 hash and
+a short display prefix.
+
+```ts
+import { generateApiToken, verifyApiToken } from '@ttoss/auth-core';
+
+const { token, tokenHash, displayPrefix } = generateApiToken({
+  prefix: 'myapp',
+});
+
+const isValid = verifyApiToken({
+  token: received,
+  tokenHash,
+  expiresAt: storedExpiresAt, // optional
+});
+```
+
+## Encoding helpers
+
+```ts
+import { decode, encode } from '@ttoss/auth-core';
+
+const encoded = encode({ id: 1 }); // base64 JSON
+const obj = decode(encoded);
 ```

--- a/packages/auth-core/src/apiToken.ts
+++ b/packages/auth-core/src/apiToken.ts
@@ -1,0 +1,80 @@
+import crypto from 'node:crypto';
+
+/**
+ * Primitives for long-lived API tokens (personal access tokens).
+ *
+ * Tokens look like `<prefix>_<64 hex chars>` — e.g. `myapp_3f2a…` — so they
+ * are recognizable in logs and secret scanners. The application stores only
+ * the SHA-256 hash and the display prefix, never the plain token.
+ */
+
+export type GeneratedApiToken = {
+  /**
+   * The plain token to show to the user once, at creation time.
+   */
+  token: string;
+  /**
+   * SHA-256 hash of the token, safe to persist and index for lookups.
+   */
+  tokenHash: string;
+  /**
+   * First characters of the token, safe to persist for display purposes
+   * (e.g., `myapp_3f2a…`).
+   */
+  displayPrefix: string;
+};
+
+export const hashApiToken = (token: string): string => {
+  return crypto.createHash('sha256').update(token).digest('hex');
+};
+
+export const generateApiToken = (args: {
+  /**
+   * Application prefix, e.g. `myapp` produces tokens like `myapp_<hex>`.
+   */
+  prefix: string;
+  /**
+   * Number of random bytes. Defaults to 32 (64 hex characters).
+   */
+  bytes?: number;
+  /**
+   * Number of characters of the token kept as `displayPrefix`. Defaults
+   * to 12.
+   */
+  displayPrefixLength?: number;
+}): GeneratedApiToken => {
+  const bytes = args.bytes ?? 32;
+  const displayPrefixLength = args.displayPrefixLength ?? 12;
+
+  const token = `${args.prefix}_${crypto.randomBytes(bytes).toString('hex')}`;
+
+  return {
+    token,
+    tokenHash: hashApiToken(token),
+    displayPrefix: token.slice(0, displayPrefixLength),
+  };
+};
+
+/**
+ * Constant-time check of a plain token against a stored hash, optionally
+ * validating expiration.
+ */
+export const verifyApiToken = (args: {
+  token: string;
+  tokenHash: string;
+  /**
+   * When provided, the token is rejected after this date. Omit (or pass
+   * `null`) for tokens that never expire.
+   */
+  expiresAt?: Date | null;
+}): boolean => {
+  if (args.expiresAt && args.expiresAt.getTime() <= Date.now()) {
+    return false;
+  }
+  const a = Buffer.from(hashApiToken(args.token), 'hex');
+  const b = Buffer.from(args.tokenHash, 'hex');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+};

--- a/packages/auth-core/src/encryption.ts
+++ b/packages/auth-core/src/encryption.ts
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto';
+
+/**
+ * Symmetric encryption helpers (AES-256-GCM) for storing sensitive values
+ * at rest — e.g., third-party API keys or user secrets in a database.
+ *
+ * The ciphertext is a single base64 string containing the IV, the
+ * authentication tag, and the encrypted payload, so no extra columns are
+ * needed to store it.
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+
+/**
+ * Generates a random 32-byte encryption key, hex encoded (64 characters).
+ * Store it in a secret manager or environment variable.
+ */
+export const generateEncryptionKey = (): string => {
+  return crypto.randomBytes(KEY_LENGTH).toString('hex');
+};
+
+const parseKey = (key: string): Buffer => {
+  const buf = Buffer.from(key, 'hex');
+  if (buf.length !== KEY_LENGTH) {
+    throw new Error(
+      'Encryption key must be a 64-character hex string (32 bytes)'
+    );
+  }
+  return buf;
+};
+
+export const encryptValue = (args: {
+  plaintext: string;
+  /**
+   * 32-byte key, hex encoded (64 characters). See `generateEncryptionKey`.
+   */
+  key: string;
+}): string => {
+  const key = parseKey(args.key);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  const encrypted = Buffer.concat([
+    cipher.update(args.plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString('base64');
+};
+
+/**
+ * Decrypts a value produced by `encryptValue`. Throws when the key is wrong
+ * or the ciphertext was tampered with (GCM authentication failure).
+ */
+export const decryptValue = (args: {
+  ciphertext: string;
+  /**
+   * 32-byte key, hex encoded (64 characters). See `generateEncryptionKey`.
+   */
+  key: string;
+}): string => {
+  const key = parseKey(args.key);
+  const buf = Buffer.from(args.ciphertext, 'base64');
+  const iv = buf.subarray(0, IV_LENGTH);
+  const authTag = buf.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const encrypted = buf.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(authTag);
+  return decipher.update(encrypted) + decipher.final('utf8');
+};

--- a/packages/auth-core/src/hash.ts
+++ b/packages/auth-core/src/hash.ts
@@ -1,50 +1,108 @@
 import crypto from 'node:crypto';
 
-const ITERATIONS = 1000;
+/**
+ * 1,000 iterations were used by the original `salt:hash` format. Kept only to
+ * verify hashes created before the versioned format existed.
+ */
+const LEGACY_ITERATIONS = 1000;
+
+/**
+ * OWASP recommendation for PBKDF2-HMAC-SHA256.
+ */
+const DEFAULT_ITERATIONS = 600_000;
 
 const KEY_LENGTH = 64;
 
 const DIGEST = 'sha256';
 
-export const hashPassword = (plainPassword: string): Promise<string> => {
-  const salt = crypto.randomBytes(16).toString('hex');
+const HASH_VERSION = 'pbkdf2-sha256';
+
+const pbkdf2 = (
+  plainPassword: string,
+  salt: string,
+  iterations: number
+): Promise<Buffer> => {
   return new Promise((resolve, reject) => {
     crypto.pbkdf2(
       plainPassword,
       salt,
-      ITERATIONS,
+      iterations,
       KEY_LENGTH,
       DIGEST,
       (err, derivedKey) => {
         if (err) {
           reject(err);
+          return;
         }
-        const hash = derivedKey.toString('hex');
-        resolve(`${salt}:${hash}`);
+        resolve(derivedKey);
       }
     );
   });
 };
 
-export const comparePassword = (
+const timingSafeEqualHex = (hexA: string, hexB: string): boolean => {
+  const a = Buffer.from(hexA, 'hex');
+  const b = Buffer.from(hexB, 'hex');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+};
+
+/**
+ * Hashes a password with PBKDF2-HMAC-SHA256.
+ *
+ * The returned string is self-describing —
+ * `pbkdf2-sha256$<iterations>$<salt>$<hash>` — so the iteration count can be
+ * raised in the future without invalidating stored hashes.
+ */
+export const hashPassword = async (
+  plainPassword: string,
+  options?: { iterations?: number }
+): Promise<string> => {
+  const iterations = options?.iterations ?? DEFAULT_ITERATIONS;
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derivedKey = await pbkdf2(plainPassword, salt, iterations);
+  return `${HASH_VERSION}$${iterations}$${salt}$${derivedKey.toString('hex')}`;
+};
+
+/**
+ * Compares a password against a stored hash using a constant-time comparison.
+ *
+ * Supports both the versioned `pbkdf2-sha256$<iterations>$<salt>$<hash>`
+ * format and the legacy `salt:hash` format (1,000 iterations).
+ */
+export const comparePassword = async (
   plainPassword: string,
   storedHash: string
 ): Promise<boolean> => {
+  if (storedHash.startsWith(`${HASH_VERSION}$`)) {
+    const [, iterationsStr, salt, hash] = storedHash.split('$');
+    const iterations = Number(iterationsStr);
+    if (!Number.isInteger(iterations) || iterations <= 0 || !salt || !hash) {
+      return false;
+    }
+    const derivedKey = await pbkdf2(plainPassword, salt, iterations);
+    return timingSafeEqualHex(hash, derivedKey.toString('hex'));
+  }
+
   const [salt, hash] = storedHash.split(':');
-  return new Promise((resolve, reject) => {
-    crypto.pbkdf2(
-      plainPassword,
-      salt,
-      ITERATIONS,
-      KEY_LENGTH,
-      DIGEST,
-      (err, derivedKey) => {
-        if (err) {
-          reject(err);
-        }
-        const hashToCompare = derivedKey.toString('hex');
-        resolve(hash === hashToCompare);
-      }
-    );
-  });
+  if (!salt || !hash) {
+    return false;
+  }
+  const derivedKey = await pbkdf2(plainPassword, salt, LEGACY_ITERATIONS);
+  return timingSafeEqualHex(hash, derivedKey.toString('hex'));
+};
+
+/**
+ * Returns true if the stored hash uses the legacy format or fewer iterations
+ * than currently recommended. Callers can re-hash the password on the user's
+ * next successful login.
+ */
+export const needsRehash = (storedHash: string): boolean => {
+  if (!storedHash.startsWith(`${HASH_VERSION}$`)) {
+    return true;
+  }
+  const [, iterationsStr] = storedHash.split('$');
+  return Number(iterationsStr) < DEFAULT_ITERATIONS;
 };

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -5,6 +5,11 @@ export {
   verifyApiToken,
 } from './apiToken';
 export { decode, encode } from './encodeDecode';
+export {
+  decryptValue,
+  encryptValue,
+  generateEncryptionKey,
+} from './encryption';
 export { comparePassword, hashPassword, needsRehash } from './hash';
 export { type JwtPayload, signJwt, verifyJwt } from './jwt';
 export {
@@ -13,3 +18,8 @@ export {
   type OneTimeToken,
   verifyOneTimeToken,
 } from './oneTimeToken';
+export {
+  generateWebhookSecret,
+  signWebhookPayload,
+  verifyWebhookSignature,
+} from './webhookSignature';

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -1,2 +1,15 @@
-export { encode, decode } from './encodeDecode';
-export { hashPassword, comparePassword } from './hash';
+export {
+  generateApiToken,
+  type GeneratedApiToken,
+  hashApiToken,
+  verifyApiToken,
+} from './apiToken';
+export { decode, encode } from './encodeDecode';
+export { comparePassword, hashPassword, needsRehash } from './hash';
+export { type JwtPayload, signJwt, verifyJwt } from './jwt';
+export {
+  generateOneTimeToken,
+  hashOneTimeToken,
+  type OneTimeToken,
+  verifyOneTimeToken,
+} from './oneTimeToken';

--- a/packages/auth-core/src/jwt.ts
+++ b/packages/auth-core/src/jwt.ts
@@ -1,0 +1,114 @@
+import crypto from 'node:crypto';
+
+import { decode, encode } from './encodeDecode';
+
+const ALGORITHM = 'HS256';
+
+const base64UrlFromBase64 = (base64: string): string => {
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+const base64UrlEncode = (obj: unknown): string => {
+  return base64UrlFromBase64(encode(obj));
+};
+
+const base64UrlDecode = (base64Url: string): unknown => {
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  return decode(base64);
+};
+
+const sign = (input: string, secret: string): string => {
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(input)
+    .digest('base64');
+  return base64UrlFromBase64(signature);
+};
+
+export type JwtPayload = Record<string, unknown> & {
+  /**
+   * Issued at, in seconds since epoch. Added automatically by `signJwt`.
+   */
+  iat?: number;
+  /**
+   * Expiration time, in seconds since epoch. Added automatically by `signJwt`
+   * when `expiresInSeconds` is provided.
+   */
+  exp?: number;
+};
+
+/**
+ * Signs a JWT with HMAC-SHA256 (HS256).
+ *
+ * For Amazon Cognito tokens, use `@ttoss/auth-core/amazon-cognito` instead —
+ * this helper is meant for self-hosted authentication where the application
+ * owns the signing secret.
+ */
+export const signJwt = (args: {
+  payload: JwtPayload;
+  secret: string;
+  /**
+   * Token lifetime in seconds, e.g. `60 * 60 * 24 * 7` for 7 days. When
+   * omitted, the token never expires.
+   */
+  expiresInSeconds?: number;
+}): string => {
+  const { payload, secret, expiresInSeconds } = args;
+
+  const iat = Math.floor(Date.now() / 1000);
+
+  const fullPayload: JwtPayload = {
+    ...payload,
+    iat,
+    ...(expiresInSeconds !== undefined && { exp: iat + expiresInSeconds }),
+  };
+
+  const header = base64UrlEncode({ alg: ALGORITHM, typ: 'JWT' });
+  const body = base64UrlEncode(fullPayload);
+  const signature = sign(`${header}.${body}`, secret);
+
+  return `${header}.${body}.${signature}`;
+};
+
+/**
+ * Verifies an HS256 JWT signature and expiration.
+ *
+ * Returns the payload when the token is valid, or `null` when the token is
+ * malformed, has an invalid signature, or is expired.
+ */
+export const verifyJwt = (args: {
+  token: string;
+  secret: string;
+}): JwtPayload | null => {
+  const { token, secret } = args;
+
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+  const [header, body, signature] = parts;
+
+  try {
+    const decodedHeader = base64UrlDecode(header) as { alg?: string };
+    if (decodedHeader.alg !== ALGORITHM) {
+      return null;
+    }
+
+    const expectedSignature = sign(`${header}.${body}`, secret);
+    const a = Buffer.from(signature);
+    const b = Buffer.from(expectedSignature);
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+      return null;
+    }
+
+    const payload = base64UrlDecode(body) as JwtPayload;
+
+    if (payload.exp !== undefined && payload.exp <= Date.now() / 1000) {
+      return null;
+    }
+
+    return payload;
+  } catch {
+    return null;
+  }
+};

--- a/packages/auth-core/src/oneTimeToken.ts
+++ b/packages/auth-core/src/oneTimeToken.ts
@@ -1,0 +1,70 @@
+import crypto from 'node:crypto';
+
+/**
+ * Primitives for single-use, expiring tokens — the building block for magic
+ * links, email verification, and password reset flows.
+ *
+ * The application stores only the token hash (never the plain token) together
+ * with the identifier and expiration date, and destroys the record after a
+ * successful verification.
+ */
+
+export type OneTimeToken = {
+  /**
+   * The plain token to deliver to the user (e.g., in a link sent by email).
+   * Never store it — store `tokenHash` instead.
+   */
+  token: string;
+  /**
+   * SHA-256 hash of the token, safe to persist.
+   */
+  tokenHash: string;
+  expires: Date;
+};
+
+export const hashOneTimeToken = (token: string): string => {
+  return crypto.createHash('sha256').update(token).digest('hex');
+};
+
+export const generateOneTimeToken = (args?: {
+  /**
+   * Number of random bytes. The token is the hex encoding, so the string
+   * length is twice this value. Defaults to 32.
+   */
+  bytes?: number;
+  /**
+   * Token lifetime in seconds. Defaults to 24 hours.
+   */
+  expiresInSeconds?: number;
+}): OneTimeToken => {
+  const bytes = args?.bytes ?? 32;
+  const expiresInSeconds = args?.expiresInSeconds ?? 60 * 60 * 24;
+
+  const token = crypto.randomBytes(bytes).toString('hex');
+
+  return {
+    token,
+    tokenHash: hashOneTimeToken(token),
+    expires: new Date(Date.now() + expiresInSeconds * 1000),
+  };
+};
+
+/**
+ * Constant-time check of a plain token against a stored hash, also validating
+ * the expiration date.
+ */
+export const verifyOneTimeToken = (args: {
+  token: string;
+  tokenHash: string;
+  expires: Date;
+}): boolean => {
+  if (args.expires.getTime() <= Date.now()) {
+    return false;
+  }
+  const a = Buffer.from(hashOneTimeToken(args.token), 'hex');
+  const b = Buffer.from(args.tokenHash, 'hex');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+};

--- a/packages/auth-core/src/webhookSignature.ts
+++ b/packages/auth-core/src/webhookSignature.ts
@@ -1,0 +1,59 @@
+import crypto from 'node:crypto';
+
+/**
+ * HMAC-SHA256 webhook payload signing, following the common
+ * `sha256=<hex>` signature header convention (e.g., GitHub's
+ * `X-Hub-Signature-256`).
+ *
+ * The sender signs the serialized payload with a per-endpoint secret and
+ * sends the signature in a header; the receiver recomputes it and compares
+ * in constant time.
+ */
+
+const SIGNATURE_PREFIX = 'sha256=';
+
+/**
+ * Generates a random secret for a webhook endpoint, hex encoded.
+ */
+export const generateWebhookSecret = (): string => {
+  return crypto.randomBytes(32).toString('hex');
+};
+
+/**
+ * Signs a serialized payload, returning a `sha256=<hex>` signature to send
+ * in a header alongside the request.
+ */
+export const signWebhookPayload = (args: {
+  payload: string;
+  secret: string;
+}): string => {
+  const hex = crypto
+    .createHmac('sha256', args.secret)
+    .update(args.payload)
+    .digest('hex');
+  return `${SIGNATURE_PREFIX}${hex}`;
+};
+
+/**
+ * Constant-time verification of a received webhook signature. Accepts the
+ * signature with or without the `sha256=` prefix.
+ */
+export const verifyWebhookSignature = (args: {
+  payload: string;
+  secret: string;
+  signature: string;
+}): boolean => {
+  const expected = signWebhookPayload({
+    payload: args.payload,
+    secret: args.secret,
+  });
+  const received = args.signature.startsWith(SIGNATURE_PREFIX)
+    ? args.signature
+    : `${SIGNATURE_PREFIX}${args.signature}`;
+  const a = Buffer.from(received);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+};

--- a/packages/auth-core/tests/unit/tests/apiToken.test.ts
+++ b/packages/auth-core/tests/unit/tests/apiToken.test.ts
@@ -1,0 +1,41 @@
+import { generateApiToken, hashApiToken, verifyApiToken } from 'src/apiToken';
+
+test('it should generate a prefixed token with hash and display prefix', () => {
+  const { token, tokenHash, displayPrefix } = generateApiToken({
+    prefix: 'myapp',
+  });
+
+  expect(token.startsWith('myapp_')).toBe(true);
+  expect(token).toHaveLength('myapp_'.length + 64);
+  expect(tokenHash).toBe(hashApiToken(token));
+  expect(displayPrefix).toBe(token.slice(0, 12));
+});
+
+test('it should verify a valid token', () => {
+  const { token, tokenHash } = generateApiToken({ prefix: 'myapp' });
+  expect(verifyApiToken({ token, tokenHash })).toBe(true);
+});
+
+test('it should reject a wrong token', () => {
+  const { tokenHash } = generateApiToken({ prefix: 'myapp' });
+  const { token: otherToken } = generateApiToken({ prefix: 'myapp' });
+  expect(verifyApiToken({ token: otherToken, tokenHash })).toBe(false);
+});
+
+test('it should respect expiresAt', () => {
+  const { token, tokenHash } = generateApiToken({ prefix: 'myapp' });
+
+  expect(
+    verifyApiToken({ token, tokenHash, expiresAt: new Date(Date.now() - 1) })
+  ).toBe(false);
+
+  expect(
+    verifyApiToken({
+      token,
+      tokenHash,
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+  ).toBe(true);
+
+  expect(verifyApiToken({ token, tokenHash, expiresAt: null })).toBe(true);
+});

--- a/packages/auth-core/tests/unit/tests/encryption.test.ts
+++ b/packages/auth-core/tests/unit/tests/encryption.test.ts
@@ -1,0 +1,45 @@
+import {
+  decryptValue,
+  encryptValue,
+  generateEncryptionKey,
+} from 'src/encryption';
+
+test('it should encrypt and decrypt a value', () => {
+  const key = generateEncryptionKey();
+  const ciphertext = encryptValue({ plaintext: 'my secret value', key });
+
+  expect(ciphertext).not.toContain('my secret value');
+  expect(decryptValue({ ciphertext, key })).toBe('my secret value');
+});
+
+test('it should produce different ciphertexts for the same plaintext', () => {
+  const key = generateEncryptionKey();
+  const a = encryptValue({ plaintext: 'same', key });
+  const b = encryptValue({ plaintext: 'same', key });
+  expect(a).not.toBe(b);
+});
+
+test('it should throw when decrypting with a wrong key', () => {
+  const ciphertext = encryptValue({
+    plaintext: 'value',
+    key: generateEncryptionKey(),
+  });
+  expect(() => {
+    return decryptValue({ ciphertext, key: generateEncryptionKey() });
+  }).toThrow();
+});
+
+test('it should throw when the ciphertext is tampered with', () => {
+  const key = generateEncryptionKey();
+  const buf = Buffer.from(encryptValue({ plaintext: 'value', key }), 'base64');
+  buf[buf.length - 1] ^= 0xff;
+  expect(() => {
+    return decryptValue({ ciphertext: buf.toString('base64'), key });
+  }).toThrow();
+});
+
+test('it should reject invalid keys', () => {
+  expect(() => {
+    return encryptValue({ plaintext: 'value', key: 'too-short' });
+  }).toThrow('Encryption key must be a 64-character hex string (32 bytes)');
+});

--- a/packages/auth-core/tests/unit/tests/hash.test.ts
+++ b/packages/auth-core/tests/unit/tests/hash.test.ts
@@ -1,16 +1,18 @@
-import { comparePassword, hashPassword } from 'src/hash';
+import { comparePassword, hashPassword, needsRehash } from 'src/hash';
 
 test('it should hash and compare password', async () => {
   const plainPassword = 'password12345678';
-  const hash = await hashPassword(plainPassword);
+  // Lower iterations to keep the test fast.
+  const hash = await hashPassword(plainPassword, { iterations: 1000 });
   const isMatch = await comparePassword(plainPassword, hash);
   expect(isMatch).toBe(true);
   expect(hash).not.toBe(plainPassword);
+  expect(hash.startsWith('pbkdf2-sha256$1000$')).toBe(true);
 });
 
 test('it should not match different passwords', async () => {
   const plainPassword = 'password123';
-  const hash = await hashPassword(plainPassword);
+  const hash = await hashPassword(plainPassword, { iterations: 1000 });
   const isMatch = await comparePassword('wrongPassword', hash);
   expect(isMatch).toBe(false);
 });
@@ -21,4 +23,23 @@ test('should match known hash', async () => {
   const plainPassword = 'password12345678';
   const isMatch = await comparePassword(plainPassword, knownHash);
   expect(isMatch).toBe(true);
+});
+
+test('it should reject malformed stored hashes', async () => {
+  expect(await comparePassword('password', 'not-a-valid-hash')).toBe(false);
+  expect(await comparePassword('password', 'pbkdf2-sha256$abc$x$y')).toBe(
+    false
+  );
+});
+
+test('needsRehash should flag legacy and low-iteration hashes', async () => {
+  const legacyHash =
+    'b8296cd24c275e87525626c90eceeab7:2b1ababeac3e34cc5f9bdb97d17007cfb783ce12fbd0148875ddcdeffd74d88b2dd167050e8f528683e0d73ea63e16ea90a1155503ea5956de7769b2c5d223fa';
+  expect(needsRehash(legacyHash)).toBe(true);
+
+  const lowIterations = await hashPassword('password', { iterations: 1000 });
+  expect(needsRehash(lowIterations)).toBe(true);
+
+  const current = await hashPassword('password');
+  expect(needsRehash(current)).toBe(false);
 });

--- a/packages/auth-core/tests/unit/tests/jwt.test.ts
+++ b/packages/auth-core/tests/unit/tests/jwt.test.ts
@@ -1,0 +1,59 @@
+import { signJwt, verifyJwt } from 'src/jwt';
+
+const secret = 'test-secret';
+
+test('it should sign and verify a token', () => {
+  const token = signJwt({
+    payload: { sub: 'user_123', email: 'user@example.com' },
+    secret,
+    expiresInSeconds: 60,
+  });
+
+  expect(token.split('.')).toHaveLength(3);
+
+  const payload = verifyJwt({ token, secret });
+
+  expect(payload).toMatchObject({
+    sub: 'user_123',
+    email: 'user@example.com',
+  });
+  expect(typeof payload?.iat).toBe('number');
+  expect(typeof payload?.exp).toBe('number');
+});
+
+test('it should reject a token signed with another secret', () => {
+  const token = signJwt({ payload: { sub: 'user_123' }, secret });
+  expect(verifyJwt({ token, secret: 'other-secret' })).toBeNull();
+});
+
+test('it should reject a tampered payload', () => {
+  const token = signJwt({ payload: { sub: 'user_123' }, secret });
+  const [header, , signature] = token.split('.');
+  const tamperedBody = Buffer.from(JSON.stringify({ sub: 'user_456' }))
+    .toString('base64')
+    .replace(/=+$/, '');
+  const tampered = `${header}.${tamperedBody}.${signature}`;
+  expect(verifyJwt({ token: tampered, secret })).toBeNull();
+});
+
+test('it should reject an expired token', () => {
+  const token = signJwt({
+    payload: { sub: 'user_123' },
+    secret,
+    expiresInSeconds: -1,
+  });
+  expect(verifyJwt({ token, secret })).toBeNull();
+});
+
+test('it should reject malformed tokens', () => {
+  expect(verifyJwt({ token: 'not-a-jwt', secret })).toBeNull();
+  expect(verifyJwt({ token: 'a.b', secret })).toBeNull();
+  expect(verifyJwt({ token: 'a.b.c', secret })).toBeNull();
+});
+
+test('it should not expire tokens without expiresInSeconds', () => {
+  const token = signJwt({ payload: { sub: 'user_123' }, secret });
+  const payload = verifyJwt({ token, secret });
+  expect(payload?.exp).toBeUndefined();
+  expect(payload?.sub).toBe('user_123');
+});

--- a/packages/auth-core/tests/unit/tests/oneTimeToken.test.ts
+++ b/packages/auth-core/tests/unit/tests/oneTimeToken.test.ts
@@ -1,0 +1,46 @@
+import {
+  generateOneTimeToken,
+  hashOneTimeToken,
+  verifyOneTimeToken,
+} from 'src/oneTimeToken';
+
+test('it should generate and verify a token', () => {
+  const { token, tokenHash, expires } = generateOneTimeToken();
+
+  expect(token).toHaveLength(64);
+  expect(tokenHash).toBe(hashOneTimeToken(token));
+  expect(expires.getTime()).toBeGreaterThan(Date.now());
+
+  expect(verifyOneTimeToken({ token, tokenHash, expires })).toBe(true);
+});
+
+test('it should reject a wrong token', () => {
+  const { tokenHash, expires } = generateOneTimeToken();
+  const { token: otherToken } = generateOneTimeToken();
+
+  expect(verifyOneTimeToken({ token: otherToken, tokenHash, expires })).toBe(
+    false
+  );
+});
+
+test('it should reject an expired token', () => {
+  const { token, tokenHash } = generateOneTimeToken();
+
+  expect(
+    verifyOneTimeToken({
+      token,
+      tokenHash,
+      expires: new Date(Date.now() - 1000),
+    })
+  ).toBe(false);
+});
+
+test('it should respect bytes and expiresInSeconds options', () => {
+  const { token, expires } = generateOneTimeToken({
+    bytes: 16,
+    expiresInSeconds: 60,
+  });
+
+  expect(token).toHaveLength(32);
+  expect(expires.getTime()).toBeLessThanOrEqual(Date.now() + 61 * 1000);
+});

--- a/packages/auth-core/tests/unit/tests/webhookSignature.test.ts
+++ b/packages/auth-core/tests/unit/tests/webhookSignature.test.ts
@@ -1,0 +1,52 @@
+import {
+  generateWebhookSecret,
+  signWebhookPayload,
+  verifyWebhookSignature,
+} from 'src/webhookSignature';
+
+const payload = JSON.stringify({ event: 'user.created', id: 'user_123' });
+
+test('it should sign and verify a payload', () => {
+  const secret = generateWebhookSecret();
+  const signature = signWebhookPayload({ payload, secret });
+
+  expect(signature.startsWith('sha256=')).toBe(true);
+  expect(verifyWebhookSignature({ payload, secret, signature })).toBe(true);
+});
+
+test('it should accept a signature without the sha256= prefix', () => {
+  const secret = generateWebhookSecret();
+  const signature = signWebhookPayload({ payload, secret }).slice(
+    'sha256='.length
+  );
+  expect(verifyWebhookSignature({ payload, secret, signature })).toBe(true);
+});
+
+test('it should reject a signature from another secret', () => {
+  const signature = signWebhookPayload({
+    payload,
+    secret: generateWebhookSecret(),
+  });
+  expect(
+    verifyWebhookSignature({
+      payload,
+      secret: generateWebhookSecret(),
+      signature,
+    })
+  ).toBe(false);
+});
+
+test('it should reject a tampered payload', () => {
+  const secret = generateWebhookSecret();
+  const signature = signWebhookPayload({ payload, secret });
+  expect(
+    verifyWebhookSignature({ payload: `${payload} `, secret, signature })
+  ).toBe(false);
+});
+
+test('it should reject malformed signatures', () => {
+  const secret = generateWebhookSecret();
+  expect(
+    verifyWebhookSignature({ payload, secret, signature: 'sha256=abc' })
+  ).toBe(false);
+});


### PR DESCRIPTION
## Summary

- `hashPassword` now uses 600k PBKDF2 iterations (OWASP) with a versioned, self-describing hash format (`pbkdf2-sha256$<iterations>$<salt>$<hash>`); the legacy `salt:hash` format still verifies
- `comparePassword` uses constant-time comparison and validates malformed input
- New `needsRehash` helper to upgrade weak hashes on login
- New `signJwt`/`verifyJwt` (HS256, `node:crypto` only) for self-hosted auth
- New one-time token primitives for magic links, email verification, and password reset flows
- New API token primitives (prefixed tokens, SHA-256 storage hash, display prefix, expiration check)
- Expanded README with usage docs for all modules

## Test plan

- New unit tests for JWT, one-time tokens, and API tokens
- Extended hash tests covering the versioned format, malformed input, and `needsRehash`

https://claude.ai/code/session_015FgBHKsuS31jCvFqLhX4sx

---
_Generated by [Claude Code](https://claude.ai/code/session_015FgBHKsuS31jCvFqLhX4sx)_