### PR TITLE
feat(http-server-mcp): public MCP methods and RFC 9728 discovery in createMcpRouter

### DIFF
--- a/docs/website/docs/engineering/06-guidelines/mcp-server-oauth.md
+++ b/docs/website/docs/engineering/06-guidelines/mcp-server-oauth.md
@@ -26,7 +26,7 @@ The **resource server** is the MCP endpoint itself: it verifies the Bearer token
 
 ## Resource server: verifying tokens
 
-`createMcpRouter` gates every request through its `auth` option. Invalid or missing tokens get `401 Unauthorized` before any tool runs.
+`createMcpRouter` gates requests through its `auth` option. Invalid or missing tokens get `401 Unauthorized` before any tool runs — except for the MCP lifecycle methods `initialize` and `tools/list`, which stay public so a client can discover the server before it has a token (see [Client discovery](#client-discovery)).
 
 ### Against Amazon Cognito
 
@@ -87,6 +87,27 @@ const mcpRouter = createMcpRouter(mcpServer, {
 ```
 
 Opaque API tokens work the same way — hash the presented token with `@ttoss/auth-core` and look it up in your database, throwing when it is missing or revoked. See the [`@ttoss/http-server-mcp` README](/docs/modules/packages/http-server-mcp) for the opaque-token recipe and the `getIdentity()` / `checkScopes()` helpers used inside tool handlers.
+
+### Client discovery
+
+The [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) requires two behaviors so clients like Claude and Cursor can bootstrap OAuth without being pre-configured, and `createMcpRouter` handles both. The lifecycle methods `initialize` and `tools/list` bypass verification so the client can discover the server before authenticating — override the set with `publicMethods` (pass `[]` to require a token for every method). And when `resourceMetadataUrl` is set, a `401` advertises the [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) protected-resource document via `WWW-Authenticate: Bearer resource_metadata="…"`, pointing the client at the metadata that names the authorization server.
+
+```typescript
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: { userPoolId: '...', clientId: '...' },
+    resourceServerUrl: 'https://mcp.example.com',
+    authorizationServerUrl: process.env.COGNITO_ISSUER_URL!,
+    // Emit RFC 9728 discovery on 401.
+    resourceMetadataUrl:
+      'https://mcp.example.com/.well-known/oauth-protected-resource',
+    // Defaults to ['initialize', 'tools/list'].
+    publicMethods: ['initialize', 'tools/list'],
+  },
+});
+```
+
+Setting both `resourceServerUrl` and `authorizationServerUrl` also serves that metadata document at `/.well-known/oauth-protected-resource`, completing the discovery chain the `WWW-Authenticate` header points to.
 
 ## Authorization server: issuing tokens
 

--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -129,7 +129,7 @@ const data = await apiCall('GET', 'https://partner.api.com/data', {
 
 ## Authentication
 
-`createMcpRouter` supports OAuth 2.0 Bearer token authentication via the `auth` option. Every incoming MCP request must include a valid `Authorization: Bearer <token>` header — invalid or missing tokens receive a `401 Unauthorized` response.
+`createMcpRouter` supports OAuth 2.0 Bearer token authentication via the `auth` option. Incoming MCP requests must include a valid `Authorization: Bearer <token>` header — invalid or missing tokens receive a `401 Unauthorized` response. The MCP lifecycle methods `initialize` and `tools/list` are exempt by default so clients can discover the server before authenticating (see [Public methods and discovery](#public-methods-and-discovery)).
 
 ```mermaid
 sequenceDiagram
@@ -315,6 +315,31 @@ app.use(createMcpRouter(mcpServer).routes());
 
 The `WWW-Authenticate: Bearer resource_metadata="…"` header is how MCP clients bootstrap OAuth discovery after their first unauthorized request.
 
+### Public methods and discovery
+
+The two behaviors the [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) requires for client bootstrapping are built into the `auth` option, so you no longer need the hand-rolled middleware shown above:
+
+- **`publicMethods`** — JSON-RPC methods that bypass verification, read from the request body's `method` field. Defaults to `['initialize', 'tools/list']` so clients can discover the server before authenticating. Pass `[]` to require a token for every method, or a custom list to change the exempt set.
+- **`resourceMetadataUrl`** — when set, a `401` responds with `WWW-Authenticate: Bearer resource_metadata="<resourceMetadataUrl>"` (RFC 9728) instead of a bare `Bearer`, pointing MCP clients at the protected-resource metadata document. When omitted, the header falls back to `Bearer`.
+
+```typescript
+createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: { userPoolId: '...', clientId: '...' },
+    // Serve the metadata document (unauthenticated)...
+    resourceServerUrl: 'https://mcp.example.com',
+    authorizationServerUrl:
+      'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxx',
+    // ...and point 401s at it for auto-discovery.
+    resourceMetadataUrl:
+      'https://mcp.example.com/.well-known/oauth-protected-resource',
+    // publicMethods defaults to ['initialize', 'tools/list'].
+  },
+});
+```
+
+Both fields are optional. Omitting `resourceMetadataUrl` keeps the bare `Bearer` header, and the `publicMethods` default matches what MCP clients expect for discovery.
+
 ## OAuth 2.1 Authorization Server
 
 The `auth` option above covers the **resource-server** half of MCP authorization — it verifies tokens issued by an external authorization server (Cognito, Auth0, …). When you want your own first-party server to _issue_ the tokens, `createMcpAuthServer` provides the **authorization-server** half: the `/authorize`, `/token`, `/register`, and discovery endpoints an MCP client (Claude, Cursor, VS Code) auto-discovers and runs the full OAuth 2.1 flow against.
@@ -403,6 +428,8 @@ Creates a Koa router configured to handle MCP protocol requests.
     - `auth.verifyToken` — Custom async token verifier `(token: string) => Promise<unknown>`
     - `auth.requiredScopes` — Router-level scope guard; returns 403 if any scope is missing
     - `auth.resourceServerUrl` + `auth.authorizationServerUrl` — Enable `/.well-known/oauth-protected-resource`
+    - `auth.publicMethods` — JSON-RPC methods that bypass verification (default `['initialize', 'tools/list']`)
+    - `auth.resourceMetadataUrl` — Emit RFC 9728 `WWW-Authenticate: Bearer resource_metadata="…"` on 401
 
 **Returns:** `Router` — Koa router instance
 

--- a/packages/http-server-mcp/src/auth.ts
+++ b/packages/http-server-mcp/src/auth.ts
@@ -1,0 +1,177 @@
+import { CognitoJwtVerifier } from '@ttoss/auth-core/amazon-cognito';
+import type { Router } from '@ttoss/http-server';
+import type Koa from 'koa';
+
+type Context = Koa.Context;
+
+/** Amazon Cognito user pool configuration for JWT verification. */
+export interface CognitoUserPoolConfig {
+  /** The Cognito User Pool ID (e.g. `us-east-1_abc123`). */
+  userPoolId: string;
+  /**
+   * Which token type to verify.
+   * @default 'access'
+   */
+  tokenUse?: 'access' | 'id';
+  /** The app client ID registered in the User Pool. */
+  clientId: string;
+}
+
+/**
+ * Authentication options for the MCP router.
+ *
+ * Supply either `cognitoUserPool` (uses `CognitoJwtVerifier` from
+ * `@ttoss/auth-core`) or a custom `verifyToken` function — not both.
+ */
+export interface McpAuthOptions {
+  /**
+   * Amazon Cognito user pool config. When provided, the router creates a
+   * `CognitoJwtVerifier` and validates every incoming Bearer token against it.
+   */
+  cognitoUserPool?: CognitoUserPoolConfig;
+  /**
+   * Custom token verifier for non-Cognito providers (Auth0, Keycloak, …).
+   * Receives the raw Bearer token string. Should resolve with the verified
+   * payload or reject/throw on failure.
+   */
+  verifyToken?: (token: string) => Promise<unknown>;
+  /**
+   * Router-level scope guard. All listed scopes must be present on the token
+   * for any MCP request to be allowed. Returns 403 if any scope is missing.
+   *
+   * Cognito encodes scopes as a space-separated string in `payload.scope`.
+   *
+   * @example ['mcp:access']
+   */
+  requiredScopes?: string[];
+  /**
+   * URL of this MCP server, used in the OAuth Protected Resource Metadata
+   * response (`/.well-known/oauth-protected-resource`). Both this field and
+   * `authorizationServerUrl` must be provided to enable the endpoint.
+   */
+  resourceServerUrl?: string;
+  /**
+   * URL of the OAuth Authorization Server that issues tokens for this resource.
+   * Enables `/.well-known/oauth-protected-resource` for MCP client auto-discovery
+   * (RFC 9728) when combined with `resourceServerUrl`.
+   */
+  authorizationServerUrl?: string;
+  /**
+   * JSON-RPC methods (read from `body.method`) that bypass token verification,
+   * so MCP clients can discover the server before authenticating. Set to an
+   * empty array to require a token for every method.
+   *
+   * @default ['initialize', 'tools/list']
+   */
+  publicMethods?: string[];
+  /**
+   * When set, a `401` from verification responds with
+   * `WWW-Authenticate: Bearer resource_metadata="<resourceMetadataUrl>"`
+   * (RFC 9728) so MCP clients can auto-discover the authorization server.
+   * When omitted, the header falls back to a bare `Bearer`.
+   *
+   * @example 'https://mcp.example.com/.well-known/oauth-protected-resource'
+   */
+  resourceMetadataUrl?: string;
+}
+
+/** MCP lifecycle/discovery methods reachable before a client authenticates. */
+const DEFAULT_PUBLIC_METHODS = ['initialize', 'tools/list'];
+
+/**
+ * Builds the token verifier from the auth options, preferring an explicit
+ * `verifyToken` and otherwise creating a `CognitoJwtVerifier`.
+ */
+export const buildTokenVerifier = (
+  auth: McpAuthOptions
+): ((token: string) => Promise<unknown>) => {
+  if (auth.cognitoUserPool) {
+    const v = CognitoJwtVerifier.create({
+      tokenUse: 'access',
+      ...auth.cognitoUserPool,
+    });
+    return (t) => {
+      return v.verify(t);
+    };
+  }
+  if (auth.verifyToken) {
+    return auth.verifyToken;
+  }
+  throw new Error(
+    'McpAuthOptions requires either cognitoUserPool or verifyToken'
+  );
+};
+
+/** Returns true when the identity carries every required scope (or none are required). */
+const hasRequiredScopes = (
+  requiredScopes: string[] | undefined,
+  identity: unknown
+): boolean => {
+  if (!requiredScopes?.length) {
+    return true;
+  }
+  const scope = (identity as { scope?: string })?.scope ?? '';
+  const tokenScopes = scope.split(' ');
+  return requiredScopes.every((s) => {
+    return tokenScopes.includes(s);
+  });
+};
+
+/**
+ * Registers the token-verification middleware (with public-method bypass and
+ * RFC 9728 discovery) and, when configured, the OAuth protected-resource
+ * metadata endpoint on the given router.
+ */
+export const registerAuthRoutes = (
+  router: Router,
+  path: string,
+  auth: McpAuthOptions,
+  tokenVerifier: (token: string) => Promise<unknown>
+): void => {
+  const publicMethods = new Set(auth.publicMethods ?? DEFAULT_PUBLIC_METHODS);
+  const unauthorizedHeader = auth.resourceMetadataUrl
+    ? `Bearer resource_metadata="${auth.resourceMetadataUrl}"`
+    : 'Bearer';
+
+  router.use(path, async (ctx: Context, next) => {
+    // Public lifecycle/discovery methods bypass verification so clients can
+    // discover the server before they have a token (MCP authorization spec).
+    const method = (ctx.request.body as { method?: string } | undefined)
+      ?.method;
+    if (publicMethods.has(method ?? '')) {
+      await next();
+      return;
+    }
+
+    const authHeader = ctx.headers.authorization;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+
+    let identity: unknown;
+    try {
+      identity = await tokenVerifier(token);
+    } catch {
+      ctx.status = 401;
+      ctx.set('WWW-Authenticate', unauthorizedHeader);
+      ctx.body = 'Unauthorized';
+      return;
+    }
+
+    if (!hasRequiredScopes(auth.requiredScopes, identity)) {
+      ctx.status = 403;
+      ctx.body = 'Forbidden';
+      return;
+    }
+
+    (ctx.state as { identity?: unknown }).identity = identity;
+    await next();
+  });
+
+  if (auth.resourceServerUrl && auth.authorizationServerUrl) {
+    router.get('/.well-known/oauth-protected-resource', (ctx: Context) => {
+      ctx.body = {
+        resource: auth.resourceServerUrl,
+        authorization_servers: [auth.authorizationServerUrl],
+      };
+    });
+  }
+};

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -4,10 +4,15 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { CognitoJwtVerifier } from '@ttoss/auth-core/amazon-cognito';
 import { Router } from '@ttoss/http-server';
 import type Koa from 'koa';
 import { z } from 'zod';
+
+import {
+  buildTokenVerifier,
+  type McpAuthOptions,
+  registerAuthRoutes,
+} from './auth';
 
 type Context = Koa.Context;
 
@@ -191,60 +196,6 @@ export const checkScopes = (required: string[]): void => {
   }
 };
 
-/** Amazon Cognito user pool configuration for JWT verification. */
-export interface CognitoUserPoolConfig {
-  /** The Cognito User Pool ID (e.g. `us-east-1_abc123`). */
-  userPoolId: string;
-  /**
-   * Which token type to verify.
-   * @default 'access'
-   */
-  tokenUse?: 'access' | 'id';
-  /** The app client ID registered in the User Pool. */
-  clientId: string;
-}
-
-/**
- * Authentication options for the MCP router.
- *
- * Supply either `cognitoUserPool` (uses `CognitoJwtVerifier` from
- * `@ttoss/auth-core`) or a custom `verifyToken` function — not both.
- */
-export interface McpAuthOptions {
-  /**
-   * Amazon Cognito user pool config. When provided, the router creates a
-   * `CognitoJwtVerifier` and validates every incoming Bearer token against it.
-   */
-  cognitoUserPool?: CognitoUserPoolConfig;
-  /**
-   * Custom token verifier for non-Cognito providers (Auth0, Keycloak, …).
-   * Receives the raw Bearer token string. Should resolve with the verified
-   * payload or reject/throw on failure.
-   */
-  verifyToken?: (token: string) => Promise<unknown>;
-  /**
-   * Router-level scope guard. All listed scopes must be present on the token
-   * for any MCP request to be allowed. Returns 403 if any scope is missing.
-   *
-   * Cognito encodes scopes as a space-separated string in `payload.scope`.
-   *
-   * @example ['mcp:access']
-   */
-  requiredScopes?: string[];
-  /**
-   * URL of this MCP server, used in the OAuth Protected Resource Metadata
-   * response (`/.well-known/oauth-protected-resource`). Both this field and
-   * `authorizationServerUrl` must be provided to enable the endpoint.
-   */
-  resourceServerUrl?: string;
-  /**
-   * URL of the OAuth Authorization Server that issues tokens for this resource.
-   * Enables `/.well-known/oauth-protected-resource` for MCP client auto-discovery
-   * (RFC 9728) when combined with `resourceServerUrl`.
-   */
-  authorizationServerUrl?: string;
-}
-
 /**
  * Options for configuring the MCP router
  */
@@ -301,10 +252,13 @@ export interface McpRouterOptions {
   /**
    * OAuth / JWT authentication configuration for the MCP endpoint.
    *
-   * When set, every incoming MCP request must include a valid Bearer token in
-   * the `Authorization` header. Invalid or missing tokens receive a `401`
-   * response with `WWW-Authenticate: Bearer`. Tokens that fail a
-   * `requiredScopes` check receive `403`.
+   * When set, incoming MCP requests must include a valid Bearer token in the
+   * `Authorization` header — except for `publicMethods` (by default
+   * `initialize` and `tools/list`), which bypass verification so clients can
+   * discover the server before authenticating. Invalid or missing tokens
+   * receive a `401` response with `WWW-Authenticate: Bearer` (or
+   * `Bearer resource_metadata="..."` when `resourceMetadataUrl` is set, per
+   * RFC 9728). Tokens that fail a `requiredScopes` check receive `403`.
    *
    * The verified token payload is accessible inside tool handlers via
    * {@link getIdentity}. Fine-grained per-tool scope checks can be done with
@@ -331,74 +285,6 @@ export interface McpRouterOptions {
    */
   auth?: McpAuthOptions;
 }
-
-const buildTokenVerifier = (
-  auth: McpAuthOptions
-): ((token: string) => Promise<unknown>) => {
-  if (auth.cognitoUserPool) {
-    const v = CognitoJwtVerifier.create({
-      tokenUse: 'access',
-      ...auth.cognitoUserPool,
-    });
-    return (t) => {
-      return v.verify(t);
-    };
-  }
-  if (auth.verifyToken) {
-    return auth.verifyToken;
-  }
-  throw new Error(
-    'McpAuthOptions requires either cognitoUserPool or verifyToken'
-  );
-};
-
-const registerAuthRoutes = (
-  router: Router,
-  path: string,
-  auth: McpAuthOptions,
-  tokenVerifier: (token: string) => Promise<unknown>
-): void => {
-  router.use(path, async (ctx: Context, next) => {
-    const authHeader = ctx.headers.authorization;
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
-
-    let identity: unknown;
-    try {
-      identity = await tokenVerifier(token);
-    } catch {
-      ctx.status = 401;
-      ctx.set('WWW-Authenticate', 'Bearer');
-      ctx.body = 'Unauthorized';
-      return;
-    }
-
-    if (auth.requiredScopes?.length) {
-      const tokenScopes = ((identity as { scope?: string })?.scope ?? '').split(
-        ' '
-      );
-      const missing = auth.requiredScopes.filter((s) => {
-        return !tokenScopes.includes(s);
-      });
-      if (missing.length > 0) {
-        ctx.status = 403;
-        ctx.body = 'Forbidden';
-        return;
-      }
-    }
-
-    (ctx.state as { identity?: unknown }).identity = identity;
-    await next();
-  });
-
-  if (auth.resourceServerUrl && auth.authorizationServerUrl) {
-    router.get('/.well-known/oauth-protected-resource', (ctx: Context) => {
-      ctx.body = {
-        resource: auth.resourceServerUrl,
-        authorization_servers: [auth.authorizationServerUrl],
-      };
-    });
-  }
-};
 
 /**
  * Creates a Koa router configured to handle MCP protocol requests
@@ -835,6 +721,11 @@ export const createProtectedResourceMetadataMiddleware = (args: {
     await next();
   };
 };
+
+/**
+ * Re-export the MCP router authentication option types.
+ */
+export type { CognitoUserPoolConfig, McpAuthOptions } from './auth';
 
 /**
  * Re-export OAuth 2.1 Authorization Server primitives for MCP.

--- a/packages/http-server-mcp/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp/tests/unit/jest.config.ts
@@ -4,10 +4,10 @@ export default {
   ...jestUnitConfig(),
   coverageThreshold: {
     global: {
-      statements: 99.6,
-      branches: 94.2,
+      statements: 99.65,
+      branches: 95.0,
       functions: 99.9,
-      lines: 99.6,
+      lines: 99.65,
     },
   },
 };

--- a/packages/http-server-mcp/tests/unit/tests/auth.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/auth.test.ts
@@ -99,7 +99,7 @@ describe('auth — verifyToken', () => {
 
     const res = await request(app.callback())
       .post('/mcp')
-      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 1))
       .set('Content-Type', 'application/json')
       .set('Accept', MCP_ACCEPT);
 
@@ -114,7 +114,7 @@ describe('auth — verifyToken', () => {
 
     const res = await request(app.callback())
       .post('/mcp')
-      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 1))
       .set('Content-Type', 'application/json')
       .set('Accept', MCP_ACCEPT)
       .set('Authorization', 'Bearer bad-token');
@@ -175,7 +175,22 @@ describe('auth — verifyToken', () => {
 
     const res = await request(app.callback())
       .post('/mcp')
-      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 403 when the token carries no scope claim at all', async () => {
+    const app = buildApp(() => {
+      return Promise.resolve({ sub: 'u1' }); // no `scope` property
+    }, ['mcp:access']);
+
+    const res = await request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 1))
       .set('Content-Type', 'application/json')
       .set('Accept', MCP_ACCEPT)
       .set('Authorization', 'Bearer tok');
@@ -189,9 +204,18 @@ describe('auth — verifyToken', () => {
       return Promise.resolve(payload);
     }, ['mcp:access']);
 
-    const res = await request(app.callback())
+    const callback = app.callback();
+
+    await request(callback)
       .post('/mcp')
       .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+
+    const res = await request(callback)
+      .post('/mcp')
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 2))
       .set('Content-Type', 'application/json')
       .set('Accept', MCP_ACCEPT)
       .set('Authorization', 'Bearer tok');
@@ -275,6 +299,106 @@ describe('auth — verifyToken', () => {
   });
 });
 
+describe('auth — public methods and RFC 9728 discovery', () => {
+  const buildApp = (authOverrides: {
+    publicMethods?: string[];
+    resourceMetadataUrl?: string;
+  }) => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    mcpServer.registerTool(
+      'whoami',
+      { description: 'Returns identity', inputSchema: {} },
+      async () => {
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }
+    );
+
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          // Always rejects so any verified path returns 401.
+          verifyToken: () => {
+            return Promise.reject(new Error('invalid'));
+          },
+          ...authOverrides,
+        },
+      }).routes()
+    );
+    return app;
+  };
+
+  const post = (app: ReturnType<typeof buildApp>, method: string) => {
+    return request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest(method, initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT);
+  };
+
+  test('initialize is public by default (no token required)', async () => {
+    const res = await post(buildApp({}), 'initialize');
+    expect(res.status).not.toBe(401);
+  });
+
+  test('tools/list is public by default (no token required)', async () => {
+    const res = await post(buildApp({}), 'tools/list');
+    expect(res.status).not.toBe(401);
+  });
+
+  test('protected methods still require a token by default', async () => {
+    const res = await post(buildApp({}), 'tools/call');
+    expect(res.status).toBe(401);
+  });
+
+  test('publicMethods overrides the default set', async () => {
+    const app = buildApp({ publicMethods: ['ping'] });
+
+    // 'ping' now bypasses verification...
+    const pingRes = await post(app, 'ping');
+    expect(pingRes.status).not.toBe(401);
+
+    // ...while 'initialize' is no longer public.
+    const initRes = await post(app, 'initialize');
+    expect(initRes.status).toBe(401);
+  });
+
+  test('empty publicMethods requires a token for every method', async () => {
+    const res = await post(buildApp({ publicMethods: [] }), 'initialize');
+    expect(res.status).toBe(401);
+  });
+
+  test('a request without a method is treated as protected', async () => {
+    const res = await request(buildApp({}).callback())
+      .post('/mcp')
+      .send({ jsonrpc: '2.0', id: 1 })
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT);
+
+    expect(res.status).toBe(401);
+  });
+
+  test('401 emits RFC 9728 header when resourceMetadataUrl is set', async () => {
+    const app = buildApp({
+      resourceMetadataUrl:
+        'https://mcp.example.com/.well-known/oauth-protected-resource',
+    });
+    const res = await post(app, 'tools/call');
+
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toBe(
+      'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"'
+    );
+  });
+
+  test('401 falls back to bare Bearer when resourceMetadataUrl is omitted', async () => {
+    const res = await post(buildApp({}), 'tools/call');
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toBe('Bearer');
+  });
+});
+
 describe('auth — OAuth Protected Resource metadata endpoint', () => {
   test('serves /.well-known/oauth-protected-resource when configured', async () => {
     const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
@@ -352,7 +476,7 @@ describe('auth — cognitoUserPool', () => {
 
     const res = await request(app.callback())
       .post('/mcp')
-      .send(makeMcpRequest('initialize', initializeParams, 1))
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 1))
       .set('Content-Type', 'application/json')
       .set('Accept', MCP_ACCEPT)
       .set('Authorization', 'Bearer bad-token');
@@ -383,9 +507,19 @@ describe('auth — cognitoUserPool', () => {
       }).routes()
     );
 
-    const res = await request(app.callback())
+    const callback = app.callback();
+
+    await request(callback)
       .post('/mcp')
       .send(makeMcpRequest('initialize', initializeParams, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer valid-token');
+
+    // A protected method exercises the Cognito verifier.
+    const res = await request(callback)
+      .post('/mcp')
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 2))
       .set('Content-Type', 'application/json')
       .set('Accept', MCP_ACCEPT)
       .set('Authorization', 'Bearer valid-token');


### PR DESCRIPTION
Closes #1065.

## What

`createMcpRouter`'s `auth` option now handles the two pieces of MCP authorization that every consumer was re-implementing by hand: public lifecycle methods and RFC 9728 discovery. Two opt-in fields were added to `McpAuthOptions`:

- **`publicMethods`** — JSON-RPC methods (read from the request body's `method`) that bypass token verification, so clients can discover the server before authenticating. Defaults to `['initialize', 'tools/list']`. Pass `[]` to require a token for every method.
- **`resourceMetadataUrl`** — when set, a `401` responds with `WWW-Authenticate: Bearer resource_metadata="<url>"` (RFC 9728), letting clients like Claude and Cursor auto-discover the authorization server. When omitted, the header falls back to a bare `Bearer`.

This removes the glue middleware shown in the issue that consumers (e.g. myholdapp) copy-paste around the router.

## ⚠️ Behavioral change to note

Per the issue's spec, `publicMethods` defaults to `['initialize', 'tools/list']`. For existing `auth` consumers this means those two methods are now reachable **without** a token (previously the whole `/mcp` endpoint was gated). This matches the MCP authorization spec's discovery requirement, but it does expose the tool catalog (`tools/list`) unauthenticated. Set `publicMethods: []` to restore strict gating. The API itself is backward compatible — both fields are optional and no signatures changed.

## Implementation

- Auth logic extracted from `index.ts` into a new `src/auth.ts` module (`McpAuthOptions`, `CognitoUserPoolConfig`, `buildTokenVerifier`, `registerAuthRoutes`), keeping `index.ts` under the `max-lines` budget. The previously-public types are re-exported from the package root, so the public API is unchanged.
- Existing tests that sent `initialize` to assert `401`/`403` were updated to use a protected method, since `initialize` is now public by default.
- New tests cover: public-method bypass, default public set, `publicMethods` override and empty-set, missing-method requests, protected-method verification, the RFC 9728 header (present and omitted), and a token with no `scope` claim. `auth.ts` is at 100% coverage; thresholds bumped accordingly.

## Acceptance criteria

- [x] `createMcpRouter` accepts `publicMethods` and `resourceMetadataUrl`.
- [x] `initialize` and `tools/list` are public by default; `publicMethods` overrides the set.
- [x] A `401` with `resourceMetadataUrl` set emits `Bearer resource_metadata="..."` per RFC 9728.
- [x] Omitting both fields keeps the API backward compatible (see behavioral note above re: default public methods).
- [x] Tests cover public-method bypass, protected-method verification, 401 + header, and defaults.

## Docs

- Updated `docs/.../mcp-server-oauth.md` with a "Client discovery" section.
- Updated the `@ttoss/http-server-mcp` README with a "Public methods and discovery" section and the new option reference.

## Note on CI/build

`pnpm turbo run build` currently fails in this environment with a pre-existing toolchain error (`[BABEL]: request for '@babel/helper-plugin-utils' ... not been linked`) in the shared formatjs build plugin — reproducible on the untouched `@ttoss/i18n-cli` package, so it is unrelated to this change. The full test suite (119 tests) passes and lint is clean.

https://claude.ai/code/session_01R9WkRGcYQsgP65nBm6qxer

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9WkRGcYQsgP65nBm6qxer)_