### PR TITLE
feat(cloud-auth): support OAuth authorization server resources

### DIFF
--- a/packages/cloud-auth/README.md
+++ b/packages/cloud-auth/README.md
@@ -264,14 +264,91 @@ const template = createAuthTemplate({
 });
 ```
 
+### Hosted UI Domain
+
+Add a Cognito hosted UI so OAuth clients can redirect users to the login page. Use a Cognito prefix domain or bring your own custom domain with an ACM certificate:
+
+```typescript
+// Cognito prefix domain (e.g. https://my-app.auth.us-east-1.amazoncognito.com)
+const template = createAuthTemplate({
+  domain: { domainName: 'my-app' },
+});
+
+// Custom domain
+const template = createAuthTemplate({
+  domain: {
+    domainName: 'auth.example.com',
+    certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/abc',
+  },
+});
+```
+
+Output `CognitoUserPoolDomainUrl` is exported with the full URL.
+
+### Resource Servers and Custom Scopes
+
+Define resource servers with custom OAuth scopes to gate access to your APIs:
+
+```typescript
+const template = createAuthTemplate({
+  resourceServers: [
+    {
+      identifier: 'mcp',
+      name: 'MCP Server',
+      scopes: [
+        { scopeName: 'access', scopeDescription: 'Access the MCP server' },
+      ],
+    },
+  ],
+});
+```
+
+The scope `mcp/access` (format: `<identifier>/<scopeName>`) can then be required by your API.
+
+### Additional App Clients (OAuth / Confidential Clients)
+
+The default app client (`AppClientId`) is a public client used by Amplify and must not have a secret. Use `additionalAppClients` to create separate confidential OAuth clients — for example, a client for a remote MCP connector:
+
+```typescript
+const template = createAuthTemplate({
+  domain: { domainName: 'my-app' },
+  resourceServers: [
+    {
+      identifier: 'mcp',
+      name: 'MCP Server',
+      scopes: [
+        { scopeName: 'access', scopeDescription: 'Access the MCP server' },
+      ],
+    },
+  ],
+  additionalAppClients: [
+    {
+      name: 'mcp-client',
+      generateSecret: true,
+      oauth: {
+        flows: ['code'],
+        scopes: ['openid', 'mcp/access'],
+        callbackUrls: ['https://claude.ai/api/mcp/auth_callback'],
+      },
+    },
+  ],
+});
+```
+
+Each additional client gets its own `AppClientId<PascalName>` output (e.g. `AppClientIdMcpClient`).
+
 ## Template Outputs
 
 The template provides these CloudFormation outputs for integration:
 
-- **Region**: AWS region for Amplify Auth configuration
-- **UserPoolId**: Cognito User Pool ID
-- **AppClientId**: User Pool Client ID for applications
-- **IdentityPoolId**: Identity Pool ID (when enabled)
+| Output                     | Description                                                | Condition                           |
+| -------------------------- | ---------------------------------------------------------- | ----------------------------------- |
+| `Region`                   | AWS region for Amplify Auth `region`                       | Always                              |
+| `UserPoolId`               | Cognito User Pool ID                                       | Always                              |
+| `AppClientId`              | Default public client ID for Amplify `userPoolWebClientId` | Always                              |
+| `IdentityPoolId`           | Identity Pool ID                                           | When `identityPool.enabled`         |
+| `CognitoUserPoolDomainUrl` | Hosted UI domain URL                                       | When `domain` is set                |
+| `AppClientId<PascalName>`  | Additional app client IDs                                  | Per entry in `additionalAppClients` |
 
 Access outputs in other CloudFormation templates:
 
@@ -279,6 +356,7 @@ Access outputs in other CloudFormation templates:
 AuthConfig:
   UserPoolId: !ImportValue MyAuthStack:UserPoolId
   AppClientId: !ImportValue MyAuthStack:AppClientId
+  McpClientId: !ImportValue MyAuthStack:AppClientIdMcpClient
 ```
 
 ## Advanced Configuration
@@ -313,6 +391,60 @@ const template = createAuthTemplate({
   ],
 });
 ```
+
+### End-to-End OAuth for Remote MCP Connectors
+
+This example wires `@ttoss/cloud-auth` with `@ttoss/http-server-mcp` so Claude (or any OAuth 2.1 client) can authenticate against your MCP server using authorization code + PKCE:
+
+```typescript
+// cloudformation.ts
+import { createAuthTemplate } from '@ttoss/cloud-auth';
+
+export default createAuthTemplate({
+  domain: { domainName: 'my-app' },
+  resourceServers: [
+    {
+      identifier: 'mcp',
+      name: 'MCP Server',
+      scopes: [{ scopeName: 'access', scopeDescription: 'Full MCP access' }],
+    },
+  ],
+  additionalAppClients: [
+    {
+      name: 'mcp-client',
+      generateSecret: true,
+      oauth: {
+        flows: ['code'],
+        scopes: ['openid', 'mcp/access'],
+        callbackUrls: ['https://claude.ai/api/mcp/auth_callback'],
+      },
+    },
+  ],
+});
+```
+
+```typescript
+// server.ts
+import { createMcpRouter } from '@ttoss/http-server-mcp';
+
+const mcpRouter = createMcpRouter({
+  auth: {
+    cognitoUserPool: {
+      userPoolId: process.env.USER_POOL_ID,
+      clientId: process.env.MCP_CLIENT_ID, // AppClientIdMcpClient output
+      requiredScopes: ['mcp/access'],
+    },
+  },
+  // ...tools
+});
+```
+
+The MCP client flow:
+
+1. Client calls your MCP server → `401`.
+2. Client reads `/.well-known/oauth-protected-resource` → discovers the Cognito authorization server URL (`CognitoUserPoolDomainUrl` output).
+3. Client runs authorization code + PKCE through the Cognito hosted UI.
+4. `createMcpRouter` verifies the access token and enforces `mcp/access`.
 
 ### Production Considerations
 

--- a/packages/cloud-auth/src/index.ts
+++ b/packages/cloud-auth/src/index.ts
@@ -1,2 +1,13 @@
 export * from './config';
-export { type CloudFormationTemplate, createAuthTemplate } from './template';
+export {
+  type AdditionalAppClientConfig,
+  type CloudFormationTemplate,
+  createAuthTemplate,
+  defaultPrincipalTags,
+  DenyStatement,
+  type DomainConfig,
+  type OAuthConfig,
+  type ResourceServerConfig,
+  type ResourceServerScope,
+} from './template';
+export type { IdentityPoolConfig } from './template-identity-pool';

--- a/packages/cloud-auth/src/template-identity-pool.ts
+++ b/packages/cloud-auth/src/template-identity-pool.ts
@@ -1,0 +1,208 @@
+import type { CloudFormationTemplate, Policy } from '@ttoss/cloudformation';
+
+const DenyStatement = {
+  Effect: 'Deny' as const,
+  Action: ['*'],
+  Resource: ['*'],
+};
+
+const CognitoUserPoolLogicalId = 'CognitoUserPool';
+const CognitoUserPoolClientLogicalId = 'CognitoUserPoolClient';
+const CognitoIdentityPoolLogicalId = 'CognitoIdentityPool';
+
+export const IdentityPoolAuthenticatedIAMRoleLogicalId =
+  'IdentityPoolAuthenticatedIAMRole';
+
+export const IdentityPoolUnauthenticatedIAMRoleLogicalId =
+  'IdentityPoolUnauthenticatedIAMRole';
+
+export type IdentityPoolConfig = {
+  enabled?: boolean;
+  name?: string;
+  allowUnauthenticatedIdentities?: boolean;
+  authenticatedRoleArn?: string;
+  authenticatedPolicies?: Policy[];
+  unauthenticatedRoleArn?: string;
+  unauthenticatedPolicies?: Policy[];
+  principalTags?: Record<string, string> | boolean;
+};
+
+const buildAuthenticatedRoleResource = (policies?: Policy[]) => {
+  return {
+    Type: 'AWS::IAM::Role',
+    Properties: {
+      AssumeRolePolicyDocument: {
+        Version: '2012-10-17' as const,
+        Statement: [
+          {
+            Effect: 'Allow' as const,
+            Principal: { Federated: 'cognito-identity.amazonaws.com' },
+            Action: ['sts:AssumeRoleWithWebIdentity', 'sts:TagSession'],
+            Condition: {
+              StringEquals: {
+                'cognito-identity.amazonaws.com:aud': {
+                  Ref: CognitoIdentityPoolLogicalId,
+                },
+              },
+              'ForAnyValue:StringLike': {
+                'cognito-identity.amazonaws.com:amr': 'authenticated',
+              },
+            },
+          },
+        ],
+      },
+      Policies: policies || [
+        {
+          PolicyName: 'IdentityPoolAuthenticatedIAMRolePolicyName',
+          PolicyDocument: {
+            Version: '2012-10-17' as const,
+            Statement: [DenyStatement],
+          },
+        },
+      ],
+    },
+  };
+};
+
+const buildUnauthenticatedRoleResource = (policies?: Policy[]) => {
+  return {
+    Type: 'AWS::IAM::Role',
+    Properties: {
+      AssumeRolePolicyDocument: {
+        Version: '2012-10-17' as const,
+        Statement: [
+          {
+            Effect: 'Allow' as const,
+            Principal: { Federated: 'cognito-identity.amazonaws.com' },
+            Action: 'sts:AssumeRoleWithWebIdentity',
+            Condition: {
+              StringEquals: {
+                'cognito-identity.amazonaws.com:aud': {
+                  Ref: CognitoIdentityPoolLogicalId,
+                },
+              },
+              'ForAnyValue:StringLike': {
+                'cognito-identity.amazonaws.com:amr': 'unauthenticated',
+              },
+            },
+          },
+        ],
+      },
+      Policies: policies || [
+        {
+          PolicyName: 'IdentityPoolUnauthenticatedIAMRolePolicyName',
+          PolicyDocument: {
+            Version: '2012-10-17' as const,
+            Statement: [DenyStatement],
+          },
+        },
+      ],
+    },
+  };
+};
+
+export const defaultPrincipalTags = {
+  appClientId: 'aud',
+  userId: 'sub',
+};
+
+const applyIdentityPoolPrincipalTags = (
+  template: CloudFormationTemplate,
+  principalTags: IdentityPoolConfig['principalTags']
+) => {
+  if (principalTags === false) return;
+
+  const PrincipalTags =
+    !principalTags || typeof principalTags === 'boolean'
+      ? defaultPrincipalTags
+      : principalTags;
+
+  template.Resources.CognitoIdentityPoolPrincipalTag = {
+    Type: 'AWS::Cognito::IdentityPoolPrincipalTag',
+    Properties: {
+      IdentityPoolId: { Ref: CognitoIdentityPoolLogicalId },
+      IdentityProviderName: {
+        'Fn::GetAtt': [CognitoUserPoolLogicalId, 'ProviderName'],
+      },
+      PrincipalTags,
+      UseDefaults: false,
+    },
+  };
+};
+
+export const applyIdentityPool = (
+  template: CloudFormationTemplate,
+  identityPool: IdentityPoolConfig
+) => {
+  template.Resources[CognitoIdentityPoolLogicalId] = {
+    Type: 'AWS::Cognito::IdentityPool',
+    Properties: {
+      AllowUnauthenticatedIdentities:
+        identityPool.allowUnauthenticatedIdentities || false,
+      CognitoIdentityProviders: [
+        {
+          ClientId: { Ref: CognitoUserPoolClientLogicalId },
+          ProviderName: {
+            'Fn::GetAtt': [CognitoUserPoolLogicalId, 'ProviderName'],
+          },
+        },
+      ],
+      ...(identityPool.name && { IdentityPoolName: identityPool.name }),
+    },
+  };
+
+  template.Resources.CognitoIdentityPoolRoleAttachment = {
+    Type: 'AWS::Cognito::IdentityPoolRoleAttachment',
+    Properties: {
+      IdentityPoolId: { Ref: CognitoIdentityPoolLogicalId },
+      Roles: {},
+    },
+  };
+
+  const roles =
+    template.Resources.CognitoIdentityPoolRoleAttachment.Properties?.Roles;
+
+  if (identityPool.authenticatedRoleArn) {
+    Object.assign(roles, { authenticated: identityPool.authenticatedRoleArn });
+  } else {
+    template.Resources[IdentityPoolAuthenticatedIAMRoleLogicalId] =
+      buildAuthenticatedRoleResource(identityPool.authenticatedPolicies);
+    Object.assign(roles, {
+      authenticated: {
+        'Fn::GetAtt': [IdentityPoolAuthenticatedIAMRoleLogicalId, 'Arn'],
+      },
+    });
+  }
+
+  if (identityPool.unauthenticatedRoleArn) {
+    Object.assign(roles, {
+      unauthenticated: identityPool.unauthenticatedRoleArn,
+    });
+  } else {
+    template.Resources[IdentityPoolUnauthenticatedIAMRoleLogicalId] =
+      buildUnauthenticatedRoleResource(identityPool.unauthenticatedPolicies);
+    Object.assign(roles, {
+      unauthenticated: {
+        'Fn::GetAtt': [IdentityPoolUnauthenticatedIAMRoleLogicalId, 'Arn'],
+      },
+    });
+  }
+
+  applyIdentityPoolPrincipalTags(template, identityPool.principalTags);
+
+  template.Outputs = {
+    ...template.Outputs,
+    IdentityPoolId: {
+      Description: 'You use this value on Amplify Auth `identityPoolId`.',
+      Value: { Ref: CognitoIdentityPoolLogicalId },
+      Export: {
+        Name: {
+          'Fn::Join': [
+            ':',
+            [{ Ref: 'AWS::StackName' }, 'CognitoIdentityPoolId'],
+          ],
+        },
+      },
+    },
+  };
+};

--- a/packages/cloud-auth/src/template.ts
+++ b/packages/cloud-auth/src/template.ts
@@ -1,24 +1,24 @@
 import type {
   CloudFormationGetAtt,
   CloudFormationTemplate,
-  Policy,
 } from '@ttoss/cloudformation';
 
-export { CloudFormationTemplate };
-
 import { PASSWORD_MINIMUM_LENGTH } from './config';
+import type { IdentityPoolConfig } from './template-identity-pool';
+import {
+  applyIdentityPool,
+  IdentityPoolAuthenticatedIAMRoleLogicalId,
+  IdentityPoolUnauthenticatedIAMRoleLogicalId,
+} from './template-identity-pool';
+
+export type { CloudFormationTemplate };
+
+export type { IdentityPoolConfig };
+export { defaultPrincipalTags } from './template-identity-pool';
 
 const CognitoUserPoolLogicalId = 'CognitoUserPool';
-
 const CognitoUserPoolClientLogicalId = 'CognitoUserPoolClient';
-
 const CognitoIdentityPoolLogicalId = 'CognitoIdentityPool';
-
-const IdentityPoolAuthenticatedIAMRoleLogicalId =
-  'IdentityPoolAuthenticatedIAMRole';
-
-const IdentityPoolUnauthenticatedIAMRoleLogicalId =
-  'IdentityPoolUnauthenticatedIAMRole';
 
 export const DenyStatement = {
   Effect: 'Deny' as const,
@@ -26,36 +26,14 @@ export const DenyStatement = {
   Resource: ['*'],
 };
 
-export const defaultPrincipalTags = {
-  appClientId: 'aud',
-  userId: 'sub',
-};
-
 type SchemaAttribute = {
   attributeDataType?: 'Boolean' | 'DateTime' | 'Number' | 'String';
   developerOnlyAttribute?: boolean;
   mutable?: boolean;
   name?: string;
-  numberAttributeConstraints?: {
-    maxValue?: string;
-    minValue?: string;
-  };
+  numberAttributeConstraints?: { maxValue?: string; minValue?: string };
   required?: boolean;
-  stringAttributeConstraints?: {
-    maxLength: string;
-    minLength: string;
-  };
-};
-
-type IdentityPoolConfig = {
-  enabled?: boolean;
-  name?: string;
-  allowUnauthenticatedIdentities?: boolean;
-  authenticatedRoleArn?: string;
-  authenticatedPolicies?: Policy[];
-  unauthenticatedRoleArn?: string;
-  unauthenticatedPolicies?: Policy[];
-  principalTags?: Record<string, string> | boolean;
+  stringAttributeConstraints?: { maxLength: string; minLength: string };
 };
 
 type LambdaTriggers = {
@@ -73,6 +51,34 @@ type LambdaTriggers = {
   customSMSSender?: string | CloudFormationGetAtt;
 };
 
+export type DomainConfig = {
+  domainName: string;
+  certificateArn?: string;
+};
+
+export type ResourceServerScope = {
+  scopeName: string;
+  scopeDescription: string;
+};
+
+export type ResourceServerConfig = {
+  identifier: string;
+  name: string;
+  scopes: ResourceServerScope[];
+};
+
+export type OAuthConfig = {
+  flows: Array<'code' | 'implicit' | 'client_credentials'>;
+  scopes: string[];
+  callbackUrls: string[];
+};
+
+export type AdditionalAppClientConfig = {
+  name: string;
+  generateSecret?: boolean;
+  oauth?: OAuthConfig;
+};
+
 type CreateAuthTemplateParams = {
   autoVerifiedAttributes?: Array<'email' | 'phone_number'> | null | false;
   identityPool?: IdentityPoolConfig;
@@ -80,28 +86,37 @@ type CreateAuthTemplateParams = {
   usernameAttributes?: Array<'email' | 'phone_number'> | null;
   lambdaTriggers?: LambdaTriggers;
   deletionProtection?: 'ACTIVE' | 'INACTIVE';
+  domain?: DomainConfig;
+  resourceServers?: ResourceServerConfig[];
+  additionalAppClients?: AdditionalAppClientConfig[];
 };
 
-export const createAuthTemplate = ({
-  autoVerifiedAttributes = ['email'],
-  identityPool,
-  schema,
-  usernameAttributes = ['email'],
-  lambdaTriggers,
+export const toPascalCase = (name: string) => {
+  return name
+    .split(/[-_\s]+/)
+    .map((part) => {
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join('');
+};
+
+const buildBaseTemplate = ({
+  autoVerifiedAttributes,
+  usernameAttributes,
   deletionProtection,
-}: CreateAuthTemplateParams = {}): CloudFormationTemplate => {
+}: Pick<
+  CreateAuthTemplateParams,
+  'autoVerifiedAttributes' | 'usernameAttributes' | 'deletionProtection'
+>): CloudFormationTemplate => {
   const AutoVerifiedAttributes =
     Array.isArray(autoVerifiedAttributes) && autoVerifiedAttributes.length > 0
       ? autoVerifiedAttributes
       : [];
 
-  const template: CloudFormationTemplate = {
+  return {
     AWSTemplateFormatVersion: '2010-09-09',
     Resources: {
       [CognitoUserPoolLogicalId]: {
-        /**
-         * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpool.html
-         */
         Type: 'AWS::Cognito::UserPool',
         Properties: {
           AutoVerifiedAttributes,
@@ -116,45 +131,30 @@ export const createAuthTemplate = ({
             },
           },
           UsernameAttributes: usernameAttributes,
-          UsernameConfiguration: {
-            CaseSensitive: false,
-          },
-          UserPoolName: {
-            Ref: 'AWS::StackName',
-          },
+          UsernameConfiguration: { CaseSensitive: false },
+          UserPoolName: { Ref: 'AWS::StackName' },
           ...(deletionProtection && { DeletionProtection: deletionProtection }),
         },
       },
       [CognitoUserPoolClientLogicalId]: {
-        /**
-         * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpoolclient.html
-         */
         Type: 'AWS::Cognito::UserPoolClient',
         Properties: {
           SupportedIdentityProviders: ['COGNITO'],
-          UserPoolId: {
-            Ref: 'CognitoUserPool',
-          },
+          UserPoolId: { Ref: 'CognitoUserPool' },
         },
       },
     },
     Outputs: {
       Region: {
         Description: 'You use this value on Amplify Auth `region`.',
-        Value: {
-          Ref: 'AWS::Region',
-        },
+        Value: { Ref: 'AWS::Region' },
         Export: {
-          Name: {
-            'Fn::Join': [':', [{ Ref: 'AWS::StackName' }, 'Region']],
-          },
+          Name: { 'Fn::Join': [':', [{ Ref: 'AWS::StackName' }, 'Region']] },
         },
       },
       UserPoolId: {
         Description: 'You use this value on Amplify Auth `userPoolId`.',
-        Value: {
-          Ref: CognitoUserPoolLogicalId,
-        },
+        Value: { Ref: CognitoUserPoolLogicalId },
         Export: {
           Name: {
             'Fn::Join': [':', [{ Ref: 'AWS::StackName' }, 'UserPoolId']],
@@ -164,9 +164,7 @@ export const createAuthTemplate = ({
       AppClientId: {
         Description:
           'You use this value on Amplify Auth `userPoolWebClientId`.',
-        Value: {
-          Ref: CognitoUserPoolClientLogicalId,
-        },
+        Value: { Ref: CognitoUserPoolClientLogicalId },
         Export: {
           Name: {
             'Fn::Join': [':', [{ Ref: 'AWS::StackName' }, 'AppClientId']],
@@ -175,328 +173,232 @@ export const createAuthTemplate = ({
       },
     },
   };
+};
 
-  if (schema) {
-    const Schema = schema.map((attribute) => {
-      let NumberAttributeConstraints = undefined;
-
-      if (attribute.numberAttributeConstraints) {
-        NumberAttributeConstraints = {
-          MaxValue: attribute.numberAttributeConstraints?.maxValue,
-          MinValue: attribute.numberAttributeConstraints?.minValue,
-        };
-      }
-
-      let StringAttributeConstraints = undefined;
-
-      if (attribute.stringAttributeConstraints) {
-        StringAttributeConstraints = {
-          MaxLength: attribute.stringAttributeConstraints?.maxLength,
-          MinLength: attribute.stringAttributeConstraints?.minLength,
-        };
-      }
-
-      return {
-        AttributeDataType: attribute.attributeDataType,
-        DeveloperOnlyAttribute: attribute.developerOnlyAttribute,
-        Mutable: attribute.mutable,
-        Name: attribute.name,
-        NumberAttributeConstraints,
-        Required: attribute.required,
-        StringAttributeConstraints,
-      };
-    });
-
-    template.Resources[CognitoUserPoolLogicalId].Properties = {
-      ...template.Resources[CognitoUserPoolLogicalId].Properties,
-      Schema,
+const applySchema = (
+  template: CloudFormationTemplate,
+  schema: SchemaAttribute[]
+) => {
+  const Schema = schema.map((attribute) => {
+    return {
+      AttributeDataType: attribute.attributeDataType,
+      DeveloperOnlyAttribute: attribute.developerOnlyAttribute,
+      Mutable: attribute.mutable,
+      Name: attribute.name,
+      Required: attribute.required,
+      NumberAttributeConstraints: attribute.numberAttributeConstraints
+        ? {
+            MaxValue: attribute.numberAttributeConstraints.maxValue,
+            MinValue: attribute.numberAttributeConstraints.minValue,
+          }
+        : undefined,
+      StringAttributeConstraints: attribute.stringAttributeConstraints
+        ? {
+            MaxLength: attribute.stringAttributeConstraints.maxLength,
+            MinLength: attribute.stringAttributeConstraints.minLength,
+          }
+        : undefined,
     };
+  });
+
+  template.Resources[CognitoUserPoolLogicalId].Properties = {
+    ...template.Resources[CognitoUserPoolLogicalId].Properties,
+    Schema,
+  };
+};
+
+const applyLambdaTriggers = (
+  template: CloudFormationTemplate,
+  lambdaTriggers: LambdaTriggers
+) => {
+  const triggerMap: Array<[keyof LambdaTriggers, string]> = [
+    ['preSignUp', 'PreSignUp'],
+    ['postConfirmation', 'PostConfirmation'],
+    ['preAuthentication', 'PreAuthentication'],
+    ['postAuthentication', 'PostAuthentication'],
+    ['defineAuthChallenge', 'DefineAuthChallenge'],
+    ['createAuthChallenge', 'CreateAuthChallenge'],
+    ['verifyAuthChallengeResponse', 'VerifyAuthChallengeResponse'],
+    ['preTokenGeneration', 'PreTokenGeneration'],
+    ['userMigration', 'UserMigration'],
+    ['customMessage', 'CustomMessage'],
+    ['customEmailSender', 'CustomEmailSender'],
+    ['customSMSSender', 'CustomSMSSender'],
+  ];
+
+  const LambdaConfig: Record<string, string | CloudFormationGetAtt> = {};
+
+  for (const [key, cfKey] of triggerMap) {
+    const value = lambdaTriggers[key];
+    if (value) LambdaConfig[cfKey] = value;
   }
 
-  if (identityPool?.enabled) {
-    template.Resources[CognitoIdentityPoolLogicalId] = {
-      /**
-       * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html
-       */
-      Type: 'AWS::Cognito::IdentityPool',
+  if (Object.keys(LambdaConfig).length === 0) return;
+
+  template.Resources[CognitoUserPoolLogicalId].Properties = {
+    ...template.Resources[CognitoUserPoolLogicalId].Properties,
+    LambdaConfig,
+  };
+
+  for (const [key, lambdaTrigger] of Object.entries(LambdaConfig)) {
+    const permissionLogicalId =
+      `${key}PermissionFor${CognitoUserPoolLogicalId}`.slice(0, 255);
+
+    template.Resources[permissionLogicalId] = {
+      Type: 'AWS::Lambda::Permission',
       Properties: {
-        AllowUnauthenticatedIdentities:
-          identityPool.allowUnauthenticatedIdentities || false,
-        CognitoIdentityProviders: [
-          {
-            ClientId: {
-              Ref: CognitoUserPoolClientLogicalId,
-            },
-            ProviderName: {
-              'Fn::GetAtt': [CognitoUserPoolLogicalId, 'ProviderName'],
-            },
-          },
-        ],
+        Action: 'lambda:InvokeFunction',
+        FunctionName: lambdaTrigger,
+        Principal: 'cognito-idp.amazonaws.com',
+        SourceArn: { 'Fn::GetAtt': [CognitoUserPoolLogicalId, 'Arn'] },
       },
     };
+  }
+};
 
-    if (identityPool.name) {
-      template.Resources[CognitoIdentityPoolLogicalId].Properties = {
-        ...template.Resources[CognitoIdentityPoolLogicalId].Properties,
-        IdentityPoolName: identityPool.name,
+const applyDomain = (
+  template: CloudFormationTemplate,
+  domain: DomainConfig
+) => {
+  template.Resources.CognitoUserPoolDomain = {
+    Type: 'AWS::Cognito::UserPoolDomain',
+    Properties: {
+      Domain: domain.domainName,
+      UserPoolId: { Ref: CognitoUserPoolLogicalId },
+      ...(domain.certificateArn && {
+        CustomDomainConfig: { CertificateArn: domain.certificateArn },
+      }),
+    },
+  };
+
+  const domainUrl = domain.certificateArn
+    ? `https://${domain.domainName}`
+    : {
+        'Fn::Sub': `https://${domain.domainName}.auth.\${AWS::Region}.amazoncognito.com`,
       };
-    }
 
-    template.Resources.CognitoIdentityPoolRoleAttachment = {
-      /**
-       * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolroleattachment.html
-       */
-      Type: 'AWS::Cognito::IdentityPoolRoleAttachment',
-      Properties: {
-        IdentityPoolId: {
-          Ref: CognitoIdentityPoolLogicalId,
+  template.Outputs = {
+    ...template.Outputs,
+    CognitoUserPoolDomainUrl: {
+      Description: 'The Cognito hosted UI domain URL.',
+      Value: domainUrl,
+      Export: {
+        Name: {
+          'Fn::Join': [
+            ':',
+            [{ Ref: 'AWS::StackName' }, 'CognitoUserPoolDomainUrl'],
+          ],
         },
-        Roles: {},
+      },
+    },
+  };
+};
+
+const applyResourceServers = (
+  template: CloudFormationTemplate,
+  resourceServers: ResourceServerConfig[]
+) => {
+  for (const server of resourceServers) {
+    const logicalId = `CognitoUserPoolResourceServer${toPascalCase(server.identifier)}`;
+
+    template.Resources[logicalId] = {
+      Type: 'AWS::Cognito::UserPoolResourceServer',
+      Properties: {
+        Identifier: server.identifier,
+        Name: server.name,
+        Scopes: server.scopes.map((scope) => {
+          return {
+            ScopeName: scope.scopeName,
+            ScopeDescription: scope.scopeDescription,
+          };
+        }),
+        UserPoolId: { Ref: CognitoUserPoolLogicalId },
       },
     };
+  }
+};
 
-    if (!identityPool.authenticatedRoleArn) {
-      template.Resources[IdentityPoolAuthenticatedIAMRoleLogicalId] = {
-        Type: 'AWS::IAM::Role',
-        Properties: {
-          AssumeRolePolicyDocument: {
-            Version: '2012-10-17' as const,
-            Statement: [
-              {
-                Effect: 'Allow' as const,
-                Principal: {
-                  Federated: 'cognito-identity.amazonaws.com',
-                },
-                Action: ['sts:AssumeRoleWithWebIdentity', 'sts:TagSession'],
-                Condition: {
-                  StringEquals: {
-                    'cognito-identity.amazonaws.com:aud': {
-                      Ref: CognitoIdentityPoolLogicalId,
-                    },
-                  },
-                  'ForAnyValue:StringLike': {
-                    'cognito-identity.amazonaws.com:amr': 'authenticated',
-                  },
-                },
-              },
-            ],
-          },
-          Policies: identityPool.authenticatedPolicies || [
-            {
-              PolicyName: 'IdentityPoolAuthenticatedIAMRolePolicyName',
-              PolicyDocument: {
-                Version: '2012-10-17' as const,
-                Statement: [DenyStatement],
-              },
-            },
-          ],
-        },
-      };
+const applyAdditionalAppClients = (
+  template: CloudFormationTemplate,
+  additionalAppClients: AdditionalAppClientConfig[]
+) => {
+  for (const client of additionalAppClients) {
+    const pascalName = toPascalCase(client.name);
+    const logicalId = `AppClient${pascalName}`;
+    const outputKey = `AppClientId${pascalName}`;
 
-      Object.assign(
-        template.Resources.CognitoIdentityPoolRoleAttachment.Properties?.Roles,
-        {
-          authenticated: {
-            'Fn::GetAtt': [IdentityPoolAuthenticatedIAMRoleLogicalId, 'Arn'],
-          },
-        }
-      );
-    } else {
-      Object.assign(
-        template.Resources.CognitoIdentityPoolRoleAttachment.Properties?.Roles,
-        {
-          authenticated: identityPool.authenticatedRoleArn,
-        }
-      );
-    }
-
-    if (!identityPool.unauthenticatedRoleArn) {
-      template.Resources[IdentityPoolUnauthenticatedIAMRoleLogicalId] = {
-        Type: 'AWS::IAM::Role',
-        Properties: {
-          AssumeRolePolicyDocument: {
-            Version: '2012-10-17' as const,
-            Statement: [
-              {
-                Effect: 'Allow' as const,
-                Principal: {
-                  Federated: 'cognito-identity.amazonaws.com',
-                },
-                Action: 'sts:AssumeRoleWithWebIdentity',
-                Condition: {
-                  StringEquals: {
-                    'cognito-identity.amazonaws.com:aud': {
-                      Ref: CognitoIdentityPoolLogicalId,
-                    },
-                  },
-                  'ForAnyValue:StringLike': {
-                    'cognito-identity.amazonaws.com:amr': 'unauthenticated',
-                  },
-                },
-              },
-            ],
-          },
-          Policies: identityPool.unauthenticatedPolicies || [
-            {
-              PolicyName: 'IdentityPoolUnauthenticatedIAMRolePolicyName',
-              PolicyDocument: {
-                Version: '2012-10-17' as const,
-                Statement: [DenyStatement],
-              },
-            },
-          ],
-        },
-      };
-
-      Object.assign(
-        template.Resources.CognitoIdentityPoolRoleAttachment.Properties?.Roles,
-        {
-          unauthenticated: {
-            'Fn::GetAtt': [IdentityPoolUnauthenticatedIAMRoleLogicalId, 'Arn'],
-          },
-        }
-      );
-    } else {
-      Object.assign(
-        template.Resources.CognitoIdentityPoolRoleAttachment.Properties?.Roles,
-        {
-          unauthenticated: identityPool.unauthenticatedRoleArn,
-        }
-      );
-    }
-
-    /**
-     * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypoolprincipaltag.html
-     */
-    if (
-      identityPool.principalTags ||
-      identityPool.principalTags === undefined
-    ) {
-      const PrincipalTags = (() => {
-        if (typeof identityPool.principalTags === 'boolean') {
-          return defaultPrincipalTags;
-        }
-
-        if (identityPool.principalTags === undefined) {
-          return defaultPrincipalTags;
-        }
-
-        return identityPool.principalTags;
-      })();
-
-      template.Resources.CognitoIdentityPoolPrincipalTag = {
-        Type: 'AWS::Cognito::IdentityPoolPrincipalTag',
-        Properties: {
-          IdentityPoolId: {
-            Ref: CognitoIdentityPoolLogicalId,
-          },
-          IdentityProviderName: {
-            'Fn::GetAtt': [CognitoUserPoolLogicalId, 'ProviderName'],
-          },
-          PrincipalTags,
-          UseDefaults: false,
-        },
-      };
-    }
+    template.Resources[logicalId] = {
+      Type: 'AWS::Cognito::UserPoolClient',
+      Properties: {
+        ClientName: client.name,
+        UserPoolId: { Ref: CognitoUserPoolLogicalId },
+        SupportedIdentityProviders: ['COGNITO'],
+        GenerateSecret: client.generateSecret ?? false,
+        ...(client.oauth && {
+          AllowedOAuthFlows: client.oauth.flows,
+          AllowedOAuthFlowsUserPoolClient: true,
+          AllowedOAuthScopes: client.oauth.scopes,
+          CallbackURLs: client.oauth.callbackUrls,
+        }),
+      },
+    };
 
     template.Outputs = {
       ...template.Outputs,
-      IdentityPoolId: {
-        Description: 'You use this value on Amplify Auth `identityPoolId`.',
-        Value: {
-          Ref: CognitoIdentityPoolLogicalId,
-        },
+      [outputKey]: {
+        Description: `App client ID for ${client.name}.`,
+        Value: { Ref: logicalId },
         Export: {
           Name: {
-            'Fn::Join': [
-              ':',
-              [{ Ref: 'AWS::StackName' }, 'CognitoIdentityPoolId'],
-            ],
+            'Fn::Join': [':', [{ Ref: 'AWS::StackName' }, outputKey]],
           },
         },
       },
     };
   }
+};
 
-  // Apply Lambda triggers if provided
-  if (lambdaTriggers) {
-    const LambdaConfig: Record<string, string | CloudFormationGetAtt> = {};
+const applyAll = (
+  template: CloudFormationTemplate,
+  params: CreateAuthTemplateParams
+) => {
+  if (params.schema) applySchema(template, params.schema);
+  if (params.identityPool?.enabled)
+    applyIdentityPool(template, params.identityPool);
+  if (params.lambdaTriggers)
+    applyLambdaTriggers(template, params.lambdaTriggers);
+  if (params.domain) applyDomain(template, params.domain);
+  if (params.resourceServers)
+    applyResourceServers(template, params.resourceServers);
+  if (params.additionalAppClients)
+    applyAdditionalAppClients(template, params.additionalAppClients);
+};
 
-    if (lambdaTriggers.preSignUp) {
-      LambdaConfig.PreSignUp = lambdaTriggers.preSignUp;
-    }
-    if (lambdaTriggers.postConfirmation) {
-      LambdaConfig.PostConfirmation = lambdaTriggers.postConfirmation;
-    }
-    if (lambdaTriggers.preAuthentication) {
-      LambdaConfig.PreAuthentication = lambdaTriggers.preAuthentication;
-    }
-    if (lambdaTriggers.postAuthentication) {
-      LambdaConfig.PostAuthentication = lambdaTriggers.postAuthentication;
-    }
-    if (lambdaTriggers.defineAuthChallenge) {
-      LambdaConfig.DefineAuthChallenge = lambdaTriggers.defineAuthChallenge;
-    }
-    if (lambdaTriggers.createAuthChallenge) {
-      LambdaConfig.CreateAuthChallenge = lambdaTriggers.createAuthChallenge;
-    }
-    if (lambdaTriggers.verifyAuthChallengeResponse) {
-      LambdaConfig.VerifyAuthChallengeResponse =
-        lambdaTriggers.verifyAuthChallengeResponse;
-    }
-    if (lambdaTriggers.preTokenGeneration) {
-      LambdaConfig.PreTokenGeneration = lambdaTriggers.preTokenGeneration;
-    }
-    if (lambdaTriggers.userMigration) {
-      LambdaConfig.UserMigration = lambdaTriggers.userMigration;
-    }
-    if (lambdaTriggers.customMessage) {
-      LambdaConfig.CustomMessage = lambdaTriggers.customMessage;
-    }
-    if (lambdaTriggers.customEmailSender) {
-      LambdaConfig.CustomEmailSender = lambdaTriggers.customEmailSender;
-    }
-    if (lambdaTriggers.customSMSSender) {
-      LambdaConfig.CustomSMSSender = lambdaTriggers.customSMSSender;
-    }
+export const createAuthTemplate = (
+  params: CreateAuthTemplateParams = {}
+): CloudFormationTemplate => {
+  const {
+    autoVerifiedAttributes = ['email'],
+    usernameAttributes = ['email'],
+    deletionProtection,
+  } = params;
 
-    if (Object.keys(LambdaConfig).length > 0) {
-      template.Resources[CognitoUserPoolLogicalId].Properties = {
-        ...template.Resources[CognitoUserPoolLogicalId].Properties,
-        LambdaConfig,
-      };
-    }
+  const template = buildBaseTemplate({
+    autoVerifiedAttributes,
+    usernameAttributes,
+    deletionProtection,
+  });
 
-    for (const [key, lambdaTrigger] of Object.entries(LambdaConfig)) {
-      const permissionLogicalId =
-        `${key}PermissionFor${CognitoUserPoolLogicalId}`.slice(0, 255);
-
-      template.Resources[permissionLogicalId] = {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          Action: 'lambda:InvokeFunction',
-          FunctionName: lambdaTrigger,
-          Principal: 'cognito-idp.amazonaws.com',
-          SourceArn: {
-            'Fn::GetAtt': [CognitoUserPoolLogicalId, 'Arn'],
-          },
-        },
-      };
-    }
-  }
+  applyAll(template, params);
 
   return template;
 };
 
 createAuthTemplate.CognitoUserPoolLogicalId = CognitoUserPoolLogicalId;
-
 createAuthTemplate.CognitoUserPoolClientLogicalId =
   CognitoUserPoolClientLogicalId;
-
 createAuthTemplate.CognitoIdentityPoolLogicalId = CognitoIdentityPoolLogicalId;
-
 createAuthTemplate.IdentityPoolAuthenticatedIAMRoleLogicalId =
   IdentityPoolAuthenticatedIAMRoleLogicalId;
-
 createAuthTemplate.IdentityPoolUnauthenticatedIAMRoleLogicalId =
   IdentityPoolUnauthenticatedIAMRoleLogicalId;

--- a/packages/cloud-auth/tests/unit/template.test.ts
+++ b/packages/cloud-auth/tests/unit/template.test.ts
@@ -366,6 +366,268 @@ describe('identity pool', () => {
   );
 });
 
+describe('domain', () => {
+  test('should not add domain resource if domain not provided', () => {
+    const template = createAuthTemplate();
+    expect(template.Resources.CognitoUserPoolDomain).toBeUndefined();
+    expect(template.Outputs?.CognitoUserPoolDomainUrl).toBeUndefined();
+  });
+
+  test('should add domain resource with prefix domain', () => {
+    const template = createAuthTemplate({
+      domain: { domainName: 'my-auth-prefix' },
+    });
+
+    expect(template.Resources.CognitoUserPoolDomain).toEqual({
+      Type: 'AWS::Cognito::UserPoolDomain',
+      Properties: {
+        Domain: 'my-auth-prefix',
+        UserPoolId: { Ref: 'CognitoUserPool' },
+      },
+    });
+  });
+
+  test('should output Fn::Sub URL for prefix domain', () => {
+    const template = createAuthTemplate({
+      domain: { domainName: 'my-auth-prefix' },
+    });
+
+    expect(template.Outputs?.CognitoUserPoolDomainUrl?.Value).toEqual({
+      'Fn::Sub': 'https://my-auth-prefix.auth.${AWS::Region}.amazoncognito.com',
+    });
+  });
+
+  test('should add domain resource with custom domain and certificate', () => {
+    const template = createAuthTemplate({
+      domain: {
+        domainName: 'auth.example.com',
+        certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/abc',
+      },
+    });
+
+    expect(template.Resources.CognitoUserPoolDomain).toEqual({
+      Type: 'AWS::Cognito::UserPoolDomain',
+      Properties: {
+        Domain: 'auth.example.com',
+        UserPoolId: { Ref: 'CognitoUserPool' },
+        CustomDomainConfig: {
+          CertificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/abc',
+        },
+      },
+    });
+  });
+
+  test('should output plain URL for custom domain', () => {
+    const template = createAuthTemplate({
+      domain: {
+        domainName: 'auth.example.com',
+        certificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/abc',
+      },
+    });
+
+    expect(template.Outputs?.CognitoUserPoolDomainUrl?.Value).toBe(
+      'https://auth.example.com'
+    );
+  });
+
+  test('should export domain URL output', () => {
+    const template = createAuthTemplate({
+      domain: { domainName: 'my-auth-prefix' },
+    });
+
+    expect(template.Outputs?.CognitoUserPoolDomainUrl?.Export?.Name).toEqual({
+      'Fn::Join': [
+        ':',
+        [{ Ref: 'AWS::StackName' }, 'CognitoUserPoolDomainUrl'],
+      ],
+    });
+  });
+});
+
+describe('resourceServers', () => {
+  test('should not add resource server resources if not provided', () => {
+    const template = createAuthTemplate();
+    const resourceServers = Object.keys(template.Resources).filter((key) => {
+      return (
+        template.Resources[key].Type === 'AWS::Cognito::UserPoolResourceServer'
+      );
+    });
+    expect(resourceServers).toHaveLength(0);
+  });
+
+  test('should add a resource server', () => {
+    const template = createAuthTemplate({
+      resourceServers: [
+        {
+          identifier: 'mcp',
+          name: 'MCP Server',
+          scopes: [
+            { scopeName: 'access', scopeDescription: 'Access the MCP server' },
+          ],
+        },
+      ],
+    });
+
+    expect(template.Resources.CognitoUserPoolResourceServerMcp).toEqual({
+      Type: 'AWS::Cognito::UserPoolResourceServer',
+      Properties: {
+        Identifier: 'mcp',
+        Name: 'MCP Server',
+        Scopes: [
+          { ScopeName: 'access', ScopeDescription: 'Access the MCP server' },
+        ],
+        UserPoolId: { Ref: 'CognitoUserPool' },
+      },
+    });
+  });
+
+  test('should add multiple resource servers', () => {
+    const template = createAuthTemplate({
+      resourceServers: [
+        {
+          identifier: 'mcp',
+          name: 'MCP Server',
+          scopes: [
+            { scopeName: 'access', scopeDescription: 'Access the MCP server' },
+          ],
+        },
+        {
+          identifier: 'api',
+          name: 'API Server',
+          scopes: [
+            { scopeName: 'read', scopeDescription: 'Read access' },
+            { scopeName: 'write', scopeDescription: 'Write access' },
+          ],
+        },
+      ],
+    });
+
+    expect(template.Resources.CognitoUserPoolResourceServerMcp).toBeDefined();
+    expect(template.Resources.CognitoUserPoolResourceServerApi).toBeDefined();
+    expect(
+      template.Resources.CognitoUserPoolResourceServerApi.Properties?.Scopes
+    ).toHaveLength(2);
+  });
+});
+
+describe('additionalAppClients', () => {
+  test('should not add additional clients if not provided', () => {
+    const template = createAuthTemplate();
+    const clients = Object.keys(template.Resources).filter((key) => {
+      return (
+        key !== 'CognitoUserPoolClient' &&
+        template.Resources[key].Type === 'AWS::Cognito::UserPoolClient'
+      );
+    });
+    expect(clients).toHaveLength(0);
+  });
+
+  test('should leave default CognitoUserPoolClient untouched', () => {
+    const template = createAuthTemplate({
+      additionalAppClients: [{ name: 'mcp-client', generateSecret: true }],
+    });
+
+    expect(template.Resources.CognitoUserPoolClient).toEqual({
+      Type: 'AWS::Cognito::UserPoolClient',
+      Properties: {
+        SupportedIdentityProviders: ['COGNITO'],
+        UserPoolId: { Ref: 'CognitoUserPool' },
+      },
+    });
+
+    expect(template.Outputs?.AppClientId).toBeDefined();
+  });
+
+  test('should add an additional app client without OAuth', () => {
+    const template = createAuthTemplate({
+      additionalAppClients: [{ name: 'mcp-client', generateSecret: true }],
+    });
+
+    expect(template.Resources.AppClientMcpClient).toEqual({
+      Type: 'AWS::Cognito::UserPoolClient',
+      Properties: {
+        ClientName: 'mcp-client',
+        UserPoolId: { Ref: 'CognitoUserPool' },
+        SupportedIdentityProviders: ['COGNITO'],
+        GenerateSecret: true,
+      },
+    });
+  });
+
+  test('should add an additional app client with OAuth config', () => {
+    const template = createAuthTemplate({
+      additionalAppClients: [
+        {
+          name: 'mcp-client',
+          generateSecret: true,
+          oauth: {
+            flows: ['code'],
+            scopes: ['openid', 'mcp/access'],
+            callbackUrls: ['https://claude.ai/api/mcp/auth_callback'],
+          },
+        },
+      ],
+    });
+
+    expect(template.Resources.AppClientMcpClient).toEqual({
+      Type: 'AWS::Cognito::UserPoolClient',
+      Properties: {
+        ClientName: 'mcp-client',
+        UserPoolId: { Ref: 'CognitoUserPool' },
+        SupportedIdentityProviders: ['COGNITO'],
+        GenerateSecret: true,
+        AllowedOAuthFlows: ['code'],
+        AllowedOAuthFlowsUserPoolClient: true,
+        AllowedOAuthScopes: ['openid', 'mcp/access'],
+        CallbackURLs: ['https://claude.ai/api/mcp/auth_callback'],
+      },
+    });
+  });
+
+  test('should output app client ID for additional client', () => {
+    const template = createAuthTemplate({
+      additionalAppClients: [{ name: 'mcp-client' }],
+    });
+
+    expect(template.Outputs?.AppClientIdMcpClient).toEqual({
+      Description: 'App client ID for mcp-client.',
+      Value: { Ref: 'AppClientMcpClient' },
+      Export: {
+        Name: {
+          'Fn::Join': [
+            ':',
+            [{ Ref: 'AWS::StackName' }, 'AppClientIdMcpClient'],
+          ],
+        },
+      },
+    });
+  });
+
+  test('should add multiple additional app clients', () => {
+    const template = createAuthTemplate({
+      additionalAppClients: [
+        { name: 'mcp-client', generateSecret: true },
+        { name: 'another-client' },
+      ],
+    });
+
+    expect(template.Resources.AppClientMcpClient).toBeDefined();
+    expect(template.Resources.AppClientAnotherClient).toBeDefined();
+    expect(template.Outputs?.AppClientIdMcpClient).toBeDefined();
+    expect(template.Outputs?.AppClientIdAnotherClient).toBeDefined();
+  });
+
+  test('should default GenerateSecret to false if not provided', () => {
+    const template = createAuthTemplate({
+      additionalAppClients: [{ name: 'my-client' }],
+    });
+
+    expect(
+      template.Resources.AppClientMyClient.Properties?.GenerateSecret
+    ).toBe(false);
+  });
+});
+
 describe('lambda triggers', () => {
   test('should not add LambdaConfig if no lambda triggers provided', () => {
     const template = createAuthTemplate();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `domain` option to `createAuthTemplate`: creates `AWS::Cognito::UserPoolDomain` (supports both Cognito prefix domains and custom domains with certificate), exports `CognitoUserPoolDomainUrl`
- Adds `resourceServers` option: creates `AWS::Cognito::UserPoolResourceServer` resources with custom scopes (e.g. `mcp/access`)
- Adds `additionalAppClients` option: creates additional `AWS::Cognito::UserPoolClient` resources with optional OAuth flows, scopes, callback URLs, and secret generation; exports `AppClientId<PascalName>` for each

The existing default `CognitoUserPoolClient` / `AppClientId` output are untouched. This also refactors `template.ts` into focused helper functions and extracts identity pool logic into `template-identity-pool.ts` to comply with line/complexity linting rules.

Closes #1040

## Usage example

```ts
const template = createAuthTemplate({
  domain: {
    domainName: 'auth.example.com',
    certificateArn: 'arn:aws:acm:...', // optional, custom domains only
  },
  resourceServers: [
    {
      identifier: 'mcp',
      name: 'MCP Server',
      scopes: [{ scopeName: 'access', scopeDescription: 'Access the MCP server' }],
    },
  ],
  additionalAppClients: [
    {
      name: 'mcp-client',
      generateSecret: true,
      oauth: {
        flows: ['code'],
        scopes: ['openid', 'mcp/access'],
        callbackUrls: ['https://claude.ai/api/mcp/auth_callback'],
      },
    },
  ],
});
```

## Test plan

- [x] All 72 unit tests pass with 100% coverage
- [x] `domain` — prefix domain uses `Fn::Sub` URL, custom domain uses literal `https://` URL
- [x] `resourceServers` — creates `CognitoUserPoolResourceServer<PascalId>` resources
- [x] `additionalAppClients` — creates `AppClient<PascalName>` resources and `AppClientId<PascalName>` outputs
- [x] OAuth config (flows, scopes, callbackUrls) is applied when provided, omitted when not
- [x] Default `CognitoUserPoolClient` / `AppClientId` output unchanged
- [x] Lint passes (complexity, max-lines, import order)

https://claude.ai/code/session_01C7CiTbr7pyE8C3PsZ4CRoW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7CiTbr7pyE8C3PsZ4CRoW)_