### PR TITLE
fix(config): add .d.mts moduleNameMapper to jestUnitConfig

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,7 +28,7 @@
     "tsconfig.test.json"
   ],
   "scripts": {
-    "build-config": "tsdown --config-loader tsx",
+    "build-config": "tsdown --config-loader tsx && mkdir -p dist/__mocks__ && cp src/__mocks__/emptyModule.cjs dist/__mocks__/emptyModule.cjs",
     "test": "jest --projects tests/unit"
   },
   "dependencies": {

--- a/packages/config/src/__mocks__/emptyModule.cjs
+++ b/packages/config/src/__mocks__/emptyModule.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/config/src/jest.ts
+++ b/packages/config/src/jest.ts
@@ -25,6 +25,12 @@ export const defaultConfig: Config = {
   moduleDirectories: ['node_modules', '<rootDir>/../..'],
   moduleNameMapper: {
     /**
+     * Redirect .d.mts type declaration files to an empty module so Jest
+     * doesn't try to execute ESM import statements in type-only files
+     * accidentally bundled into dist output.
+     */
+    '\\.d\\.mts$': require.resolve('./__mocks__/emptyModule.cjs'),
+    /**
      * Remove CSS import errors:
      *
      * Jest failed to parse a file. This happens e.g. when your code or its


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `moduleNameMapper` entry in `jestUnitConfig` (and `defaultConfig`) that redirects any `*.d.mts` import to an empty CJS module
- Creates `packages/config/src/__mocks__/emptyModule.cjs` (`module.exports = {}`) as the redirect target
- Updates the `build-config` script to copy the mock file into `dist/__mocks__/` so it's available when the published package is consumed

## Test plan

- [ ] `pnpm run build-config` in `packages/config` completes without errors and `dist/__mocks__/emptyModule.cjs` exists
- [ ] `pnpm run test` in `packages/config` passes (19 tests green)
- [ ] Projects consuming `@ttoss/forms` or `@ttoss/react-dashboard` no longer crash Jest with `SyntaxError: Cannot use import statement outside a module` from `.d.mts` files

Closes #1036

https://claude.ai/code/session_015kFMGsEsuyvLMaDuw8Hxih
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015kFMGsEsuyvLMaDuw8Hxih)_