### PR TITLE
fix(website): generate markdown files for llms.txt references

### DIFF
--- a/docs/website/docusaurus.config.ts
+++ b/docs/website/docusaurus.config.ts
@@ -47,6 +47,9 @@ const config: Config = {
           'docusaurus-plugin-llms',
           {
             generateMarkdownFiles: true,
+            excludeImports: true,
+            removeDuplicateHeadings: true,
+            includeBlog: true,
           },
         ],
     './plugins/principles-graph/index.mjs',

--- a/docs/website/docusaurus.config.ts
+++ b/docs/website/docusaurus.config.ts
@@ -41,7 +41,14 @@ const config: Config = {
   },
 
   plugins: [
-    isDevelopment ? null : 'docusaurus-plugin-llms',
+    isDevelopment
+      ? null
+      : [
+          'docusaurus-plugin-llms',
+          {
+            generateMarkdownFiles: true,
+          },
+        ],
     './plugins/principles-graph/index.mjs',
     /**
      * Only include these plugins in production. We remove them in development


### PR DESCRIPTION
## Summary

- Enables `generateMarkdownFiles: true` in `docusaurus-plugin-llms` config
- Without this, `llms.txt` listed links like `https://ttoss.dev/docs/ai/01-ai.md` that returned 404 because no `.md` files were written to the static output
- With this option, the plugin writes individual `.md` files into the build so all links in `llms.txt` resolve correctly

## Test plan

- [ ] Run `docusaurus build` (production) and verify `.md` files appear under `build/docs/`
- [ ] Check `https://ttoss.dev/llms.txt` after deploy — all links should return 200

https://claude.ai/code/session_015hjew9Z1P6kaYzDQGmy9MK

---
_Generated by [Claude Code](https://claude.ai/code/session_015hjew9Z1P6kaYzDQGmy9MK)_