### PR TITLE
feat(@ttoss/http-server-auth): add authentication middleware package

### DIFF
--- a/packages/http-server-auth/README.md
+++ b/packages/http-server-auth/README.md
@@ -1,0 +1,121 @@
+# @ttoss/http-server-auth
+
+Authentication middleware for [`@ttoss/http-server`](../http-server) (Koa). Wraps [`@ttoss/auth-core`](../auth-core) primitives into a ready-to-use Bearer-token strategy chain.
+
+## Installation
+
+```bash
+pnpm add @ttoss/http-server-auth
+```
+
+## Usage
+
+### Global middleware
+
+```ts
+import { authMiddleware } from '@ttoss/http-server-auth';
+import { App } from '@ttoss/http-server';
+
+const app = new App();
+
+app.use(
+  authMiddleware({
+    strategies: ['jwt', 'apiToken', 'system'],
+
+    jwt: {
+      secret: process.env.JWT_SECRET,
+    },
+
+    apiToken: {
+      lookup: async (tokenHash) => {
+        const record = await ApiTokenModel.findOne({
+          where: { tokenHash, revoked: false },
+        });
+        if (!record) return null;
+        await record.update({ lastUsedAt: new Date() });
+        return { id: record.user.publicId, email: record.user.email };
+      },
+    },
+
+    system: {
+      secret: process.env.INTERNAL_API_SECRET,
+      user: { id: 'system', email: 'system@internal' },
+    },
+
+    allowedOrigins: [
+      process.env.APP_URL,
+      'http://localhost:3000',
+      /\.vercel\.app$/,
+    ],
+
+    required: true, // default
+  })
+);
+```
+
+### Per-route middleware
+
+```ts
+import { requireAuth } from '@ttoss/http-server-auth';
+import { Router } from '@ttoss/http-server';
+
+const router = new Router();
+
+router.get(
+  '/internal/revalidate',
+  requireAuth({
+    strategies: ['system'],
+    system: { secret: process.env.INTERNAL_API_SECRET, user: { id: 'system' } },
+  }),
+  handler
+);
+
+router.get(
+  '/me',
+  requireAuth({
+    strategies: ['jwt', 'apiToken'],
+    jwt: { secret: process.env.JWT_SECRET },
+    apiToken: { lookup },
+  }),
+  handler
+);
+```
+
+### Optional auth
+
+```ts
+app.use(
+  authMiddleware({
+    strategies: ['jwt'],
+    jwt: { secret: process.env.JWT_SECRET },
+    required: false, // unauthenticated requests pass through with ctx.state.user === undefined
+  })
+);
+```
+
+## Context types
+
+On successful authentication the middleware sets:
+
+```ts
+ctx.state.user; // AuthenticatedUser
+ctx.state.authStrategy; // 'jwt' | 'apiToken' | 'system'
+```
+
+```ts
+type AuthenticatedUser = {
+  id: string;
+  email?: string;
+  [key: string]: unknown;
+};
+```
+
+## Behavior
+
+1. Reads `Authorization: Bearer <token>`; missing header → 401 if `required`.
+2. If `allowedOrigins` is configured and the `Origin` header doesn't match → 403. Requests without an Origin header are never rejected.
+3. Tries each strategy in `strategies` order; first match wins.
+   - `jwt` — verifies HS256 JWT via `@ttoss/auth-core verifyJwt`; maps `sub`/`email` to user (override with `jwt.mapPayload`).
+   - `apiToken` — hashes the token (SHA-256) and calls `apiToken.lookup(hash)`.
+   - `system` — constant-time comparison against `system.secret`.
+4. All strategies fail and `required` → 401. Failure reason is never leaked.

--- a/packages/http-server-auth/README.md
+++ b/packages/http-server-auth/README.md
@@ -1,6 +1,6 @@
 # @ttoss/http-server-auth
 
-Authentication middleware for [`@ttoss/http-server`](../http-server) (Koa). Wraps [`@ttoss/auth-core`](../auth-core) primitives into a ready-to-use Bearer-token strategy chain.
+Authentication middleware for `@ttoss/http-server` (Koa). Wraps `@ttoss/auth-core` primitives into a ready-to-use Bearer-token strategy chain.
 
 ## Installation
 

--- a/packages/http-server-auth/package.json
+++ b/packages/http-server-auth/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@ttoss/http-server-auth",
+  "version": "0.1.0",
+  "description": "Authentication middleware for @ttoss/http-server",
+  "keywords": [
+    "auth",
+    "authentication",
+    "koa",
+    "middleware",
+    "ttoss"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ttoss/ttoss.git",
+    "directory": "packages/http-server-auth"
+  },
+  "license": "MIT",
+  "author": "ttoss",
+  "contributors": [
+    "Pedro Arantes <pedro@arantespp.com> (https://arantespp.com)"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "jest --projects tests/unit"
+  },
+  "dependencies": {
+    "@ttoss/auth-core": "workspace:^"
+  },
+  "devDependencies": {
+    "@ttoss/config": "workspace:^",
+    "@ttoss/http-server": "workspace:^",
+    "@types/koa": "^3.0.3",
+    "jest": "^30.4.2",
+    "supertest": "^7.2.2",
+    "tsdown": "^0.22.2"
+  },
+  "peerDependencies": {
+    "@ttoss/http-server": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "types": "./dist/index.d.mts"
+      }
+    },
+    "provenance": true
+  }
+}

--- a/packages/http-server-auth/src/authMiddleware.ts
+++ b/packages/http-server-auth/src/authMiddleware.ts
@@ -1,0 +1,101 @@
+import crypto from 'node:crypto';
+
+import { hashApiToken, verifyJwt } from '@ttoss/auth-core';
+import type { Context, Next } from 'koa';
+
+import { isOriginAllowed } from './origin';
+import type {
+  ApiTokenOptions,
+  AuthenticatedUser,
+  AuthMiddlewareOptions,
+  JwtOptions,
+  SystemOptions,
+} from './types';
+
+const tryJwt = (token: string, opts: JwtOptions): AuthenticatedUser | null => {
+  const payload = verifyJwt({ token, secret: opts.secret });
+  if (!payload) return null;
+  if (opts.mapPayload)
+    return opts.mapPayload(payload as Record<string, unknown>);
+  return {
+    id: String(payload.sub ?? ''),
+    ...(payload.email !== undefined && { email: String(payload.email) }),
+  } as AuthenticatedUser;
+};
+
+const tryApiToken = async (
+  token: string,
+  opts: ApiTokenOptions
+): Promise<AuthenticatedUser | null> => {
+  return opts.lookup(hashApiToken(token));
+};
+
+const trySystem = (
+  token: string,
+  opts: SystemOptions
+): AuthenticatedUser | null => {
+  const a = Buffer.from(token);
+  const b = Buffer.from(opts.secret);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+  return opts.user;
+};
+
+const resolveUser = async (
+  token: string,
+  options: AuthMiddlewareOptions
+): Promise<{ user: AuthenticatedUser; strategy: string } | null> => {
+  for (const strategy of options.strategies) {
+    let user: AuthenticatedUser | null = null;
+
+    if (strategy === 'jwt' && options.jwt) {
+      user = tryJwt(token, options.jwt);
+    } else if (strategy === 'apiToken' && options.apiToken) {
+      user = await tryApiToken(token, options.apiToken);
+    } else if (strategy === 'system' && options.system) {
+      user = trySystem(token, options.system);
+    }
+
+    if (user) return { user, strategy };
+  }
+  return null;
+};
+
+/**
+ * Koa middleware that authenticates requests via Bearer token.
+ * Supports JWT, hashed API tokens, and a shared system secret.
+ * Sets `ctx.state.user` and `ctx.state.authStrategy` on success.
+ */
+export const authMiddleware = (options: AuthMiddlewareOptions) => {
+  const required = options.required ?? true;
+
+  return async (ctx: Context, next: Next): Promise<void> => {
+    if (options.allowedOrigins) {
+      const origin = ctx.get('Origin');
+      if (origin && !isOriginAllowed(origin, options.allowedOrigins)) {
+        ctx.throw(403, 'Invalid origin');
+      }
+    }
+
+    const authHeader = ctx.get('Authorization');
+    const token =
+      authHeader && authHeader.startsWith('Bearer ')
+        ? authHeader.slice(7)
+        : null;
+
+    if (!token) {
+      if (required) ctx.throw(401, 'Unauthorized');
+      return next();
+    }
+
+    const result = await resolveUser(token, options);
+
+    if (!result) {
+      if (required) ctx.throw(401, 'Unauthorized');
+      return next();
+    }
+
+    ctx.state.user = result.user;
+    ctx.state.authStrategy = result.strategy;
+    return next();
+  };
+};

--- a/packages/http-server-auth/src/authMiddleware.ts
+++ b/packages/http-server-auth/src/authMiddleware.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 
 import { hashApiToken, verifyJwt } from '@ttoss/auth-core';
-import type { Context, Next } from 'koa';
+import type { Context, Next } from '@ttoss/http-server';
 
 import { isOriginAllowed } from './origin';
 import type {

--- a/packages/http-server-auth/src/index.ts
+++ b/packages/http-server-auth/src/index.ts
@@ -1,0 +1,11 @@
+export { authMiddleware } from './authMiddleware';
+export { isOriginAllowed } from './origin';
+export { requireAuth } from './requireAuth';
+export type {
+  ApiTokenOptions,
+  AuthenticatedUser,
+  AuthMiddlewareOptions,
+  AuthStrategy,
+  JwtOptions,
+  SystemOptions,
+} from './types';

--- a/packages/http-server-auth/src/origin.ts
+++ b/packages/http-server-auth/src/origin.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns true if origin matches any entry in the allowlist.
+ * Strings are compared exactly; RegExps are tested.
+ */
+export const isOriginAllowed = (
+  origin: string,
+  allowedOrigins: Array<string | RegExp | undefined>
+): boolean => {
+  for (const entry of allowedOrigins) {
+    if (entry === undefined) continue;
+    if (typeof entry === 'string') {
+      if (entry === origin) return true;
+    } else {
+      if (entry.test(origin)) return true;
+    }
+  }
+  return false;
+};

--- a/packages/http-server-auth/src/requireAuth.ts
+++ b/packages/http-server-auth/src/requireAuth.ts
@@ -1,4 +1,4 @@
-import type { Context, Next } from 'koa';
+import type { Context, Next } from '@ttoss/http-server';
 
 import { authMiddleware } from './authMiddleware';
 import type { AuthMiddlewareOptions } from './types';

--- a/packages/http-server-auth/src/requireAuth.ts
+++ b/packages/http-server-auth/src/requireAuth.ts
@@ -1,0 +1,17 @@
+import type { Context, Next } from 'koa';
+
+import { authMiddleware } from './authMiddleware';
+import type { AuthMiddlewareOptions } from './types';
+
+/**
+ * Route-level authentication middleware. Same options as `authMiddleware`,
+ * `required` defaults to true.
+ *
+ * @example
+ * router.get('/me', requireAuth({ strategies: ['jwt', 'apiToken'] }), handler);
+ */
+export const requireAuth = (
+  options: AuthMiddlewareOptions
+): ((ctx: Context, next: Next) => Promise<void>) => {
+  return authMiddleware({ required: true, ...options });
+};

--- a/packages/http-server-auth/src/types.ts
+++ b/packages/http-server-auth/src/types.ts
@@ -1,0 +1,48 @@
+export type AuthenticatedUser = {
+  id: string;
+  email?: string;
+  [key: string]: unknown;
+};
+
+export type AuthStrategy = 'jwt' | 'apiToken' | 'system';
+
+export type JwtOptions = {
+  secret: string;
+  /**
+   * Override how the JWT payload maps to an AuthenticatedUser.
+   * Defaults to `{ id: payload.sub, email: payload.email }`.
+   */
+  mapPayload?: (payload: Record<string, unknown>) => AuthenticatedUser | null;
+};
+
+export type ApiTokenOptions = {
+  /**
+   * Receives the SHA-256 hash of the presented token and returns the
+   * authenticated user, or null if not found / revoked.
+   */
+  lookup: (tokenHash: string) => Promise<AuthenticatedUser | null>;
+};
+
+export type SystemOptions = {
+  secret: string;
+  /** User attached to ctx.state.user for system calls. */
+  user: AuthenticatedUser;
+};
+
+export type AuthMiddlewareOptions = {
+  /** Ordered list of strategies to attempt. First match wins. */
+  strategies: AuthStrategy[];
+  jwt?: JwtOptions;
+  apiToken?: ApiTokenOptions;
+  system?: SystemOptions;
+  /**
+   * Optional origin allowlist. Strings are exact-matched; RegExps are tested.
+   * Requests without an Origin header are never rejected by this check.
+   */
+  allowedOrigins?: Array<string | RegExp | undefined>;
+  /**
+   * When true (default), unauthenticated requests receive 401.
+   * When false, they pass through with ctx.state.user === undefined.
+   */
+  required?: boolean;
+};

--- a/packages/http-server-auth/tests/unit/babel.config.cjs
+++ b/packages/http-server-auth/tests/unit/babel.config.cjs
@@ -1,0 +1,3 @@
+const { babelConfig } = require('@ttoss/config');
+
+module.exports = babelConfig();

--- a/packages/http-server-auth/tests/unit/jest.config.ts
+++ b/packages/http-server-auth/tests/unit/jest.config.ts
@@ -1,0 +1,12 @@
+import { jestUnitConfig } from '@ttoss/config';
+
+export default jestUnitConfig({
+  coverageThreshold: {
+    global: {
+      branches: 95,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/http-server-auth/tests/unit/tests/authMiddleware.test.ts
+++ b/packages/http-server-auth/tests/unit/tests/authMiddleware.test.ts
@@ -1,0 +1,252 @@
+import { hashApiToken, signJwt } from '@ttoss/auth-core';
+import { App } from '@ttoss/http-server';
+import { authMiddleware } from 'src/authMiddleware';
+import type { AuthenticatedUser } from 'src/types';
+import request from 'supertest';
+
+const jwtSecret = 'test-jwt-secret';
+const systemSecret = 'test-system-secret';
+const systemUser: AuthenticatedUser = {
+  id: 'system',
+  email: 'system@internal',
+};
+
+const makeApp = (opts: Parameters<typeof authMiddleware>[0]) => {
+  const app = new App();
+  app.use(authMiddleware(opts));
+  app.use((ctx) => {
+    ctx.body = { user: ctx.state.user, strategy: ctx.state.authStrategy };
+  });
+  return app;
+};
+
+// JWT strategy
+describe('jwt strategy', () => {
+  const app = makeApp({ strategies: ['jwt'], jwt: { secret: jwtSecret } });
+
+  test('authenticates a valid JWT', async () => {
+    const token = signJwt({
+      payload: { sub: 'user_1', email: 'user@example.com' },
+      secret: jwtSecret,
+    });
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({
+      id: 'user_1',
+      email: 'user@example.com',
+    });
+    expect(res.body.strategy).toBe('jwt');
+  });
+
+  test('rejects an invalid JWT', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer invalid.token.here');
+    expect(res.status).toBe(401);
+  });
+
+  test('rejects a JWT signed with wrong secret', async () => {
+    const token = signJwt({
+      payload: { sub: 'user_1' },
+      secret: 'wrong-secret',
+    });
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  test('uses custom mapPayload when provided', async () => {
+    const appCustomMap = makeApp({
+      strategies: ['jwt'],
+      jwt: {
+        secret: jwtSecret,
+        mapPayload: (p) => {
+          return { id: `mapped_${p.sub}` };
+        },
+      },
+    });
+    const token = signJwt({ payload: { sub: 'user_1' }, secret: jwtSecret });
+    const res = await request(appCustomMap.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.body.user.id).toBe('mapped_user_1');
+  });
+});
+
+// apiToken strategy
+describe('apiToken strategy', () => {
+  const storedHash = hashApiToken('my-api-token');
+  const lookup = jest.fn(async (tokenHash: string) => {
+    if (tokenHash === storedHash)
+      return { id: 'user_2', email: 'api@example.com' };
+    return null;
+  });
+  const app = makeApp({ strategies: ['apiToken'], apiToken: { lookup } });
+
+  beforeEach(() => {
+    return lookup.mockClear();
+  });
+
+  test('authenticates a valid API token', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer my-api-token');
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({ id: 'user_2' });
+    expect(res.body.strategy).toBe('apiToken');
+  });
+
+  test('rejects an unknown API token', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer unknown-token');
+    expect(res.status).toBe(401);
+  });
+
+  test('calls lookup with SHA-256 hash of the token', async () => {
+    await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer my-api-token');
+    expect(lookup).toHaveBeenCalledWith(storedHash);
+  });
+});
+
+// system strategy
+describe('system strategy', () => {
+  const app = makeApp({
+    strategies: ['system'],
+    system: { secret: systemSecret, user: systemUser },
+  });
+
+  test('authenticates with the correct system secret', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${systemSecret}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject(systemUser);
+    expect(res.body.strategy).toBe('system');
+  });
+
+  test('rejects a wrong system secret', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer wrong-system-secret');
+    expect(res.status).toBe(401);
+  });
+});
+
+// strategy ordering
+describe('strategy ordering', () => {
+  test('first matching strategy wins', async () => {
+    const lookup = jest.fn(async () => {
+      return { id: 'api_user' };
+    });
+    const app = makeApp({
+      strategies: ['jwt', 'apiToken'],
+      jwt: { secret: jwtSecret },
+      apiToken: { lookup },
+    });
+    const token = signJwt({ payload: { sub: 'jwt_user' }, secret: jwtSecret });
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.body.strategy).toBe('jwt');
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});
+
+// required: false
+describe('optional auth (required: false)', () => {
+  const app = makeApp({
+    strategies: ['jwt'],
+    jwt: { secret: jwtSecret },
+    required: false,
+  });
+
+  test('passes through without Authorization header', async () => {
+    const res = await request(app.callback()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.user).toBeUndefined();
+  });
+
+  test('passes through with an invalid token', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer bad.token');
+    expect(res.status).toBe(200);
+    expect(res.body.user).toBeUndefined();
+  });
+
+  test('still authenticates a valid token', async () => {
+    const token = signJwt({ payload: { sub: 'user_1' }, secret: jwtSecret });
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user).toMatchObject({ id: 'user_1' });
+  });
+});
+
+// missing / malformed Authorization header
+describe('missing or malformed Authorization header', () => {
+  const app = makeApp({ strategies: ['jwt'], jwt: { secret: jwtSecret } });
+
+  test('returns 401 when Authorization header is absent', async () => {
+    const res = await request(app.callback()).get('/');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns 401 for non-Bearer scheme', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Basic dXNlcjpwYXNz');
+    expect(res.status).toBe(401);
+  });
+
+  test('401 response body does not reveal which strategy failed', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Authorization', 'Bearer bad.token');
+    expect(res.status).toBe(401);
+    expect(res.text).not.toMatch(/jwt|api|strategy/i);
+  });
+});
+
+// origin allowlist
+describe('allowedOrigins', () => {
+  const app = makeApp({
+    strategies: ['jwt'],
+    jwt: { secret: jwtSecret },
+    required: false,
+    allowedOrigins: ['http://localhost:3000', /\.vercel\.app$/],
+  });
+
+  test('allows matching string origin', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Origin', 'http://localhost:3000');
+    expect(res.status).toBe(200);
+  });
+
+  test('allows matching RegExp origin', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Origin', 'https://preview.vercel.app');
+    expect(res.status).toBe(200);
+  });
+
+  test('rejects non-matching origin', async () => {
+    const res = await request(app.callback())
+      .get('/')
+      .set('Origin', 'http://evil.com');
+    expect(res.status).toBe(403);
+  });
+
+  test('allows requests without Origin header', async () => {
+    const res = await request(app.callback()).get('/');
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/http-server-auth/tests/unit/tests/origin.test.ts
+++ b/packages/http-server-auth/tests/unit/tests/origin.test.ts
@@ -1,0 +1,45 @@
+import { isOriginAllowed } from 'src/origin';
+
+test('matches exact string', () => {
+  expect(
+    isOriginAllowed('http://localhost:3000', ['http://localhost:3000'])
+  ).toBe(true);
+});
+
+test('rejects non-matching string', () => {
+  expect(isOriginAllowed('http://evil.com', ['http://localhost:3000'])).toBe(
+    false
+  );
+});
+
+test('matches RegExp', () => {
+  expect(
+    isOriginAllowed('https://preview.vercel.app', [/\.vercel\.app$/])
+  ).toBe(true);
+});
+
+test('rejects non-matching RegExp', () => {
+  expect(isOriginAllowed('https://evil.com', [/\.vercel\.app$/])).toBe(false);
+});
+
+test('skips undefined entries', () => {
+  expect(
+    isOriginAllowed('http://localhost:3000', [
+      undefined,
+      'http://localhost:3000',
+    ])
+  ).toBe(true);
+});
+
+test('returns false for empty allowlist', () => {
+  expect(isOriginAllowed('http://localhost:3000', [])).toBe(false);
+});
+
+test('matches first of multiple entries', () => {
+  expect(
+    isOriginAllowed('http://localhost:3000', [
+      'http://other.com',
+      'http://localhost:3000',
+    ])
+  ).toBe(true);
+});

--- a/packages/http-server-auth/tests/unit/tests/requireAuth.test.ts
+++ b/packages/http-server-auth/tests/unit/tests/requireAuth.test.ts
@@ -1,0 +1,70 @@
+import { signJwt } from '@ttoss/auth-core';
+import { App, Router } from '@ttoss/http-server';
+import { requireAuth } from 'src/requireAuth';
+import request from 'supertest';
+
+const jwtSecret = 'require-auth-secret';
+const systemSecret = 'system-secret';
+
+const makeApp = () => {
+  const app = new App();
+  const router = new Router();
+
+  router.get(
+    '/me',
+    requireAuth({ strategies: ['jwt'], jwt: { secret: jwtSecret } }),
+    (ctx) => {
+      ctx.body = { user: ctx.state.user, strategy: ctx.state.authStrategy };
+    }
+  );
+
+  router.get(
+    '/internal',
+    requireAuth({
+      strategies: ['system'],
+      system: { secret: systemSecret, user: { id: 'system' } },
+    }),
+    (ctx) => {
+      ctx.body = { user: ctx.state.user, strategy: ctx.state.authStrategy };
+    }
+  );
+
+  app.use(router.routes());
+  app.use(router.allowedMethods());
+  return app;
+};
+
+test('requireAuth protects route — rejects unauthenticated', async () => {
+  const app = makeApp();
+  const res = await request(app.callback()).get('/me');
+  expect(res.status).toBe(401);
+});
+
+test('requireAuth allows authenticated JWT request', async () => {
+  const app = makeApp();
+  const token = signJwt({ payload: { sub: 'user_1' }, secret: jwtSecret });
+  const res = await request(app.callback())
+    .get('/me')
+    .set('Authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.user.id).toBe('user_1');
+  expect(res.body.strategy).toBe('jwt');
+});
+
+test('requireAuth allows system-token on /internal', async () => {
+  const app = makeApp();
+  const res = await request(app.callback())
+    .get('/internal')
+    .set('Authorization', `Bearer ${systemSecret}`);
+  expect(res.status).toBe(200);
+  expect(res.body.strategy).toBe('system');
+});
+
+test('requireAuth rejects wrong strategy on /internal', async () => {
+  const app = makeApp();
+  const token = signJwt({ payload: { sub: 'user_1' }, secret: jwtSecret });
+  const res = await request(app.callback())
+    .get('/internal')
+    .set('Authorization', `Bearer ${token}`);
+  expect(res.status).toBe(401);
+});

--- a/packages/http-server-auth/tsconfig.json
+++ b/packages/http-server-auth/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ttoss/config/tsconfig.json"
+}

--- a/packages/http-server-auth/tsdown.config.ts
+++ b/packages/http-server-auth/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { tsdownConfig } from '@ttoss/config';
+
+export default tsdownConfig({
+  entry: ['src/index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,7 +706,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -1208,6 +1208,31 @@ importers:
       '@types/koa__multer':
         specifier: ^2.0.8
         version: 2.0.8
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+
+  packages/http-server-auth:
+    dependencies:
+      '@ttoss/auth-core':
+        specifier: workspace:^
+        version: link:../auth-core
+    devDependencies:
+      '@ttoss/config':
+        specifier: workspace:^
+        version: link:../config
+      '@ttoss/http-server':
+        specifier: workspace:^
+        version: link:../http-server
+      '@types/koa':
+        specifier: ^3.0.3
+        version: 3.0.3
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
@@ -21802,7 +21827,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -21813,7 +21838,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -21821,11 +21846,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -21834,13 +21859,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -21848,7 +21873,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@ts-morph/common@0.29.0':
@@ -22392,7 +22417,7 @@ snapshots:
 
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 4.17.25
+      '@types/express': 5.0.6
 
   '@types/serve-static@1.15.10':
     dependencies:
@@ -31971,7 +31996,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- New package `@ttoss/http-server-auth` providing Bearer-token authentication middleware for `@ttoss/http-server`
- Implements three strategies: JWT (via `@ttoss/auth-core verifyJwt`), hashed API tokens (SHA-256 lookup), and system shared-secret (constant-time comparison)
- Includes `authMiddleware` (global) and `requireAuth` (route-level) helpers, origin allowlist enforcement, and optional auth mode

## Test plan

- [ ] 31 unit tests pass covering all exported functions: `authMiddleware`, `requireAuth`, `isOriginAllowed`
- [ ] Each strategy success and failure path tested independently
- [ ] Strategy ordering verified (first match wins)
- [ ] `required: false` passes through unauthenticated requests
- [ ] Origin allowlist: string exact match, RegExp, missing Origin header, rejection
- [ ] Missing/malformed Authorization header returns 401 without leaking strategy details
- [ ] Coverage thresholds: 100% statements/functions/lines, 95% branches

https://claude.ai/code/session_014fvJaJZBAY4p4sMw8iEK5U
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014fvJaJZBAY4p4sMw8iEK5U)_