### PR TITLE
chore(read-config-file): add package support metadata

### DIFF
--- a/packages/read-config-file/package.json
+++ b/packages/read-config-file/package.json
@@ -18,6 +18,10 @@
     "url": "https://github.com/ttoss/ttoss.git",
     "directory": "packages/read-config-file"
   },
+  "bugs": {
+    "url": "https://github.com/ttoss/ttoss/issues"
+  },
+  "homepage": "https://github.com/ttoss/ttoss/tree/main/packages/read-config-file#readme",
   "license": "MIT",
   "author": "ttoss",
   "contributors": [


### PR DESCRIPTION
## Summary

- add `bugs` metadata for the repository issue tracker
- add a package-specific `homepage` link for `@ttoss/read-config-file`

## Verification

- `node -e "const p=require('./packages/read-config-file/package.json'); if (p.bugs?.url !== 'https://github.com/ttoss/ttoss/issues' || p.homepage !== 'https://github.com/ttoss/ttoss/tree/main/packages/read-config-file#readme') process.exit(1); console.log(JSON.stringify({name:p.name, version:p.version, bugs:p.bugs, homepage:p.homepage}, null, 2))"`
- `npm pack ./packages/read-config-file --dry-run --ignore-scripts --json`
- `git diff --check`

This is an AI-assisted package metadata cleanup.
