### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/read-config-file/package.json
+++ b/packages/read-config-file/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@ttoss/read-config-file",
   "version": "2.2.20",
+  "bugs": {
+    "url": "https://github.com/ttoss/ttoss/issues"
+  },
   "description": "Read a configuration file",
   "keywords": [
     "config",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/read-config-file/package.json`.