### PR TITLE
feat(oauth-client): add reusable third-party OAuth client package

### DIFF
--- a/docs/website/docs/engineering/guidelines/oauth-third-party-client.md
+++ b/docs/website/docs/engineering/guidelines/oauth-third-party-client.md
@@ -10,7 +10,7 @@ This guideline covers an app acting as an **OAuth client**: it sends a user to a
 | OAuth **server** | issuing tokens for your own app          | [OAuth Authorization Server](/docs/engineering/guidelines/oauth-authorization-server) |
 | MCP application  | the MCP-specific use of these primitives | [MCP Server with OAuth](/docs/engineering/guidelines/mcp-server-oauth)                |
 
-The only runtime dependencies are ttoss packages: [`@ttoss/http-server`](/docs/modules/packages/http-server) for the endpoints and [`@ttoss/auth-core`](/docs/modules/packages/auth-core) for token encryption and the internal service token. The examples use TikTok, but the pattern is provider-agnostic — swap the URLs, scopes, and parameter names.
+The only runtime dependencies are ttoss packages: [`@ttoss/oauth-client`](/docs/modules/packages/oauth-client) for the OAuth flow itself (authorization URL, code exchange, refresh), [`@ttoss/http-server`](/docs/modules/packages/http-server) for the endpoints, and [`@ttoss/auth-core`](/docs/modules/packages/auth-core) for token encryption and the internal service token. `@ttoss/oauth-client` ships provider presets — the examples use `createTikTokClient`; other providers are one preset over the same core, or `createOAuthClient` for one without a preset yet.
 
 ```mermaid
 sequenceDiagram
@@ -34,62 +34,55 @@ sequenceDiagram
 
 ## 1. Authorization redirect
 
-A `connect-url` endpoint builds the provider's `/authorize` URL and returns it (or redirects to it). Generate a random `state`, persist it against the session, and verify it on callback to prevent CSRF.
+A `connect-url` endpoint builds the provider's `/authorize` URL with `client.buildAuthUrl` and returns it (or redirects to it). Generate a random `state`, persist it against the session, and verify it on callback to prevent CSRF — `state` and its verification stay app-side, since they belong to your session store.
 
 ```typescript
+import { createTikTokClient } from '@ttoss/oauth-client';
 import { Router } from '@ttoss/http-server';
 import crypto from 'node:crypto';
 
 const router = new Router();
+const tiktok = createTikTokClient({
+  clientKey: process.env.TIKTOK_CLIENT_KEY!,
+  clientSecret: process.env.TIKTOK_CLIENT_SECRET!,
+});
 
 router.get('/social/tiktok/connect-url', (ctx) => {
   const state = crypto.randomBytes(16).toString('hex');
   // Persist `state` against the user's session for later verification.
   saveOAuthState(ctx, state);
 
-  const url = new URL('https://www.tiktok.com/v2/auth/authorize/');
-  url.searchParams.set('client_key', process.env.TIKTOK_CLIENT_KEY!);
-  url.searchParams.set('scope', 'user.info.basic,video.publish');
-  url.searchParams.set('response_type', 'code');
-  url.searchParams.set(
-    'redirect_uri',
-    `${process.env.APP_URL}/my/settings/social`
-  );
-  url.searchParams.set('state', state);
-
-  ctx.body = { url: url.toString() };
+  ctx.body = {
+    url: tiktok.buildAuthUrl({
+      redirectUri: `${process.env.APP_URL}/my/settings/social`,
+      scope: ['user.info.basic', 'video.publish'],
+      state,
+    }),
+  };
 });
 ```
 
 ## 2. Callback exchange
 
-The provider redirects the user back to the settings page with `?code=`. The page posts that code to a `connect` endpoint, which verifies `state` and exchanges the code for tokens at the provider's `/token` endpoint.
+The provider redirects the user back to the settings page with `?code=`. The page posts that code to a `connect` endpoint, which verifies `state` and exchanges the code for tokens with `client.exchangeCode`. Provider-specific fields (TikTok's `open_id`) come back on `raw`.
 
 ```typescript
 router.post('/social/tiktok/connect', async (ctx) => {
   const { code, state } = ctx.request.body as { code: string; state: string };
   assertOAuthState(ctx, state); // throws on mismatch
 
-  const res = await fetch('https://open.tiktokapis.com/v2/oauth/token/', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_key: process.env.TIKTOK_CLIENT_KEY!,
-      client_secret: process.env.TIKTOK_CLIENT_SECRET!,
-      grant_type: 'authorization_code',
-      code,
-      redirect_uri: `${process.env.APP_URL}/my/settings/social`,
-    }),
+  const tokens = await tiktok.exchangeCode({
+    code,
+    redirectUri: `${process.env.APP_URL}/my/settings/social`,
   });
-  const data = await res.json();
 
   await saveSocialToken({
     userId: ctx.state.userId,
     platform: 'tiktok',
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token,
-    accessTokenExpiresAt: new Date(Date.now() + data.expires_in * 1000),
-    openId: data.open_id,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    accessTokenExpiresAt: new Date(Date.now() + tokens.expiresIn * 1000),
+    openId: tokens.raw.open_id,
   });
 
   ctx.body = { connected: true };
@@ -127,34 +120,49 @@ The ciphertext is a single base64 string (IV + auth tag + payload), so no extra 
 
 Access tokens are short-lived; refresh tokens last longer. Use two complementary strategies.
 
-**Lazy refresh at call time** — `getValidToken` returns a usable access token, refreshing first if it expires within a safety window (e.g. 2 hours). Every code path that calls the provider goes through this helper, so callers never handle expiry.
+**Lazy refresh at call time** — `client.getValidToken` returns a usable access token, refreshing first if it expires within a safety window (default 2 hours) and handing the new tokens to `onRefresh` so you can re-store them. Every code path that calls the provider goes through this helper, so callers never handle expiry. The client works with plaintext, so decrypt on the way in and encrypt inside `onRefresh`.
 
 ```typescript
-const REFRESH_WINDOW_MS = 2 * 60 * 60 * 1000; // 2h
-
 export const getValidTikTokToken = async (userId: string): Promise<string> => {
   const token = await loadSocialToken({ userId, platform: 'tiktok' });
-  const expiringSoon =
-    token.accessTokenExpiresAt.getTime() - Date.now() < REFRESH_WINDOW_MS;
-  if (expiringSoon) {
-    return refreshTikTokToken(token); // calls /token with grant_type=refresh_token, re-stores
-  }
-  return decryptValue({ ciphertext: token.accessToken, key: KEY });
+  return tiktok.getValidToken(
+    {
+      accessToken: decryptValue({ ciphertext: token.accessToken, key: KEY }),
+      refreshToken: decryptValue({ ciphertext: token.refreshToken, key: KEY }),
+      accessTokenExpiresAt: token.accessTokenExpiresAt,
+    },
+    {
+      onRefresh: (updated) =>
+        saveSocialToken({
+          userId,
+          platform: 'tiktok',
+          accessToken: encryptValue({
+            plaintext: updated.accessToken,
+            key: KEY,
+          }),
+          refreshToken: encryptValue({
+            plaintext: updated.refreshToken,
+            key: KEY,
+          }),
+          accessTokenExpiresAt: new Date(Date.now() + updated.expiresIn * 1000),
+        }),
+    }
+  );
 };
 ```
 
-**Scheduled refresh** — a cron job refreshes tokens expiring within a wider window (e.g. 6 hours) so connections stay alive even for users who are inactive. This guards against refresh tokens that themselves expire if never used.
+**Scheduled refresh** — a cron job refreshes tokens expiring within a wider window (default 6 hours) so connections stay alive even for users who are inactive. This guards against refresh tokens that themselves expire if never used. `findExpiringTokens` selects the records due for refresh.
 
 ```typescript
+import { findExpiringTokens } from '@ttoss/oauth-client';
+
 // jobs/tiktokTokenRefresher.ts — scheduled (e.g. hourly) by your deploy infra
 export const tiktokTokenRefresher = async () => {
-  const soon = new Date(Date.now() + 6 * 60 * 60 * 1000);
-  const tokens = await listSocialTokensExpiringBefore({
-    platform: 'tiktok',
-    before: soon,
-  });
+  const tokens = findExpiringTokens(
+    await listSocialTokens({ platform: 'tiktok' })
+  );
   for (const token of tokens) {
-    await refreshTikTokToken(token).catch((error) =>
+    await getValidTikTokToken(token.userId).catch((error) =>
       logRefreshFailure(token, error)
     );
   }

--- a/packages/oauth-client/README.md
+++ b/packages/oauth-client/README.md
@@ -1,0 +1,131 @@
+# @ttoss/oauth-client
+
+Reusable client for connecting a ttoss app to third-party OAuth 2.0 providers
+(TikTok, Instagram, YouTube, Google, …). It covers building the authorization
+URL, exchanging the callback code, and keeping access tokens fresh through lazy
+and scheduled refresh. The client is **ORM- and storage-agnostic**: it operates
+on plain token objects and delegates persistence to you, so it works with
+Sequelize, Prisma, or anything else.
+
+See the [OAuth Client guideline](https://ttoss.dev/docs/engineering/guidelines/oauth-third-party-client)
+for the full end-to-end pattern (endpoints, scheduled jobs, internal token access).
+
+## Install
+
+```bash
+pnpm add @ttoss/oauth-client
+```
+
+## Generic core
+
+`createOAuthClient` builds a client for any provider. Parameter-name overrides
+absorb providers that deviate from RFC 6749.
+
+```typescript
+import { createOAuthClient } from '@ttoss/oauth-client';
+
+const client = createOAuthClient({
+  authorizationUrl: 'https://provider.example/authorize',
+  tokenUrl: 'https://provider.example/token',
+  clientId: process.env.CLIENT_ID!,
+  clientSecret: process.env.CLIENT_SECRET!,
+});
+
+// 1. Redirect the user to the provider
+const url = client.buildAuthUrl({
+  redirectUri: 'https://app.example/callback',
+  scope: ['read', 'write'],
+  state: crypto.randomBytes(16).toString('hex'), // persist & verify on callback
+});
+
+// 2. Exchange the callback code for tokens
+const tokens = await client.exchangeCode({
+  code,
+  redirectUri: 'https://app.example/callback',
+});
+```
+
+## Provider presets
+
+Presets pre-configure a provider's quirks. TikTok, for example, names the client
+id `client_key` and uses comma-separated scopes — the preset encodes both.
+
+```typescript
+import { createTikTokClient } from '@ttoss/oauth-client';
+
+const tiktok = createTikTokClient({
+  clientKey: process.env.TIKTOK_CLIENT_KEY!,
+  clientSecret: process.env.TIKTOK_CLIENT_SECRET!,
+});
+```
+
+Adding a provider is one new preset over the same core; nothing else changes.
+
+## Keeping tokens fresh
+
+`getValidToken` returns a usable access token, refreshing first if it expires
+within `refreshWindowMs` (default 2h). `onRefresh` receives the new tokens so you
+can persist them.
+
+```typescript
+const accessToken = await client.getValidToken(record, {
+  onRefresh: async (updated) => {
+    await saveToken(record.id, updated);
+  },
+});
+```
+
+`findExpiringTokens` powers a scheduled job that proactively refreshes tokens
+expiring within a wider window (default 6h), keeping connections alive for
+inactive users.
+
+```typescript
+import { findExpiringTokens } from '@ttoss/oauth-client';
+
+const expiring = findExpiringTokens(await loadAllTokens());
+await Promise.all(expiring.map(refreshOne));
+```
+
+## Encryption at rest
+
+Access and refresh tokens are credentials — **encrypt them at rest**. The package
+stays encryption-agnostic and works with plaintext records; encrypt at the
+storage boundary with [`@ttoss/auth-core`](https://ttoss.dev/docs/modules/packages/auth-core):
+
+```typescript
+import { decryptValue, encryptValue } from '@ttoss/auth-core';
+
+const KEY = process.env.TOKEN_ENCRYPTION_KEY!; // from generateEncryptionKey()
+
+const accessToken = await client.getValidToken(
+  {
+    accessToken: decryptValue({ ciphertext: row.accessToken, key: KEY }),
+    refreshToken: decryptValue({ ciphertext: row.refreshToken, key: KEY }),
+    accessTokenExpiresAt: row.accessTokenExpiresAt,
+  },
+  {
+    onRefresh: async (updated) => {
+      await row.update({
+        accessToken: encryptValue({ plaintext: updated.accessToken, key: KEY }),
+        refreshToken: encryptValue({
+          plaintext: updated.refreshToken,
+          key: KEY,
+        }),
+        accessTokenExpiresAt: new Date(Date.now() + updated.expiresIn * 1000),
+      });
+    },
+  }
+);
+```
+
+## API
+
+| Export                      | Purpose                                                          |
+| --------------------------- | ---------------------------------------------------------------- |
+| `createOAuthClient`         | Build a client for a generic `OAuthProvider`.                    |
+| `createTikTokClient`        | Preset for TikTok Login Kit.                                     |
+| `client.buildAuthUrl`       | Build the provider's authorization URL.                          |
+| `client.exchangeCode`       | Exchange an authorization code for tokens.                       |
+| `client.refreshAccessToken` | Refresh an access token from a stored refresh token.             |
+| `client.getValidToken`      | Return a valid token, refreshing lazily within a safety window.  |
+| `findExpiringTokens`        | Filter records expiring within a window (for scheduled refresh). |

--- a/packages/oauth-client/package.json
+++ b/packages/oauth-client/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@ttoss/oauth-client",
+  "version": "0.0.0",
+  "description": "Reusable third-party OAuth 2.0 client for ttoss — authorization, code exchange, lazy and scheduled token refresh",
+  "keywords": [
+    "auth",
+    "oauth",
+    "oauth2",
+    "tiktok",
+    "ttoss"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ttoss/ttoss.git",
+    "directory": "packages/oauth-client"
+  },
+  "license": "MIT",
+  "author": "ttoss",
+  "contributors": [
+    "Pedro Arantes <pedro@arantespp.com> (https://arantespp.com)"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./providers": "./src/providers/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "jest --projects tests/unit"
+  },
+  "devDependencies": {
+    "@ttoss/auth-core": "workspace:^",
+    "@ttoss/config": "workspace:^",
+    "jest": "^30.4.2",
+    "tsdown": "^0.22.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "types": "./dist/index.d.mts"
+      },
+      "./providers": {
+        "import": "./dist/providers/index.mjs",
+        "require": "./dist/providers/index.cjs",
+        "types": "./dist/providers/index.d.mts"
+      }
+    },
+    "provenance": true
+  }
+}

--- a/packages/oauth-client/src/client.ts
+++ b/packages/oauth-client/src/client.ts
@@ -1,0 +1,157 @@
+import type {
+  OAuthProvider,
+  TokenRecord,
+  TokenResponse,
+  TokenResponseParser,
+} from './types';
+
+/** Default safety window for lazy refresh: 2 hours. */
+export const DEFAULT_REFRESH_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+const defaultParseTokenResponse: TokenResponseParser = (raw) => {
+  return {
+    accessToken: String(raw.access_token),
+    refreshToken: String(raw.refresh_token),
+    expiresIn: Number(raw.expires_in),
+    raw,
+  };
+};
+
+/** Options for {@link OAuthClient.buildAuthUrl}. */
+export interface BuildAuthUrlOptions {
+  /** Where the provider redirects the user back to after consent. */
+  redirectUri: string;
+  /** Requested scope(s). An array is joined with the provider's separator. */
+  scope: string | string[];
+  /** Opaque CSRF value; persist it and verify it on callback. */
+  state: string;
+  /** Extra provider-specific query parameters to append. */
+  extraParams?: Record<string, string>;
+}
+
+/** Options for {@link OAuthClient.exchangeCode}. */
+export interface ExchangeCodeOptions {
+  /** Authorization code received on the callback. */
+  code: string;
+  /** Must match the `redirectUri` used to build the authorization URL. */
+  redirectUri: string;
+}
+
+/** Options for {@link OAuthClient.getValidToken}. */
+export interface GetValidTokenOptions {
+  /** Refresh if the access token expires within this window. Default: 2h. */
+  refreshWindowMs?: number;
+  /** Called with the refreshed tokens so the caller can persist them. */
+  onRefresh: (updated: TokenResponse) => Promise<void> | void;
+}
+
+/**
+ * A configured OAuth 2.0 client bound to a single provider. Obtain one via
+ * {@link createOAuthClient} or a provider preset (e.g. `createTikTokClient`).
+ */
+export interface OAuthClient {
+  /** Build the provider's authorization URL to redirect the user to. */
+  buildAuthUrl: (options: BuildAuthUrlOptions) => string;
+  /** Exchange an authorization code for tokens at the token endpoint. */
+  exchangeCode: (options: ExchangeCodeOptions) => Promise<TokenResponse>;
+  /** Refresh an access token using a stored refresh token. */
+  refreshAccessToken: (refreshToken: string) => Promise<TokenResponse>;
+  /**
+   * Return a valid access token, refreshing first if it expires within
+   * `refreshWindowMs`. On refresh, `onRefresh` is awaited before returning so
+   * the caller can persist the new tokens.
+   */
+  getValidToken: (
+    record: TokenRecord,
+    options: GetValidTokenOptions
+  ) => Promise<string>;
+}
+
+/**
+ * Create an OAuth client for a generic {@link OAuthProvider}. The returned
+ * client is stateless and delegates all persistence to its caller, making it
+ * ORM- and storage-agnostic.
+ */
+export const createOAuthClient = (provider: OAuthProvider): OAuthClient => {
+  const clientIdParam = provider.params?.clientId ?? 'client_id';
+  const clientSecretParam = provider.params?.clientSecret ?? 'client_secret';
+  const scopeSeparator = provider.params?.scopeSeparator ?? ' ';
+  const refreshGrantType = provider.params?.refreshGrantType ?? 'refresh_token';
+  const parse = provider.parseTokenResponse ?? defaultParseTokenResponse;
+
+  const requestToken = async (
+    body: URLSearchParams
+  ): Promise<TokenResponse> => {
+    const response = await fetch(provider.tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `OAuth token request failed: ${response.status} ${response.statusText} ${text}`
+      );
+    }
+
+    return parse(await response.json());
+  };
+
+  const refreshAccessToken = (refreshToken: string) => {
+    return requestToken(
+      new URLSearchParams({
+        [clientIdParam]: provider.clientId,
+        [clientSecretParam]: provider.clientSecret,
+        grant_type: refreshGrantType,
+        refresh_token: refreshToken,
+      })
+    );
+  };
+
+  return {
+    buildAuthUrl: ({ redirectUri, scope, state, extraParams }) => {
+      const url = new URL(provider.authorizationUrl);
+      url.searchParams.set(clientIdParam, provider.clientId);
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('redirect_uri', redirectUri);
+      url.searchParams.set(
+        'scope',
+        Array.isArray(scope) ? scope.join(scopeSeparator) : scope
+      );
+      url.searchParams.set('state', state);
+      for (const [key, value] of Object.entries(extraParams ?? {})) {
+        url.searchParams.set(key, value);
+      }
+      return url.toString();
+    },
+
+    exchangeCode: ({ code, redirectUri }) => {
+      return requestToken(
+        new URLSearchParams({
+          [clientIdParam]: provider.clientId,
+          [clientSecretParam]: provider.clientSecret,
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+        })
+      );
+    },
+
+    refreshAccessToken,
+
+    getValidToken: async (record, options) => {
+      const refreshWindowMs =
+        options.refreshWindowMs ?? DEFAULT_REFRESH_WINDOW_MS;
+      const msUntilExpiry = record.accessTokenExpiresAt.getTime() - Date.now();
+
+      if (msUntilExpiry > refreshWindowMs) {
+        return record.accessToken;
+      }
+
+      const updated = await refreshAccessToken(record.refreshToken);
+      await options.onRefresh(updated);
+      return updated.accessToken;
+    },
+  };
+};

--- a/packages/oauth-client/src/index.ts
+++ b/packages/oauth-client/src/index.ts
@@ -1,0 +1,21 @@
+export {
+  type BuildAuthUrlOptions,
+  createOAuthClient,
+  DEFAULT_REFRESH_WINDOW_MS,
+  type ExchangeCodeOptions,
+  type GetValidTokenOptions,
+  type OAuthClient,
+} from './client';
+export { createTikTokClient, type TikTokClientOptions } from './providers';
+export {
+  DEFAULT_EXPIRING_WINDOW_MS,
+  findExpiringTokens,
+  type FindExpiringTokensOptions,
+} from './tokens';
+export {
+  type OAuthProvider,
+  type ProviderParamOverrides,
+  type TokenRecord,
+  type TokenResponse,
+  type TokenResponseParser,
+} from './types';

--- a/packages/oauth-client/src/providers/index.ts
+++ b/packages/oauth-client/src/providers/index.ts
@@ -1,0 +1,1 @@
+export { createTikTokClient, type TikTokClientOptions } from './tiktok';

--- a/packages/oauth-client/src/providers/tiktok.ts
+++ b/packages/oauth-client/src/providers/tiktok.ts
@@ -1,0 +1,30 @@
+import { createOAuthClient, type OAuthClient } from '../client';
+
+/** Options for {@link createTikTokClient}. */
+export interface TikTokClientOptions {
+  /** TikTok app `client_key` (TikTok's name for the client id). */
+  clientKey: string;
+  /** TikTok app `client_secret`. */
+  clientSecret: string;
+}
+
+/**
+ * Build an {@link OAuthClient} preconfigured for TikTok's Login Kit. Encodes
+ * TikTok's deviations from RFC 6749: the client id is sent as `client_key` and
+ * scopes are comma-separated. The token endpoint returns `open_id` alongside
+ * the tokens, available on `TokenResponse.raw`.
+ */
+export const createTikTokClient = (
+  options: TikTokClientOptions
+): OAuthClient => {
+  return createOAuthClient({
+    authorizationUrl: 'https://www.tiktok.com/v2/auth/authorize/',
+    tokenUrl: 'https://open.tiktokapis.com/v2/oauth/token/',
+    clientId: options.clientKey,
+    clientSecret: options.clientSecret,
+    params: {
+      clientId: 'client_key',
+      scopeSeparator: ',',
+    },
+  });
+};

--- a/packages/oauth-client/src/tokens.ts
+++ b/packages/oauth-client/src/tokens.ts
@@ -1,0 +1,27 @@
+import type { TokenRecord } from './types';
+
+/** Default scheduled-refresh window: 6 hours. */
+export const DEFAULT_EXPIRING_WINDOW_MS = 6 * 60 * 60 * 1000;
+
+/** Options for {@link findExpiringTokens}. */
+export interface FindExpiringTokensOptions {
+  /** Include records expiring within this window from now. Default: 6h. */
+  windowMs?: number;
+}
+
+/**
+ * Filter a list of token records down to those that expire within `windowMs`
+ * from now (default 6 hours). Intended for a scheduled job that proactively
+ * refreshes tokens before they lapse, keeping connections alive for inactive
+ * users. Pure and provider-agnostic — it inspects only `accessTokenExpiresAt`.
+ */
+export const findExpiringTokens = <T extends TokenRecord>(
+  records: T[],
+  options?: FindExpiringTokensOptions
+): T[] => {
+  const windowMs = options?.windowMs ?? DEFAULT_EXPIRING_WINDOW_MS;
+  const threshold = Date.now() + windowMs;
+  return records.filter((record) => {
+    return record.accessTokenExpiresAt.getTime() <= threshold;
+  });
+};

--- a/packages/oauth-client/src/types.ts
+++ b/packages/oauth-client/src/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Overrides for providers that deviate from the RFC 6749 parameter names and
+ * conventions. Every field is optional; unset fields fall back to the standard
+ * OAuth 2.0 defaults.
+ */
+export interface ProviderParamOverrides {
+  /** Parameter name carrying the client identifier. Default: `client_id`. */
+  clientId?: string;
+  /** Parameter name carrying the client secret. Default: `client_secret`. */
+  clientSecret?: string;
+  /** Separator used to join multiple scopes into one string. Default: `' '`. */
+  scopeSeparator?: string;
+  /** `grant_type` value sent when refreshing a token. Default: `refresh_token`. */
+  refreshGrantType?: string;
+}
+
+/**
+ * Normalized token response returned by every client method that talks to the
+ * provider's token endpoint. `raw` preserves provider-specific fields (e.g.
+ * TikTok's `open_id`) that the generic shape does not model.
+ */
+export interface TokenResponse {
+  /** Short-lived access token used to call the provider's API. */
+  accessToken: string;
+  /** Long-lived token used to obtain new access tokens. */
+  refreshToken: string;
+  /** Lifetime of the access token, in seconds. */
+  expiresIn: number;
+  /** Untouched JSON body from the provider, for provider-specific fields. */
+  raw: Record<string, unknown>;
+}
+
+/**
+ * Maps a raw token endpoint JSON body to a {@link TokenResponse}. Supply this on
+ * {@link OAuthProvider} when a provider names its token fields differently from
+ * the OAuth 2.0 defaults (`access_token`, `refresh_token`, `expires_in`).
+ */
+export type TokenResponseParser = (
+  raw: Record<string, unknown>
+) => TokenResponse;
+
+/**
+ * Configuration for a third-party OAuth 2.0 provider. This is the generic,
+ * provider-agnostic shape consumed by {@link createOAuthClient}. Pre-built
+ * presets (e.g. `createTikTokClient`) assemble this for you.
+ */
+export interface OAuthProvider {
+  /** Authorization endpoint the user is redirected to in order to log in. */
+  authorizationUrl: string;
+  /** Token endpoint used for both code exchange and refresh. */
+  tokenUrl: string;
+  /** OAuth client identifier issued by the provider. */
+  clientId: string;
+  /** OAuth client secret issued by the provider. */
+  clientSecret: string;
+  /** Overrides for providers that deviate from RFC 6749 parameter names. */
+  params?: ProviderParamOverrides;
+  /** Custom parser for non-standard token endpoint responses. */
+  parseTokenResponse?: TokenResponseParser;
+}
+
+/**
+ * Plain, ORM-agnostic snapshot of a stored token. The package never persists
+ * these records itself — the caller loads them (decrypting if stored encrypted)
+ * and persists updates via the `onRefresh` callback.
+ */
+export interface TokenRecord {
+  /** Current access token (plaintext). */
+  accessToken: string;
+  /** Current refresh token (plaintext). */
+  refreshToken: string;
+  /** Absolute time at which the access token expires. */
+  accessTokenExpiresAt: Date;
+}

--- a/packages/oauth-client/tests/unit/babel.config.cjs
+++ b/packages/oauth-client/tests/unit/babel.config.cjs
@@ -1,0 +1,3 @@
+const { babelConfig } = require('@ttoss/config');
+
+module.exports = babelConfig();

--- a/packages/oauth-client/tests/unit/jest.config.ts
+++ b/packages/oauth-client/tests/unit/jest.config.ts
@@ -1,0 +1,12 @@
+import { jestUnitConfig } from '@ttoss/config';
+
+export default jestUnitConfig({
+  coverageThreshold: {
+    global: {
+      statements: 99,
+      branches: 99,
+      functions: 99,
+      lines: 99,
+    },
+  },
+});

--- a/packages/oauth-client/tests/unit/tests/client.test.ts
+++ b/packages/oauth-client/tests/unit/tests/client.test.ts
@@ -1,0 +1,190 @@
+import { createOAuthClient, type TokenResponse } from 'src/index';
+
+const provider = {
+  authorizationUrl: 'https://provider.example/authorize',
+  tokenUrl: 'https://provider.example/token',
+  clientId: 'my-client-id',
+  clientSecret: 'my-client-secret',
+};
+
+const tokenJson = {
+  access_token: 'new-access',
+  refresh_token: 'new-refresh',
+  expires_in: 3600,
+  scope: 'read',
+};
+
+const mockFetchOnce = (body: unknown, init?: { ok?: boolean }) => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: init?.ok ?? true,
+    status: init?.ok === false ? 400 : 200,
+    statusText: init?.ok === false ? 'Bad Request' : 'OK',
+    json: async () => {
+      return body;
+    },
+    text: async () => {
+      return JSON.stringify(body);
+    },
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('buildAuthUrl', () => {
+  test('builds a standard authorization URL', () => {
+    const client = createOAuthClient(provider);
+    const url = new URL(
+      client.buildAuthUrl({
+        redirectUri: 'https://app.example/callback',
+        scope: 'read write',
+        state: 'xyz',
+      })
+    );
+
+    expect(url.origin + url.pathname).toBe(
+      'https://provider.example/authorize'
+    );
+    expect(url.searchParams.get('client_id')).toBe('my-client-id');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://app.example/callback'
+    );
+    expect(url.searchParams.get('scope')).toBe('read write');
+    expect(url.searchParams.get('state')).toBe('xyz');
+  });
+
+  test('joins array scopes with the configured separator and appends extra params', () => {
+    const client = createOAuthClient({
+      ...provider,
+      params: { clientId: 'client_key', scopeSeparator: ',' },
+    });
+    const url = new URL(
+      client.buildAuthUrl({
+        redirectUri: 'https://app.example/callback',
+        scope: ['user.info.basic', 'video.publish'],
+        state: 'xyz',
+        extraParams: { disable_auto_auth: '1' },
+      })
+    );
+
+    expect(url.searchParams.get('client_key')).toBe('my-client-id');
+    expect(url.searchParams.has('client_id')).toBe(false);
+    expect(url.searchParams.get('scope')).toBe('user.info.basic,video.publish');
+    expect(url.searchParams.get('disable_auto_auth')).toBe('1');
+  });
+});
+
+describe('exchangeCode', () => {
+  test('posts the authorization code and parses the response', async () => {
+    const fetchMock = mockFetchOnce(tokenJson);
+    const client = createOAuthClient(provider);
+
+    const result = await client.exchangeCode({
+      code: 'auth-code',
+      redirectUri: 'https://app.example/callback',
+    });
+
+    expect(result).toEqual<TokenResponse>({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      expiresIn: 3600,
+      raw: tokenJson,
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = init.body as URLSearchParams;
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('auth-code');
+    expect(body.get('client_id')).toBe('my-client-id');
+    expect(body.get('client_secret')).toBe('my-client-secret');
+  });
+
+  test('throws when the token endpoint returns a non-ok status', async () => {
+    mockFetchOnce({ error: 'invalid_grant' }, { ok: false });
+    const client = createOAuthClient(provider);
+
+    await expect(
+      client.exchangeCode({ code: 'bad', redirectUri: 'https://app/cb' })
+    ).rejects.toThrow('OAuth token request failed: 400');
+  });
+});
+
+describe('refreshAccessToken', () => {
+  test('posts the refresh grant with the provider grant override', async () => {
+    const fetchMock = mockFetchOnce(tokenJson);
+    const client = createOAuthClient({
+      ...provider,
+      params: { refreshGrantType: 'refresh_token' },
+    });
+
+    await client.refreshAccessToken('stored-refresh');
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = init.body as URLSearchParams;
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('stored-refresh');
+  });
+});
+
+describe('getValidToken', () => {
+  test('returns the stored token unchanged when it is outside the refresh window', async () => {
+    const fetchMock = mockFetchOnce(tokenJson);
+    const client = createOAuthClient(provider);
+    const onRefresh = jest.fn();
+
+    const token = await client.getValidToken(
+      {
+        accessToken: 'current-access',
+        refreshToken: 'current-refresh',
+        accessTokenExpiresAt: new Date(Date.now() + 5 * 60 * 60 * 1000),
+      },
+      { onRefresh }
+    );
+
+    expect(token).toBe('current-access');
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('refreshes and persists when the token expires within the window', async () => {
+    mockFetchOnce(tokenJson);
+    const client = createOAuthClient(provider);
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+
+    const token = await client.getValidToken(
+      {
+        accessToken: 'current-access',
+        refreshToken: 'current-refresh',
+        accessTokenExpiresAt: new Date(Date.now() + 30 * 60 * 1000),
+      },
+      { onRefresh }
+    );
+
+    expect(token).toBe('new-access');
+    expect(onRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: 'new-access' })
+    );
+  });
+
+  test('honours a custom refresh window', async () => {
+    const fetchMock = mockFetchOnce(tokenJson);
+    const client = createOAuthClient(provider);
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+
+    const token = await client.getValidToken(
+      {
+        accessToken: 'current-access',
+        refreshToken: 'current-refresh',
+        accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      },
+      { onRefresh, refreshWindowMs: 30 * 60 * 1000 }
+    );
+
+    expect(token).toBe('current-access');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/oauth-client/tests/unit/tests/encryptedStorage.test.ts
+++ b/packages/oauth-client/tests/unit/tests/encryptedStorage.test.ts
@@ -1,0 +1,76 @@
+import {
+  decryptValue,
+  encryptValue,
+  generateEncryptionKey,
+} from '@ttoss/auth-core';
+import { createOAuthClient, type TokenResponse } from 'src/index';
+
+/**
+ * Demonstrates the recommended at-rest encryption pattern: the package stays
+ * encryption-agnostic and operates on plaintext records; the caller decrypts on
+ * load and re-encrypts inside `onRefresh` using `@ttoss/auth-core`.
+ */
+describe('encrypted storage integration with @ttoss/auth-core', () => {
+  test('round-trips tokens through encryptValue/decryptValue across a refresh', async () => {
+    const key = generateEncryptionKey();
+
+    // Stored encrypted, expiring within the refresh window.
+    const stored = {
+      accessToken: encryptValue({ plaintext: 'old-access', key }),
+      refreshToken: encryptValue({ plaintext: 'old-refresh', key }),
+      accessTokenExpiresAt: new Date(Date.now() + 30 * 60 * 1000),
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => {
+        return {
+          access_token: 'fresh-access',
+          refresh_token: 'fresh-refresh',
+          expires_in: 3600,
+        };
+      },
+      text: async () => {
+        return '';
+      },
+    }) as unknown as typeof fetch;
+
+    const client = createOAuthClient({
+      authorizationUrl: 'https://provider.example/authorize',
+      tokenUrl: 'https://provider.example/token',
+      clientId: 'id',
+      clientSecret: 'secret',
+    });
+
+    let persisted: { accessToken: string; refreshToken: string } | undefined;
+
+    const accessToken = await client.getValidToken(
+      {
+        accessToken: decryptValue({ ciphertext: stored.accessToken, key }),
+        refreshToken: decryptValue({ ciphertext: stored.refreshToken, key }),
+        accessTokenExpiresAt: stored.accessTokenExpiresAt,
+      },
+      {
+        onRefresh: (updated: TokenResponse) => {
+          persisted = {
+            accessToken: encryptValue({ plaintext: updated.accessToken, key }),
+            refreshToken: encryptValue({
+              plaintext: updated.refreshToken,
+              key,
+            }),
+          };
+        },
+      }
+    );
+
+    expect(accessToken).toBe('fresh-access');
+    expect(persisted?.accessToken).not.toContain('fresh-access');
+    expect(decryptValue({ ciphertext: persisted!.accessToken, key })).toBe(
+      'fresh-access'
+    );
+
+    jest.restoreAllMocks();
+  });
+});

--- a/packages/oauth-client/tests/unit/tests/tiktok.test.ts
+++ b/packages/oauth-client/tests/unit/tests/tiktok.test.ts
@@ -1,0 +1,62 @@
+import { createTikTokClient } from 'src/index';
+
+describe('createTikTokClient', () => {
+  test('encodes TikTok deviations in the authorization URL', () => {
+    const client = createTikTokClient({
+      clientKey: 'tk-key',
+      clientSecret: 'tk-secret',
+    });
+
+    const url = new URL(
+      client.buildAuthUrl({
+        redirectUri: 'https://app.example/my/settings/social',
+        scope: ['user.info.basic', 'video.publish'],
+        state: 'state-123',
+      })
+    );
+
+    expect(url.origin + url.pathname).toBe(
+      'https://www.tiktok.com/v2/auth/authorize/'
+    );
+    expect(url.searchParams.get('client_key')).toBe('tk-key');
+    expect(url.searchParams.has('client_id')).toBe(false);
+    expect(url.searchParams.get('scope')).toBe('user.info.basic,video.publish');
+  });
+
+  test('sends client_key to the TikTok token endpoint and exposes open_id on raw', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => {
+        return {
+          access_token: 'act',
+          refresh_token: 'rft',
+          expires_in: 86_400,
+          open_id: 'open-id-1',
+        };
+      },
+      text: async () => {
+        return '';
+      },
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = createTikTokClient({
+      clientKey: 'tk-key',
+      clientSecret: 'tk-secret',
+    });
+
+    const result = await client.exchangeCode({
+      code: 'code',
+      redirectUri: 'https://app.example/my/settings/social',
+    });
+
+    const [tokenUrl, init] = fetchMock.mock.calls[0];
+    expect(tokenUrl).toBe('https://open.tiktokapis.com/v2/oauth/token/');
+    expect((init.body as URLSearchParams).get('client_key')).toBe('tk-key');
+    expect(result.raw.open_id).toBe('open-id-1');
+
+    jest.restoreAllMocks();
+  });
+});

--- a/packages/oauth-client/tests/unit/tests/tokens.test.ts
+++ b/packages/oauth-client/tests/unit/tests/tokens.test.ts
@@ -1,0 +1,32 @@
+import { findExpiringTokens } from 'src/index';
+
+const recordExpiringIn = (ms: number) => {
+  return {
+    accessToken: 'a',
+    refreshToken: 'r',
+    accessTokenExpiresAt: new Date(Date.now() + ms),
+  };
+};
+
+describe('findExpiringTokens', () => {
+  test('returns records expiring within the default 6h window', () => {
+    const soon = recordExpiringIn(60 * 60 * 1000);
+    const later = recordExpiringIn(24 * 60 * 60 * 1000);
+    const expired = recordExpiringIn(-1000);
+
+    const result = findExpiringTokens([soon, later, expired]);
+
+    expect(result).toEqual([soon, expired]);
+  });
+
+  test('honours a custom window', () => {
+    const soon = recordExpiringIn(60 * 60 * 1000);
+    const later = recordExpiringIn(3 * 60 * 60 * 1000);
+
+    const result = findExpiringTokens([soon, later], {
+      windowMs: 90 * 60 * 1000,
+    });
+
+    expect(result).toEqual([soon]);
+  });
+});

--- a/packages/oauth-client/tsconfig.json
+++ b/packages/oauth-client/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ttoss/config/tsconfig.json"
+}

--- a/packages/oauth-client/tsdown.config.ts
+++ b/packages/oauth-client/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { tsdownConfig } from '@ttoss/config';
+
+export default tsdownConfig({
+  entry: ['src/index.ts', 'src/providers/index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1458,6 +1458,21 @@ importers:
         specifier: ^0.22.2
         version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
 
+  packages/oauth-client:
+    devDependencies:
+      '@ttoss/auth-core':
+        specifier: workspace:^
+        version: link:../auth-core
+      '@ttoss/config':
+        specifier: workspace:^
+        version: link:../config
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+
   packages/postgresdb:
     dependencies:
       pg:


### PR DESCRIPTION
## Summary

Implements the `@ttoss/oauth-client` package proposed in the OAuth third-party client tracking issue. The trigger condition has been met: there is now a real first consumer (a TikTok integration) plus a likely second (react-auth social login).

Rather than the flat function list in the proposal, the package is layered as a **generic core + provider presets**, so adding a provider is one new preset over an untouched core:

- **Core** — `createOAuthClient(provider)` returns a client with `buildAuthUrl`, `exchangeCode`, `refreshAccessToken`, and `getValidToken` (lazy refresh within a configurable window, default 2h). The `OAuthProvider` config carries parameter-name/format overrides so providers that deviate from RFC 6749 are supported.
- **Provider presets** — `createTikTokClient({ clientKey, clientSecret })` encodes TikTok's quirks (`client_key` instead of `client_id`, comma-separated scopes; `open_id` exposed via `TokenResponse.raw`).
- **Scheduled refresh** — `findExpiringTokens` filters records expiring within a window (default 6h) for a cron job.

The package is **ORM- and storage-agnostic**: it operates on plain `TokenRecord` objects and delegates persistence via `onRefresh`. It is also **encryption-agnostic** — encryption stays at the caller's storage boundary using `@ttoss/auth-core`'s `encryptValue`/`decryptValue`, demonstrated in the README and an integration test.

## Acceptance criteria

- [x] `buildAuthUrl`, `exchangeCode`, `refreshAccessToken`, `getValidToken`, `findExpiringTokens` exported from `@ttoss/oauth-client`
- [x] ORM-agnostic — no Sequelize or Prisma dependency
- [x] Token encryption documented and demonstrated using `@ttoss/auth-core`
- [x] Unit tests cover URL building, code exchange, lazy refresh (within/outside window + custom window), and the expiring-token filter
- [x] Guideline updated to reference the package instead of the manual implementation

## Testing

- `pnpm run test` in the package — 13 tests pass, 100% coverage on all logic files
- Standalone `tsc --noEmit` typecheck passes

> Note: `pnpm turbo run build` could not complete in this environment due to a pre-existing, repo-wide `babel-plugin-formatjs` linking error that also fails untouched packages (e.g. `auth-core`). It is unrelated to this change.

## Notes for review

This is the first consumer-driven extraction, so feedback on the API shape is expected — particularly the `ProviderParamOverrides` surface and whether `state`/CSRF and `status`/`disconnect` should eventually move into the package (currently left app-side, as documented in the guideline).

https://claude.ai/code/session_01E3nYNzHT23jrQskVyjJDcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3nYNzHT23jrQskVyjJDcz)_