### PR TITLE
feat(auth-core): refresh-token rotation + in-memory OAuth stores

### DIFF
--- a/docs/website/docs/engineering/06-guidelines/oauth-authorization-server.md
+++ b/docs/website/docs/engineering/06-guidelines/oauth-authorization-server.md
@@ -113,6 +113,38 @@ The `subject` you return is the only link between OAuth and your user model — 
 
 `POST /token` handles two grants ([RFC 6749](https://www.rfc-editor.org/rfc/rfc6749)). The `authorization_code` grant runs once at the end of login, verifying the PKCE `code_verifier` against the stored challenge before calling `issueTokens` and deleting the single-use code. The `refresh_token` grant lets a client renew an expired access token without sending the user back through login; it is enabled only when you supply `onRefreshToken`, which validates the presented token and returns the `subject` and `scopes` to re-issue (return `undefined` to reject). Omit `onRefreshToken` and refresh requests get `unsupported_grant_type`.
 
+## Refresh token rotation
+
+A self-validating JWT refresh token (as in the setup example) is simple but cannot be revoked before it expires and offers no protection if it leaks. When that matters, use **opaque, server-stored refresh tokens with rotation** — the OAuth 2.1 recommendation. `createRefreshRotation` from `@ttoss/auth-core` implements the mechanics that are a common source of security bugs when hand-rolled, against any [`RefreshTokenStore`](/docs/modules/packages/auth-core) backend (DynamoDB, Postgres, …): single use, expiry with sweep-on-access, scope narrowing, and **reuse detection** — replaying an already-rotated token revokes the owner's entire token set, forcing re-authentication.
+
+Wire it through the two existing hooks: `issue` mints a tracked token inside `issueTokens`, and the ready `onRefreshToken` validates and rotates.
+
+```typescript
+import { createRefreshRotation } from '@ttoss/auth-core';
+
+const refresh = createRefreshRotation({ store: refreshTokenStore });
+
+const authServer = oauthServer({
+  // …issuer, clientStore, authCodeStore, onAuthorize…
+  issueTokens: async ({ subject, scopes, client }) => ({
+    accessToken: signJwt({
+      payload: { sub: subject, scope: scopes.join(' ') },
+      secret: process.env.JWT_SECRET!,
+      expiresInSeconds: 3600,
+    }),
+    refreshToken: await refresh.issue({ client, subject, scopes }),
+    expiresIn: 3600,
+  }),
+  onRefreshToken: refresh.onRefreshToken,
+});
+```
+
+The store persists only token hashes — plaintext tokens never touch your database — keyed so the `(clientId, subject)` owner is the unit revoked on reuse.
+
+## In-memory reference stores
+
+`@ttoss/auth-core` ships `createMemoryClientStore`, `createMemoryAuthCodeStore`, and `createMemoryRefreshTokenStore` — `Map`-backed implementations of the three store contracts. They are for tests, local development, and examples (state is lost on restart); production swaps in a durable backend behind the same interfaces.
+
 ## Scopes
 
 Advertise the scopes your server issues via `scopesSupported`, and grant a subset per request in `onAuthorize`. Enforcement happens on the **resource server** that consumes the tokens: use `authMiddleware`'s `oauth` strategy with `requiredScopes` (from `@ttoss/http-server-auth`) to gate an endpoint, or check scopes per-route in your handler. The same option flows through `createMcpRouter`'s `auth` — see [MCP Server with OAuth](/docs/engineering/guidelines/mcp-server-oauth#enforcing-scopes).

--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -157,3 +157,31 @@ const res = await oauth.token({ query: {}, body, headers }); // { status, body }
 ```
 
 Your app keeps its user model, signing keys, and login/consent UI behind the hooks. See the [OAuth Authorization Server](https://ttoss.dev/docs/engineering/guidelines/oauth-authorization-server) guideline for the full flow.
+
+### Refresh token rotation
+
+`createRefreshRotation` implements opaque, server-stored refresh tokens with OAuth 2.1 rotation against any `RefreshTokenStore`: single use, expiry, scope narrowing, and reuse detection (replaying a rotated token revokes the owner's whole token set). Only token hashes are persisted. Wire `issue` into `issueTokens` and pass the ready `onRefreshToken` straight through.
+
+```ts
+import { createRefreshRotation } from '@ttoss/auth-core';
+
+const refresh = createRefreshRotation({ store: refreshTokenStore });
+
+createOAuthHandlers({
+  // …,
+  issueTokens: async ({ subject, scopes, client }) => ({
+    accessToken: signJwt({
+      payload: { sub: subject },
+      secret,
+      expiresInSeconds: 3600,
+    }),
+    refreshToken: await refresh.issue({ client, subject, scopes }),
+    expiresIn: 3600,
+  }),
+  onRefreshToken: refresh.onRefreshToken,
+});
+```
+
+### In-memory reference stores
+
+`createMemoryClientStore`, `createMemoryAuthCodeStore`, and `createMemoryRefreshTokenStore` are `Map`-backed implementations of the three store contracts — for tests, local development, and examples. Production swaps in a durable backend behind the same interfaces.

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -13,6 +13,11 @@ export {
 export { comparePassword, hashPassword, needsRehash } from './hash';
 export { type JwtPayload, signJwt, verifyJwt } from './jwt';
 export {
+  createMemoryAuthCodeStore,
+  createMemoryClientStore,
+  createMemoryRefreshTokenStore,
+} from './memoryStores';
+export {
   buildAuthorizationServerMetadata,
   buildProtectedResourceMetadata,
   generateAuthorizationCode,
@@ -44,7 +49,9 @@ export {
   type OnAuthorizeResult,
   type OnRefreshTokenArgs,
   type OnRefreshTokenResult,
+  type RefreshTokenStore,
   type StoredAuthorizationCode,
+  type StoredRefreshToken,
 } from './oauthServer';
 export {
   generateOneTimeToken,
@@ -52,6 +59,12 @@ export {
   type OneTimeToken,
   verifyOneTimeToken,
 } from './oneTimeToken';
+export {
+  createRefreshRotation,
+  type IssueRefreshTokenArgs,
+  type RefreshRotation,
+  type RefreshRotationOptions,
+} from './refreshTokenRotation';
 export {
   generateWebhookSecret,
   signWebhookPayload,

--- a/packages/auth-core/src/memoryStores.ts
+++ b/packages/auth-core/src/memoryStores.ts
@@ -1,0 +1,78 @@
+import type {
+  AuthCodeStore,
+  ClientStore,
+  OAuthClient,
+  RefreshTokenStore,
+  StoredAuthorizationCode,
+  StoredRefreshToken,
+} from './oauthServerTypes';
+
+/**
+ * In-memory reference {@link ClientStore}. Backed by a `Map`, so state is lost
+ * on restart — intended for tests, local development, and examples, not
+ * production. Seed it with pre-registered clients via `initial`.
+ */
+export const createMemoryClientStore = (
+  initial: OAuthClient[] = []
+): ClientStore => {
+  const clients = new Map<string, OAuthClient>(
+    initial.map((client) => {
+      return [client.client_id, client];
+    })
+  );
+  return {
+    get: (clientId) => {
+      return clients.get(clientId);
+    },
+    register: (client) => {
+      clients.set(client.client_id, client);
+    },
+  };
+};
+
+/**
+ * In-memory reference {@link AuthCodeStore}. Backed by a `Map` keyed by the
+ * authorization code; codes are removed on exchange (single use). For tests and
+ * local development only.
+ */
+export const createMemoryAuthCodeStore = (): AuthCodeStore => {
+  const codes = new Map<string, StoredAuthorizationCode>();
+  return {
+    save: (code) => {
+      codes.set(code.code, code);
+    },
+    get: (code) => {
+      return codes.get(code);
+    },
+    delete: (code) => {
+      codes.delete(code);
+    },
+  };
+};
+
+/**
+ * In-memory reference {@link RefreshTokenStore}. Backed by a `Map` keyed by the
+ * token hash, with owner-scoped revocation for reuse detection. For tests and
+ * local development only — production should persist tokens durably.
+ */
+export const createMemoryRefreshTokenStore = (): RefreshTokenStore => {
+  const tokens = new Map<string, StoredRefreshToken>();
+  return {
+    save: (token) => {
+      tokens.set(token.tokenHash, token);
+    },
+    get: (tokenHash) => {
+      return tokens.get(tokenHash);
+    },
+    delete: (tokenHash) => {
+      tokens.delete(tokenHash);
+    },
+    deleteByOwner: ({ clientId, subject }) => {
+      for (const [tokenHash, token] of tokens) {
+        if (token.clientId === clientId && token.subject === subject) {
+          tokens.delete(tokenHash);
+        }
+      }
+    },
+  };
+};

--- a/packages/auth-core/src/oauthServerTypes.ts
+++ b/packages/auth-core/src/oauthServerTypes.ts
@@ -116,6 +116,55 @@ export interface AuthCodeStore {
   delete: (code: string) => Promise<void> | void;
 }
 
+/**
+ * A persisted refresh token, stored by its hash (never the plaintext value) so
+ * a store compromise does not leak usable tokens. Owned by the
+ * {@link RefreshTokenStore}; minted and rotated by `createRefreshRotation`.
+ */
+export interface StoredRefreshToken {
+  /** SHA-256 hash (hex) of the opaque refresh token. Plaintext is never stored. */
+  tokenHash: string;
+  /** The `client_id` the token was issued to. */
+  clientId: string;
+  /** The authenticated end-user subject identifier. */
+  subject: string;
+  /** The scopes granted to this token. */
+  scopes: string[];
+  /** Unix timestamp (milliseconds) after which the token is invalid. */
+  expiresAt: number;
+  /**
+   * Unix timestamp (milliseconds) when the token was rotated (consumed). A
+   * consumed token that is presented again signals reuse (theft or a replay)
+   * and triggers revocation of the owner's whole token set.
+   */
+  consumedAt?: number;
+}
+
+/**
+ * App-provided store for refresh tokens, backing OAuth 2.1 rotation. The store
+ * is pure persistence — the rotation mechanics (single-use, expiry, reuse
+ * detection) live in `createRefreshRotation`. Back it with DynamoDB, Postgres,
+ * in-memory, … The "owner" of a token is the `(clientId, subject)` pair.
+ */
+export interface RefreshTokenStore {
+  /** Persist a refresh token, upserting by `tokenHash`. */
+  save: (token: StoredRefreshToken) => Promise<void> | void;
+  /** Look up a refresh token by its hash. Return `undefined` if unknown. */
+  get: (
+    tokenHash: string
+  ) => Promise<StoredRefreshToken | undefined> | StoredRefreshToken | undefined;
+  /** Remove a single refresh token by its hash. */
+  delete: (tokenHash: string) => Promise<void> | void;
+  /**
+   * Remove every refresh token belonging to an owner. Called on reuse detection
+   * to revoke the entire chain (the live token included), forcing re-auth.
+   */
+  deleteByOwner: (owner: {
+    clientId: string;
+    subject: string;
+  }) => Promise<void> | void;
+}
+
 // ---------------------------------------------------------------------------
 // Hook contracts (app-owned token minting, login/consent, refresh validation)
 // ---------------------------------------------------------------------------

--- a/packages/auth-core/src/refreshTokenRotation.ts
+++ b/packages/auth-core/src/refreshTokenRotation.ts
@@ -1,0 +1,181 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import type {
+  OAuthClient,
+  OnRefreshTokenArgs,
+  OnRefreshTokenResult,
+  RefreshTokenStore,
+} from './oauthServerTypes';
+
+/** Default refresh-token lifetime: 30 days. */
+const DEFAULT_REFRESH_TOKEN_TTL = 60 * 60 * 24 * 30;
+
+const base64Url = (buffer: Buffer): string => {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+};
+
+const defaultGenerateToken = (): string => {
+  return base64Url(randomBytes(32));
+};
+
+const defaultHashToken = (token: string): string => {
+  return createHash('sha256').update(token).digest('hex');
+};
+
+const isSubset = (requested: string[], granted: string[]): boolean => {
+  const grantedSet = new Set(granted);
+  return requested.every((scope) => {
+    return grantedSet.has(scope);
+  });
+};
+
+/** Configuration for {@link createRefreshRotation}. */
+export interface RefreshRotationOptions {
+  /** App-provided persistence for refresh tokens. */
+  store: RefreshTokenStore;
+  /**
+   * Refresh-token lifetime in seconds.
+   * @default 2592000 (30 days)
+   */
+  refreshTokenTtl?: number;
+  /**
+   * Override the opaque-token generator. Defaults to 32 random bytes,
+   * base64url-encoded. Useful for deterministic tests.
+   */
+  generateToken?: () => string;
+  /**
+   * Override the token hashing function used before persistence. Defaults to
+   * SHA-256 (hex). The plaintext token is never stored.
+   */
+  hashToken?: (token: string) => string;
+}
+
+/** Arguments for {@link RefreshRotation.issue}. */
+export interface IssueRefreshTokenArgs {
+  /** The client the token is issued to. */
+  client: OAuthClient;
+  /** The authenticated end-user subject identifier. */
+  subject: string;
+  /** The scopes granted to the token. */
+  scopes: string[];
+}
+
+/** The refresh-rotation helpers returned by {@link createRefreshRotation}. */
+export interface RefreshRotation {
+  /**
+   * Mint and persist a new opaque refresh token, returning the plaintext value
+   * to hand back to the client. Call this from your `issueTokens` hook so every
+   * issued refresh token is tracked for rotation.
+   */
+  issue: (args: IssueRefreshTokenArgs) => Promise<string>;
+  /**
+   * A ready `onRefreshToken` implementation: validates the presented token,
+   * enforces single use, expiry, and per-owner reuse detection, then approves
+   * the refresh. Pass it straight to `createOAuthHandlers`.
+   */
+  onRefreshToken: (args: OnRefreshTokenArgs) => Promise<OnRefreshTokenResult>;
+}
+
+/**
+ * Builds a backend-agnostic refresh-token rotation engine on top of a
+ * {@link RefreshTokenStore}. It implements the OAuth 2.1 rotation mechanics that
+ * are easy to get wrong by hand:
+ *
+ * - **Single use** — a refresh token is consumed (marked rotated) the first
+ *   time it is exchanged; a new one is minted by your `issueTokens` hook.
+ * - **Reuse detection** — presenting an already-consumed token signals theft or
+ *   replay, so the owner's *entire* token set is revoked, forcing re-auth.
+ * - **Expiry** — tokens past their TTL are rejected and swept on access.
+ * - **Scope narrowing** — a refresh request may request a subset of the granted
+ *   scopes; requesting a superset is rejected.
+ *
+ * The "owner" of a token is the `(clientId, subject)` pair, which is the unit
+ * revoked on reuse. Plaintext tokens are never persisted — only their hash.
+ *
+ * @example
+ * ```typescript
+ * const refresh = createRefreshRotation({ store });
+ * createOAuthHandlers({
+ *   // …,
+ *   issueTokens: async ({ subject, scopes, client }) => ({
+ *     accessToken: signJwt({ sub: subject, scope: scopes.join(' ') }),
+ *     refreshToken: await refresh.issue({ client, subject, scopes }),
+ *     expiresIn: 3600,
+ *   }),
+ *   onRefreshToken: refresh.onRefreshToken,
+ * });
+ * ```
+ */
+export const createRefreshRotation = (
+  options: RefreshRotationOptions
+): RefreshRotation => {
+  const {
+    store,
+    refreshTokenTtl = DEFAULT_REFRESH_TOKEN_TTL,
+    generateToken = defaultGenerateToken,
+    hashToken = defaultHashToken,
+  } = options;
+
+  const issue = async (args: IssueRefreshTokenArgs): Promise<string> => {
+    const token = generateToken();
+    await store.save({
+      tokenHash: hashToken(token),
+      clientId: args.client.client_id,
+      subject: args.subject,
+      scopes: args.scopes,
+      expiresAt: Date.now() + refreshTokenTtl * 1000,
+    });
+    return token;
+  };
+
+  const onRefreshToken = async (
+    args: OnRefreshTokenArgs
+  ): Promise<OnRefreshTokenResult> => {
+    const tokenHash = hashToken(args.refreshToken);
+    const stored = await store.get(tokenHash);
+
+    // Unknown token: reject without leaking whether it ever existed.
+    if (!stored) {
+      return undefined;
+    }
+
+    // Reuse of a rotated token: revoke the whole chain for this owner.
+    if (stored.consumedAt !== undefined) {
+      await store.deleteByOwner({
+        clientId: stored.clientId,
+        subject: stored.subject,
+      });
+      return undefined;
+    }
+
+    if (stored.expiresAt < Date.now()) {
+      await store.delete(tokenHash);
+      return undefined;
+    }
+
+    // A token may only be refreshed by the client it was issued to.
+    if (stored.clientId !== args.client.client_id) {
+      return undefined;
+    }
+
+    // The refresh may narrow scopes, but never broaden them (RFC 6749 §6).
+    let scopes = stored.scopes;
+    if (args.scopes.length > 0) {
+      if (!isSubset(args.scopes, stored.scopes)) {
+        return undefined;
+      }
+      scopes = args.scopes;
+    }
+
+    // Consume the token: rotation issues a fresh one via `issueTokens`.
+    await store.save({ ...stored, consumedAt: Date.now() });
+
+    return { subject: stored.subject, scopes };
+  };
+
+  return { issue, onRefreshToken };
+};

--- a/packages/auth-core/tests/unit/tests/memoryStores.test.ts
+++ b/packages/auth-core/tests/unit/tests/memoryStores.test.ts
@@ -1,0 +1,199 @@
+import { createHash } from 'node:crypto';
+
+import {
+  createMemoryAuthCodeStore,
+  createMemoryClientStore,
+  createMemoryRefreshTokenStore,
+  createOAuthHandlers,
+  createRefreshRotation,
+  type OAuthClient,
+} from '../../../src/index';
+
+const base64Url = (buffer: Buffer): string => {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+};
+
+const CODE_VERIFIER = 'a-very-long-random-pkce-code-verifier-value-1234567890';
+const CODE_CHALLENGE = base64Url(
+  createHash('sha256').update(CODE_VERIFIER).digest()
+);
+
+const publicClient: OAuthClient = {
+  client_id: 'public-client',
+  redirect_uris: ['https://app.example.com/callback'],
+  token_endpoint_auth_method: 'none',
+};
+
+describe('createMemoryClientStore', () => {
+  test('seeds initial clients and registers new ones', async () => {
+    const store = createMemoryClientStore([publicClient]);
+    expect(await store.get('public-client')).toEqual(publicClient);
+    expect(await store.get('missing')).toBeUndefined();
+
+    const fresh: OAuthClient = {
+      client_id: 'new-client',
+      redirect_uris: ['https://new.example.com/cb'],
+    };
+    await store.register(fresh);
+    expect(await store.get('new-client')).toEqual(fresh);
+  });
+});
+
+describe('createMemoryAuthCodeStore', () => {
+  test('saves, reads, and deletes codes', async () => {
+    const store = createMemoryAuthCodeStore();
+    const code = {
+      code: 'abc',
+      clientId: 'public-client',
+      redirectUri: 'https://app.example.com/callback',
+      codeChallenge: CODE_CHALLENGE,
+      scopes: ['read'],
+      subject: 'user-1',
+      expiresAt: Date.now() + 1000,
+    };
+    await store.save(code);
+    expect(await store.get('abc')).toEqual(code);
+    await store.delete('abc');
+    expect(await store.get('abc')).toBeUndefined();
+  });
+});
+
+describe('createMemoryRefreshTokenStore', () => {
+  test('saves, reads, deletes, and revokes by owner', async () => {
+    const store = createMemoryRefreshTokenStore();
+    const make = (tokenHash: string, subject: string) => {
+      return {
+        tokenHash,
+        clientId: 'public-client',
+        subject,
+        scopes: ['read'],
+        expiresAt: Date.now() + 1000,
+      };
+    };
+
+    await store.save(make('h1', 'user-1'));
+    await store.save(make('h2', 'user-1'));
+    await store.save(make('h3', 'user-2'));
+
+    expect(await store.get('h1')).toBeTruthy();
+    await store.delete('h1');
+    expect(await store.get('h1')).toBeUndefined();
+
+    await store.deleteByOwner({ clientId: 'public-client', subject: 'user-1' });
+    expect(await store.get('h2')).toBeUndefined();
+    // A different owner is untouched.
+    expect(await store.get('h3')).toBeTruthy();
+  });
+});
+
+describe('memory stores — end-to-end auth-code + PKCE + refresh rotation', () => {
+  test('register → authorize → token → refresh, all on memory stores', async () => {
+    const clientStore = createMemoryClientStore();
+    const refresh = createRefreshRotation({
+      store: createMemoryRefreshTokenStore(),
+    });
+
+    let accessCounter = 0;
+    const server = createOAuthHandlers({
+      issuer: 'https://api.example.com',
+      clientStore,
+      authCodeStore: createMemoryAuthCodeStore(),
+      issueTokens: async ({ subject, scopes, client }) => {
+        accessCounter += 1;
+        return {
+          accessToken: `access-${accessCounter}`,
+          refreshToken: await refresh.issue({ client, subject, scopes }),
+          expiresIn: 3600,
+        };
+      },
+      onAuthorize: () => {
+        return { approved: true, subject: 'alice', scopes: ['mcp:access'] };
+      },
+      onRefreshToken: refresh.onRefreshToken,
+    });
+
+    const reg = await server.register({
+      query: {},
+      body: {
+        redirect_uris: ['https://app.example.com/callback'],
+        token_endpoint_auth_method: 'none',
+      },
+      headers: {},
+    });
+    const clientId = (reg.body as OAuthClient).client_id;
+
+    const authRes = await server.authorize({
+      query: {
+        response_type: 'code',
+        client_id: clientId,
+        redirect_uri: 'https://app.example.com/callback',
+        code_challenge: CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: 'mcp:access',
+      },
+      body: {},
+      headers: {},
+    });
+    const code = new URL(authRes.redirect!).searchParams.get('code')!;
+
+    const tokenRes = await server.token({
+      query: {},
+      body: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: 'https://app.example.com/callback',
+        client_id: clientId,
+        code_verifier: CODE_VERIFIER,
+      },
+      headers: {},
+    });
+    expect(tokenRes.status).toBe(200);
+    const firstRefresh = (tokenRes.body as { refresh_token: string })
+      .refresh_token;
+    expect(firstRefresh).toBeTruthy();
+
+    // Exchange the refresh token: a new pair is issued and rotated.
+    const refreshRes = await server.token({
+      query: {},
+      body: {
+        grant_type: 'refresh_token',
+        refresh_token: firstRefresh,
+        client_id: clientId,
+      },
+      headers: {},
+    });
+    expect(refreshRes.status).toBe(200);
+    const secondRefresh = (refreshRes.body as { refresh_token: string })
+      .refresh_token;
+    expect(secondRefresh).not.toBe(firstRefresh);
+
+    // The original refresh token is now single-use — reuse fails and revokes.
+    const reuse = await server.token({
+      query: {},
+      body: {
+        grant_type: 'refresh_token',
+        refresh_token: firstRefresh,
+        client_id: clientId,
+      },
+      headers: {},
+    });
+    expect(reuse.status).toBe(400);
+    expect((reuse.body as { error: string }).error).toBe('invalid_grant');
+
+    // Reuse revoked the whole chain: the rotated token is dead too.
+    const afterRevoke = await server.token({
+      query: {},
+      body: {
+        grant_type: 'refresh_token',
+        refresh_token: secondRefresh,
+        client_id: clientId,
+      },
+      headers: {},
+    });
+    expect(afterRevoke.status).toBe(400);
+  });
+});

--- a/packages/auth-core/tests/unit/tests/refreshTokenRotation.test.ts
+++ b/packages/auth-core/tests/unit/tests/refreshTokenRotation.test.ts
@@ -1,0 +1,242 @@
+import {
+  createMemoryRefreshTokenStore,
+  createRefreshRotation,
+  type OAuthClient,
+  type RefreshTokenStore,
+} from '../../../src/index';
+
+const client: OAuthClient = {
+  client_id: 'client-abc',
+  redirect_uris: ['https://app.example.com/callback'],
+};
+
+const otherClient: OAuthClient = {
+  client_id: 'client-xyz',
+  redirect_uris: ['https://other.example.com/callback'],
+};
+
+const setup = (overrides: { store?: RefreshTokenStore } = {}) => {
+  const store = overrides.store ?? createMemoryRefreshTokenStore();
+  const rotation = createRefreshRotation({ store });
+  return { store, rotation };
+};
+
+describe('createRefreshRotation — issue', () => {
+  test('mints a unique opaque token per call', async () => {
+    const { rotation } = setup();
+    const a = await rotation.issue({ client, subject: 'user-1', scopes: [] });
+    const b = await rotation.issue({ client, subject: 'user-1', scopes: [] });
+    expect(a).toBeTruthy();
+    expect(a).not.toBe(b);
+  });
+
+  test('does not persist the plaintext token (only its hash)', async () => {
+    const saved: string[] = [];
+    const store = createMemoryRefreshTokenStore();
+    const wrapped: RefreshTokenStore = {
+      ...store,
+      save: (token) => {
+        saved.push(token.tokenHash);
+        return store.save(token);
+      },
+    };
+    const rotation = createRefreshRotation({ store: wrapped });
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).not.toBe(token);
+    expect(saved[0]).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('createRefreshRotation — onRefreshToken', () => {
+  test('approves a valid token with its granted scopes', async () => {
+    const { rotation } = setup();
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read', 'write'],
+    });
+    const result = await rotation.onRefreshToken({
+      refreshToken: token,
+      client,
+      scopes: [],
+    });
+    expect(result).toEqual({ subject: 'user-1', scopes: ['read', 'write'] });
+  });
+
+  test('rejects an unknown token', async () => {
+    const { rotation } = setup();
+    const result = await rotation.onRefreshToken({
+      refreshToken: 'never-issued',
+      client,
+      scopes: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('enforces single use — a token cannot be exchanged twice', async () => {
+    const { rotation } = setup();
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    expect(
+      await rotation.onRefreshToken({ refreshToken: token, client, scopes: [] })
+    ).toBeTruthy();
+    expect(
+      await rotation.onRefreshToken({ refreshToken: token, client, scopes: [] })
+    ).toBeUndefined();
+  });
+
+  test('reuse of a consumed token revokes the owner entire token set', async () => {
+    const { rotation } = setup();
+    const stolen = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    // A second live token for the same owner (e.g. issued by rotation).
+    const live = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+
+    // Legitimately consume the first token once.
+    await rotation.onRefreshToken({ refreshToken: stolen, client, scopes: [] });
+    // Replay the consumed token: reuse detected.
+    expect(
+      await rotation.onRefreshToken({
+        refreshToken: stolen,
+        client,
+        scopes: [],
+      })
+    ).toBeUndefined();
+
+    // The whole owner chain is revoked, including the still-live token.
+    expect(
+      await rotation.onRefreshToken({ refreshToken: live, client, scopes: [] })
+    ).toBeUndefined();
+  });
+
+  test('reuse revocation is scoped to the owner, leaving other owners intact', async () => {
+    const { rotation } = setup();
+    const reused = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    const otherOwner = await rotation.issue({
+      client,
+      subject: 'user-2',
+      scopes: ['read'],
+    });
+
+    await rotation.onRefreshToken({ refreshToken: reused, client, scopes: [] });
+    await rotation.onRefreshToken({ refreshToken: reused, client, scopes: [] });
+
+    expect(
+      await rotation.onRefreshToken({
+        refreshToken: otherOwner,
+        client,
+        scopes: [],
+      })
+    ).toEqual({ subject: 'user-2', scopes: ['read'] });
+  });
+
+  test('rejects and sweeps an expired token', async () => {
+    const store = createMemoryRefreshTokenStore();
+    const rotation = createRefreshRotation({
+      store,
+      refreshTokenTtl: -1,
+      hashToken: (token) => {
+        return `hash:${token}`;
+      },
+    });
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    expect(
+      await rotation.onRefreshToken({ refreshToken: token, client, scopes: [] })
+    ).toBeUndefined();
+    // Swept on access — no stale record lingers for a later reuse check.
+    expect(await store.get(`hash:${token}`)).toBeUndefined();
+  });
+
+  test('rejects a token presented by a different client', async () => {
+    const { rotation } = setup();
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    expect(
+      await rotation.onRefreshToken({
+        refreshToken: token,
+        client: otherClient,
+        scopes: [],
+      })
+    ).toBeUndefined();
+  });
+
+  test('narrows scopes when the refresh requests a subset', async () => {
+    const { rotation } = setup();
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read', 'write'],
+    });
+    expect(
+      await rotation.onRefreshToken({
+        refreshToken: token,
+        client,
+        scopes: ['read'],
+      })
+    ).toEqual({ subject: 'user-1', scopes: ['read'] });
+  });
+
+  test('rejects a refresh requesting scopes beyond those granted', async () => {
+    const { rotation } = setup();
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['read'],
+    });
+    expect(
+      await rotation.onRefreshToken({
+        refreshToken: token,
+        client,
+        scopes: ['read', 'admin'],
+      })
+    ).toBeUndefined();
+  });
+
+  test('honours a custom token generator and hasher', async () => {
+    let counter = 0;
+    const store = createMemoryRefreshTokenStore();
+    const rotation = createRefreshRotation({
+      store,
+      generateToken: () => {
+        counter += 1;
+        return `token-${counter}`;
+      },
+      hashToken: (token) => {
+        return `hash:${token}`;
+      },
+    });
+    const token = await rotation.issue({
+      client,
+      subject: 'user-1',
+      scopes: [],
+    });
+    expect(token).toBe('token-1');
+    expect(await store.get(`hash:${token}`)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What & why

Implements the **storage-agnostic** primitives discussed in #1062. That issue asks for a `@ttoss/postgresdb`-backed OAuth store adapter, but the genuinely valuable, bug-prone part — refresh-token **rotation** — is pure OAuth 2.1 mechanics, not Postgres. The store contracts in `@ttoss/auth-core` were already backend-agnostic (`ClientStore`, `AuthCodeStore`), and the core only exposed an `onRefreshToken` *hook* with no rotation/persistence/reuse-detection — that gap is exactly what hand-rolling gets wrong.

So this ships the generic layer in `@ttoss/auth-core`. A `@ttoss/postgresdb` adapter (#1062) becomes a thin CRUD shell over these interfaces — no security-sensitive logic in the DB package, and the rotation logic is unit-tested once, independent of any backend.

## Changes

**1. `RefreshTokenStore` contract** (`oauthServerTypes.ts`) — `save` / `get` / `delete` / `deleteByOwner`, keyed by token hash. The `(clientId, subject)` pair is the owner/revocation unit.

**2. `createRefreshRotation({ store, refreshTokenTtl?, generateToken?, hashToken? })`** — returns:
- `issue({ client, subject, scopes })` — mints a tracked opaque token; call it inside `issueTokens`.
- `onRefreshToken` — a ready hook (matches the existing signature) that enforces **single use**, **expiry** (swept on access), **scope narrowing**, and **reuse detection** — replaying an already-rotated token revokes the owner's entire token set, forcing re-auth.

Only token **hashes** are persisted (SHA-256); plaintext never touches the store. No core changes — it composes through the two existing hooks.

**3. In-memory reference stores** — `createMemoryClientStore`, `createMemoryAuthCodeStore`, `createMemoryRefreshTokenStore` for tests, local dev, and examples.

**Docs** — OAuth Authorization Server guideline (rotation + in-memory stores sections) and the `auth-core` README.

## Testing

`pnpm run test` in `packages/auth-core`: **127 passed**, 100% coverage on `refreshTokenRotation.ts` and `memoryStores.ts`. Includes an end-to-end register → authorize → token → refresh → reuse-revocation flow on the memory stores.

> Note: monorepo-wide `turbo build` fails in this environment on an unrelated `@ttoss/i18n-cli` formatjs/babel linking error under Node 22 (repo requires Node ≥24); not touched by this PR.

Relates to #1062.

https://claude.ai/code/session_01JHUGpMLeiszyeXU9cXrVrE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHUGpMLeiszyeXU9cXrVrE)_