### PR TITLE
docs(carlin): document deploy report --channel=github-pr

### DIFF
--- a/docs/website/docs/carlin/commands/deploy.mdx
+++ b/docs/website/docs/carlin/commands/deploy.mdx
@@ -202,18 +202,18 @@ flowchart TD
 
 The comment looks like this:
 
-| Package | Stack | Output Key | Output Value |
-|---------|-------|------------|--------------|
-| `@acme/api` | `acme-api-pr-42` | `ApiUrl` | https://... |
+| Package     | Stack            | Output Key   | Output Value |
+| ----------- | ---------------- | ------------ | ------------ |
+| `@acme/api` | `acme-api-pr-42` | `ApiUrl`     | https://...  |
 | `@acme/web` | `acme-web-pr-42` | `BucketName` | acme-web-... |
 
 #### Required environment variables
 
-| Variable | Description |
-|----------|-------------|
-| `GH_TOKEN` | GitHub token with `pull-requests: write` permission. |
+| Variable            | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `GH_TOKEN`          | GitHub token with `pull-requests: write` permission.                     |
 | `GITHUB_REPOSITORY` | Repository in `owner/repo` format (set automatically by GitHub Actions). |
-| `CARLIN_BRANCH` | The branch being built (used to look up the open PR). |
+| `CARLIN_BRANCH`     | The branch being built (used to look up the open PR).                    |
 
 #### Usage in CI
 

--- a/docs/website/docs/carlin/commands/deploy.mdx
+++ b/docs/website/docs/carlin/commands/deploy.mdx
@@ -180,6 +180,58 @@ This option affects:
 - Lambda Layer compatible runtimes
 - CodeBuild runtime for Lambda Layer builder
 
+## Deploy Report
+
+```bash
+carlin deploy report --channel=github-pr
+```
+
+After all packages in a monorepo are deployed, `deploy report` collects every `.carlin/*.json` output file across the workspace and publishes a consolidated summary. Use `--channel` to control where the summary is sent.
+
+### `--channel=github-pr`
+
+Posts (or updates) a single PR comment containing a table of all deploy outputs from every package deployed during the CI run. Carlin identifies the PR from the current branch, finds any existing comment it previously posted, and patches it in place — so the comment never duplicates across pushes.
+
+```mermaid
+flowchart TD
+    A[collect all .carlin/*.json files] --> B[build markdown table]
+    B --> C{PR comment exists?}
+    C -->|yes| D[PATCH existing comment]
+    C -->|no| E[POST new comment]
+```
+
+The comment looks like this:
+
+| Package | Stack | Output Key | Output Value |
+|---------|-------|------------|--------------|
+| `@acme/api` | `acme-api-pr-42` | `ApiUrl` | https://... |
+| `@acme/web` | `acme-web-pr-42` | `BucketName` | acme-web-... |
+
+#### Required environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `GH_TOKEN` | GitHub token with `pull-requests: write` permission. |
+| `GITHUB_REPOSITORY` | Repository in `owner/repo` format (set automatically by GitHub Actions). |
+| `CARLIN_BRANCH` | The branch being built (used to look up the open PR). |
+
+#### Usage in CI
+
+In the ttoss monorepo this command runs at the end of the PR pipeline, after all packages are deployed:
+
+```bash
+# Deploy all packages changed since main
+pnpm turbo run build test deploy --filter=[main]
+
+# Build carlin explicitly so the CLI is available even when no packages changed
+pnpm turbo run build --filter=carlin
+
+# Post or update a single PR comment with consolidated deploy outputs
+pnpm carlin deploy report --channel=github-pr
+```
+
+Because Carlin uses `GITHUB_PR_COMMENT_MARKER` as an HTML comment inside the body, it identifies its own comment reliably across multiple pushes to the same PR without creating duplicates.
+
 ## Destroy
 
 To destroy the stack, pass `--destroy` to the deploy command:
@@ -229,6 +281,7 @@ After deployment, outputs are saved to `.carlin/$STACK_NAME.json` and `.carlin/l
 | `--lambda-external`              | Modules excluded from the Lambda bundle.                     |
 | `--lambda-entry-points-base-dir` | Base directory for Lambda handler entry points.              |
 | `--skip-deploy`                  | Skip deployment after config resolution.                     |
+| `--channel`                      | Report deploy outputs to a channel. Supported: `github-pr`.  |
 
 `--parameters` accepts a simple object:
 


### PR DESCRIPTION
## Summary

- Adds a **Deploy Report** section to `docs/website/docs/carlin/commands/deploy.mdx`
- Documents `carlin deploy report --channel=github-pr`: how it collects workspace-wide `.carlin/*.json` output files and posts/updates a single consolidated PR comment
- Includes a Mermaid flow diagram, required environment variables table (`GH_TOKEN`, `GITHUB_REPOSITORY`, `CARLIN_BRANCH`), a sample PR comment table, and the CI usage snippet matching `.cicd/commands/pr.sh`
- Adds `--channel` to the API options table

## Test plan

- [ ] Review the rendered Mermaid diagram and tables look correct in the docs site
- [ ] Verify the CI snippet matches `.cicd/commands/pr.sh`
- [ ] Verify all env variable names match `packages/carlin/src/deploy/reportToGitHubPR.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NC9yK9HBrPKu2vT4AhWDeq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NC9yK9HBrPKu2vT4AhWDeq)_