### PR TITLE
fix(components): hide Menu panel during first-frame position calculation

### DIFF
--- a/packages/components/src/components/Menu/Menu.tsx
+++ b/packages/components/src/components/Menu/Menu.tsx
@@ -10,7 +10,9 @@ export type MenuProps = {
 
 export const Menu = ({ children, sx, menuIcon = 'menu-open' }: MenuProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [stylePos, setStylePos] = React.useState<React.CSSProperties>({});
+  const [stylePos, setStylePos] = React.useState<React.CSSProperties>({
+    visibility: 'hidden',
+  });
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const panelRef = React.useRef<HTMLDivElement>(null);
 

--- a/packages/components/tests/unit/tests/Menu.test.tsx
+++ b/packages/components/tests/unit/tests/Menu.test.tsx
@@ -436,6 +436,102 @@ describe('Menu', () => {
     }
   });
 
+  test('panel has visibility:hidden on first open before position is computed', () => {
+    // Prevent RAF from executing so stylePos stays at initial value
+    const rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => {
+        return 1; // never invoke the callback
+      });
+
+    try {
+      render(
+        <Menu>
+          <div>Menu Content</div>
+        </Menu>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+
+      const content = screen.getByText('Menu Content');
+      let node = content.parentElement;
+      while (node && node !== document.body) {
+        const styleAttr = node.getAttribute && node.getAttribute('style');
+        if (styleAttr && /pointer-events/.test(styleAttr)) break;
+        node = node.parentElement;
+      }
+      expect(node).toBeTruthy();
+      if (!node) return;
+      const vis =
+        node.style.visibility ||
+        (node.getAttribute('style') || '')
+          .match(/visibility\s*:\s*([^;]+)/)?.[1]
+          ?.trim();
+      expect(vis).toBe('hidden');
+    } finally {
+      rafSpy.mockRestore();
+    }
+  });
+
+  test('panel becomes visible after position is computed', async () => {
+    const rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      });
+
+    jest
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        if (this.tagName === 'BUTTON') {
+          return {
+            left: 100,
+            width: 40,
+            right: 140,
+            top: 100,
+            bottom: 140,
+            height: 40,
+          } as DOMRect;
+        }
+        return {
+          left: 0,
+          width: 200,
+          right: 200,
+          top: 0,
+          bottom: 100,
+          height: 100,
+        } as DOMRect;
+      });
+
+    try {
+      render(
+        <Menu>
+          <div>Menu Content</div>
+        </Menu>
+      );
+
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(() => {
+        const content = screen.getByText('Menu Content');
+        let node = content.parentElement;
+        while (node && node !== document.body) {
+          const styleAttr = node.getAttribute && node.getAttribute('style');
+          if (styleAttr && /position\s*:\s*fixed/.test(styleAttr)) break;
+          node = node.parentElement;
+        }
+        expect(node).toBeTruthy();
+        if (!node) return;
+        const vis = node.style.visibility;
+        expect(vis).not.toBe('hidden');
+      });
+    } finally {
+      rafSpy.mockRestore();
+      jest.restoreAllMocks();
+    }
+  });
+
   test('adds resize and scroll listeners (scroll with capture true)', () => {
     const addSpy = jest.spyOn(window, 'addEventListener');
 


### PR DESCRIPTION
## Summary

- Fixes #1053: Menu panel was visible at wrong position on first open due to `stylePos` being initialized as `{}`
- Initialize `stylePos` with `{ visibility: 'hidden' }` so the panel stays invisible during the first `requestAnimationFrame` position computation
- Once `compute()` calls `setStylePos` with `position: fixed` + coordinates, `visibility` is not included so the panel becomes visible normally

## Test plan

- Added two new tests using red-green TDD:
  - `panel has visibility:hidden on first open before position is computed` — verifies the panel is hidden when RAF hasn't run yet
  - `panel becomes visible after position is computed` — verifies `visibility` is not `hidden` after the layout effect computes the correct position
- All 26 tests in `Menu.test.tsx` pass

https://claude.ai/code/session_01PdfMEKXjiW6eenm6oWzd9i

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdfMEKXjiW6eenm6oWzd9i)_