### PR TITLE
feat(http-server-auth): pass ctx to auth callbacks + MCP OAuth guideline

### DIFF
--- a/docs/website/docs/engineering/06-guidelines/mcp-server-oauth.md
+++ b/docs/website/docs/engineering/06-guidelines/mcp-server-oauth.md
@@ -1,0 +1,153 @@
+---
+title: MCP Server with OAuth
+---
+
+This guideline shows how to build a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that authenticates MCP clients (Claude, Cursor, VS Code) with OAuth 2.1, using **only ttoss packages**. No external auth framework is required: [`@ttoss/http-server`](/docs/modules/packages/http-server) provides the Koa runtime, [`@ttoss/http-server-mcp`](/docs/modules/packages/http-server-mcp) provides both halves of MCP authorization, and [`@ttoss/auth-core`](/docs/modules/packages/auth-core) provides the token primitives. Your app keeps its own user model, signing keys, and login UI — ttoss owns only the protocol mechanics.
+
+## The two halves
+
+OAuth for MCP splits into two independent responsibilities. A server can play either role, or both.
+
+```mermaid
+flowchart LR
+    Client[MCP Client] -->|1 discover & login| AS[Authorization Server]
+    AS -->|2 access token| Client
+    Client -->|3 Bearer token| RS[Resource Server]
+    RS -->|4 verify| RS
+    RS -->|5 tool result| Client
+
+    subgraph ttoss [only ttoss packages]
+        AS
+        RS
+    end
+```
+
+The **resource server** is the MCP endpoint itself: it verifies the Bearer token on every request and runs tools. The **authorization server** issues those tokens through the standard `/authorize` → `/token` flow. If you authenticate against an existing provider (Amazon Cognito, Auth0), you only need the resource-server half. If your app issues its own tokens, you add the authorization-server half too.
+
+## Resource server: verifying tokens
+
+`createMcpRouter` gates every request through its `auth` option. Invalid or missing tokens get `401 Unauthorized` before any tool runs.
+
+### Against Amazon Cognito
+
+Pass `cognitoUserPool` and the router builds a `CognitoJwtVerifier` (from `@ttoss/auth-core`) internally:
+
+```typescript
+import { App, bodyParser, cors } from '@ttoss/http-server';
+import { createMcpRouter, McpServer, z } from '@ttoss/http-server-mcp';
+
+const mcpServer = new McpServer({ name: 'my-mcp-server', version: '1.0.0' });
+
+mcpServer.registerTool(
+  'get-weather',
+  { description: 'Get weather', inputSchema: { location: z.string() } },
+  async ({ location }) => ({
+    content: [{ type: 'text', text: `Weather in ${location}: Sunny` }],
+  })
+);
+
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: {
+      userPoolId: process.env.COGNITO_USER_POOL_ID!,
+      clientId: process.env.COGNITO_CLIENT_ID!,
+    },
+    // Advertise where clients should obtain tokens (OAuth discovery).
+    resourceServerUrl: 'https://mcp.example.com',
+    authorizationServerUrl: process.env.COGNITO_ISSUER_URL!,
+  },
+});
+
+const app = new App();
+app.use(cors());
+app.use(bodyParser());
+app.use(mcpRouter.routes());
+app.listen(3000);
+```
+
+### Against your own tokens
+
+When your app signs its own JWTs with `@ttoss/auth-core`, verify them with a custom `verifyToken`. The contract is minimal: resolve with an identity payload, or throw to reject.
+
+```typescript
+import { verifyJwt } from '@ttoss/auth-core';
+import { createMcpRouter } from '@ttoss/http-server-mcp';
+
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    verifyToken: async (token) => {
+      const payload = verifyJwt({ token, secret: process.env.JWT_SECRET! });
+      if (!payload) throw new Error('Invalid token');
+      return payload;
+    },
+    resourceServerUrl: 'https://mcp.example.com',
+    authorizationServerUrl: 'https://api.example.com',
+  },
+});
+```
+
+Opaque API tokens work the same way — hash the presented token with `@ttoss/auth-core` and look it up in your database, throwing when it is missing or revoked. See the [`@ttoss/http-server-mcp` README](/docs/modules/packages/http-server-mcp) for the opaque-token recipe and the `getIdentity()` / `checkScopes()` helpers used inside tool handlers.
+
+## Authorization server: issuing tokens
+
+To make your server first-party — so an MCP client discovers it, registers itself, and runs the full login flow against it — add `createMcpAuthServer`. ttoss owns only PKCE, discovery metadata, code exchange, and dynamic client registration; everything app-specific stays behind pluggable hooks.
+
+```typescript
+import { signJwt } from '@ttoss/auth-core';
+import { App, bodyParser } from '@ttoss/http-server';
+import { createMcpAuthServer } from '@ttoss/http-server-mcp';
+
+const authServer = createMcpAuthServer({
+  issuer: 'https://api.example.com',
+  clientStore, // dynamic client register/lookup, in your datastore
+  authCodeStore, // short-lived codes + PKCE challenge, in your datastore
+  // App-owned token minting — ttoss never sees your signing keys.
+  issueTokens: async ({ subject, scopes }) => ({
+    accessToken: signJwt({
+      payload: { sub: subject, scope: scopes.join(' ') },
+      secret: process.env.JWT_SECRET!,
+      expiresInSeconds: 3600,
+    }),
+    expiresIn: 3600,
+  }),
+  // App-owned login/consent — render your own UI, then approve.
+  onAuthorize: async ({ ctx, request }) => {
+    const session = await getSession(ctx);
+    if (!session) {
+      ctx.redirect(`/login?return_to=${encodeURIComponent(ctx.url)}`);
+      return { approved: false };
+    }
+    return { approved: true, subject: session.userId, scopes: request.scopes };
+  },
+  scopesSupported: ['mcp:access'],
+});
+
+const app = new App();
+app.use(bodyParser());
+app.use(authServer.routes());
+```
+
+This mounts the discovery (`/.well-known/oauth-authorization-server`), `/authorize`, `/token`, and `/register` endpoints that MCP clients auto-discover. Pair it with the `verifyToken` resource server above so the same deployment both issues and verifies its tokens. The endpoint table and store interfaces are documented in the [package README](/docs/modules/packages/http-server-mcp#oauth-21-authorization-server).
+
+## Enforcing scopes
+
+Gate the whole endpoint with `requiredScopes` (returns `403` before any tool runs), or call `checkScopes()` inside individual handlers for per-tool control:
+
+```typescript
+createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: { userPoolId: '...', clientId: '...' },
+    requiredScopes: ['mcp:access'],
+  },
+});
+```
+
+## Choosing your setup
+
+| You authenticate against… | Use                                                                  |
+| ------------------------- | -------------------------------------------------------------------- |
+| Amazon Cognito            | `createMcpRouter({ auth: { cognitoUserPool } })`                     |
+| Another OAuth provider    | `createMcpRouter({ auth: { verifyToken } })` with `jose`             |
+| Tokens your app issues    | `createMcpAuthServer` + `createMcpRouter({ auth: { verifyToken } })` |
+
+In every case the only runtime dependencies are ttoss packages. Refer to the [`@ttoss/http-server-mcp`](/docs/modules/packages/http-server-mcp) and [`@ttoss/auth-core`](/docs/modules/packages/auth-core) documentation for the complete API surface.

--- a/packages/http-server-auth/README.md
+++ b/packages/http-server-auth/README.md
@@ -27,8 +27,10 @@ app.use(
     },
 
     apiToken: {
-      lookup: async (tokenHash) => {
-        const record = await ApiTokenModel.findOne({
+      // The second argument is the Koa `ctx`, so the lookup can do
+      // request-scoped work (read `ctx.db`, bump `lastUsedAt`, etc.).
+      lookup: async (tokenHash, ctx) => {
+        const record = await ctx.db.ApiToken.findOne({
           where: { tokenHash, revoked: false },
         });
         if (!record) return null;
@@ -115,7 +117,9 @@ type AuthenticatedUser = {
 1. Reads `Authorization: Bearer <token>`; missing header → 401 if `required`.
 2. If `allowedOrigins` is configured and the `Origin` header doesn't match → 403. Requests without an Origin header are never rejected.
 3. Tries each strategy in `strategies` order; first match wins.
-   - `jwt` — verifies HS256 JWT via `@ttoss/auth-core verifyJwt`; maps `sub`/`email` to user (override with `jwt.mapPayload`).
-   - `apiToken` — hashes the token (SHA-256) and calls `apiToken.lookup(hash)`.
+   - `jwt` — verifies HS256 JWT via `@ttoss/auth-core verifyJwt`; maps `sub`/`email` to user (override with `jwt.mapPayload(payload, ctx)`).
+   - `apiToken` — hashes the token (SHA-256) and calls `apiToken.lookup(hash, ctx)`.
    - `system` — constant-time comparison against `system.secret`.
 4. All strategies fail and `required` → 401. Failure reason is never leaked.
+
+Both `apiToken.lookup` and `jwt.mapPayload` receive the Koa `ctx` as a second argument, enabling request-scoped work (e.g. reading a per-request connection off `ctx.db` or updating `lastUsedAt`). The single-argument signatures keep working — `ctx` is purely additive.

--- a/packages/http-server-auth/src/authMiddleware.ts
+++ b/packages/http-server-auth/src/authMiddleware.ts
@@ -12,11 +12,15 @@ import type {
   SystemOptions,
 } from './types';
 
-const tryJwt = (token: string, opts: JwtOptions): AuthenticatedUser | null => {
+const tryJwt = (
+  token: string,
+  opts: JwtOptions,
+  ctx: Context
+): AuthenticatedUser | null => {
   const payload = verifyJwt({ token, secret: opts.secret });
   if (!payload) return null;
   if (opts.mapPayload)
-    return opts.mapPayload(payload as Record<string, unknown>);
+    return opts.mapPayload(payload as Record<string, unknown>, ctx);
   return {
     id: String(payload.sub ?? ''),
     ...(payload.email !== undefined && { email: String(payload.email) }),
@@ -25,9 +29,10 @@ const tryJwt = (token: string, opts: JwtOptions): AuthenticatedUser | null => {
 
 const tryApiToken = async (
   token: string,
-  opts: ApiTokenOptions
+  opts: ApiTokenOptions,
+  ctx: Context
 ): Promise<AuthenticatedUser | null> => {
-  return opts.lookup(hashApiToken(token));
+  return opts.lookup(hashApiToken(token), ctx);
 };
 
 const trySystem = (
@@ -42,15 +47,16 @@ const trySystem = (
 
 const resolveUser = async (
   token: string,
-  options: AuthMiddlewareOptions
+  options: AuthMiddlewareOptions,
+  ctx: Context
 ): Promise<{ user: AuthenticatedUser; strategy: string } | null> => {
   for (const strategy of options.strategies) {
     let user: AuthenticatedUser | null = null;
 
     if (strategy === 'jwt' && options.jwt) {
-      user = tryJwt(token, options.jwt);
+      user = tryJwt(token, options.jwt, ctx);
     } else if (strategy === 'apiToken' && options.apiToken) {
-      user = await tryApiToken(token, options.apiToken);
+      user = await tryApiToken(token, options.apiToken, ctx);
     } else if (strategy === 'system' && options.system) {
       user = trySystem(token, options.system);
     }
@@ -87,7 +93,7 @@ export const authMiddleware = (options: AuthMiddlewareOptions) => {
       return next();
     }
 
-    const result = await resolveUser(token, options);
+    const result = await resolveUser(token, options, ctx);
 
     if (!result) {
       if (required) ctx.throw(401, 'Unauthorized');

--- a/packages/http-server-auth/src/types.ts
+++ b/packages/http-server-auth/src/types.ts
@@ -1,3 +1,5 @@
+import type { Context } from '@ttoss/http-server';
+
 export type AuthenticatedUser = {
   id: string;
   email?: string;
@@ -11,16 +13,28 @@ export type JwtOptions = {
   /**
    * Override how the JWT payload maps to an AuthenticatedUser.
    * Defaults to `{ id: payload.sub, email: payload.email }`.
+   *
+   * Receives the Koa `ctx` as a second argument so the mapping can do
+   * request-scoped work (e.g. reading from `ctx.db`).
    */
-  mapPayload?: (payload: Record<string, unknown>) => AuthenticatedUser | null;
+  mapPayload?: (
+    payload: Record<string, unknown>,
+    ctx: Context
+  ) => AuthenticatedUser | null;
 };
 
 export type ApiTokenOptions = {
   /**
    * Receives the SHA-256 hash of the presented token and returns the
    * authenticated user, or null if not found / revoked.
+   *
+   * Receives the Koa `ctx` as a second argument so the lookup can do
+   * request-scoped work (e.g. bumping `lastUsedAt` or reading `ctx.db`).
    */
-  lookup: (tokenHash: string) => Promise<AuthenticatedUser | null>;
+  lookup: (
+    tokenHash: string,
+    ctx: Context
+  ) => Promise<AuthenticatedUser | null>;
 };
 
 export type SystemOptions = {

--- a/packages/http-server-auth/tests/unit/jest.config.ts
+++ b/packages/http-server-auth/tests/unit/jest.config.ts
@@ -3,7 +3,7 @@ import { jestUnitConfig } from '@ttoss/config';
 export default jestUnitConfig({
   coverageThreshold: {
     global: {
-      branches: 95,
+      branches: 96.2,
       functions: 100,
       lines: 100,
       statements: 100,

--- a/packages/http-server-auth/tests/unit/tests/authMiddleware.test.ts
+++ b/packages/http-server-auth/tests/unit/tests/authMiddleware.test.ts
@@ -74,6 +74,25 @@ describe('jwt strategy', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(res.body.user.id).toBe('mapped_user_1');
   });
+
+  test('passes ctx to mapPayload', async () => {
+    const mapPayload = jest.fn((p, ctx) => {
+      return { id: String(p.sub), method: ctx.method };
+    });
+    const appCustomMap = makeApp({
+      strategies: ['jwt'],
+      jwt: { secret: jwtSecret, mapPayload },
+    });
+    const token = signJwt({ payload: { sub: 'user_1' }, secret: jwtSecret });
+    const res = await request(appCustomMap.callback())
+      .get('/')
+      .set('Authorization', `Bearer ${token}`);
+    expect(mapPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'user_1' }),
+      expect.anything()
+    );
+    expect(res.body.user.method).toBe('GET');
+  });
 });
 
 // apiToken strategy
@@ -106,11 +125,40 @@ describe('apiToken strategy', () => {
     expect(res.status).toBe(401);
   });
 
-  test('calls lookup with SHA-256 hash of the token', async () => {
+  test('calls lookup with SHA-256 hash of the token and ctx', async () => {
     await request(app.callback())
       .get('/')
       .set('Authorization', 'Bearer my-api-token');
-    expect(lookup).toHaveBeenCalledWith(storedHash);
+    expect(lookup).toHaveBeenCalledWith(storedHash, expect.anything());
+  });
+
+  test('passes ctx to lookup so it can do request-scoped work', async () => {
+    const lastUsed: string[] = [];
+    const lookupWithCtx = jest.fn(async (tokenHash: string, ctx) => {
+      if (tokenHash !== storedHash) return null;
+      // mutate request-scoped state via ctx, e.g. bumping lastUsedAt
+      ctx.state.lastUsedAt = 'now';
+      lastUsed.push(ctx.method);
+      return { id: 'user_2' };
+    });
+    const appWithCtx = new App();
+    appWithCtx.use(
+      authMiddleware({
+        strategies: ['apiToken'],
+        apiToken: { lookup: lookupWithCtx },
+      })
+    );
+    appWithCtx.use((ctx) => {
+      ctx.body = { lastUsedAt: ctx.state.lastUsedAt };
+    });
+
+    const res = await request(appWithCtx.callback())
+      .get('/')
+      .set('Authorization', 'Bearer my-api-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.lastUsedAt).toBe('now');
+    expect(lastUsed).toEqual(['GET']);
   });
 });
 


### PR DESCRIPTION
Closes #1058

## 1. `@ttoss/http-server-auth` — pass request `ctx` to auth callbacks

The auth strategies (`apiToken.lookup`, `jwt.mapPayload`) previously received only the extracted credential. This adds the Koa `ctx` as an **additive, non-breaking** second argument so apps can do request-scoped work inside the verifier:

```ts
apiToken: { lookup: (tokenHash, ctx) => Promise<AuthenticatedUser | null> }
jwt:      { mapPayload?: (payload, ctx) => AuthenticatedUser | null }
```

This unlocks use cases like bumping `lastUsedAt` on the token row per request, or reaching `ctx.db` / a per-request connection instead of forcing a module-level DB singleton.

**Changes**
- `types.ts` — added `ctx: Context` as second arg to `ApiTokenOptions.lookup` and `JwtOptions.mapPayload`.
- `authMiddleware.ts` — threaded `ctx` through `resolveUser` → `tryJwt` / `tryApiToken`.
- Tests — added coverage asserting `ctx` is passed to both callbacks and that state mutated via `ctx` inside `lookup` persists to downstream middleware.
- `README.md` — documented the new `ctx` argument.

**Compatibility** — existing single-argument signatures keep working; `ctx` is purely additive.

**Testing** — `pnpm run test`: 33 passed (100% statements/functions/lines, 96.29% branch). Bumped `coverageThreshold.branches` to 96.2.

## 2. Engineering guideline — MCP server with OAuth

Adds `docs/engineering/guidelines/mcp-server-oauth.md` showing how to build an MCP server with OAuth 2.1 authentication using **only ttoss packages** (`@ttoss/http-server`, `@ttoss/http-server-mcp`, `@ttoss/auth-core`). Covers both halves of MCP authorization — the resource server (`createMcpRouter` with Cognito, custom, or opaque-token verification) and the authorization server (`createMcpAuthServer`) — with a Mermaid diagram and a decision table.

---

Note: the monorepo-wide `turbo run build` currently fails on an unrelated, pre-existing environment issue (`babel-plugin-formatjs` / `@babel/helper-plugin-utils` module linking in `@ttoss/i18n-cli#build-config`) — not caused by this change.

https://claude.ai/code/session_01HttQQG4AcChtbMCQktTbas