### PR TITLE
feat(http-server-serverless): add AWS Lambda adapter that populates rawHeaders

### DIFF
--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -641,21 +641,23 @@ This package implements the [Model Context Protocol](https://spec.modelcontextpr
 
 ## AWS Lambda Deployment
 
-The default **stateless** mode (see [Stateless vs stateful mode](#stateless-vs-stateful-mode)) is built for serverless: a fresh transport is created per request, nothing is kept in memory between invocations, and responses are plain JSON (no SSE) — exactly the request/response shape API Gateway and Lambda Function URLs expect. Because the router is a regular Koa app, you wrap it with any Koa-to-Lambda adapter (e.g. [`serverless-http`](https://github.com/dougmoscrop/serverless-http)) and front it with an HTTP API Gateway or a Function URL.
+The default **stateless** mode (see [Stateless vs stateful mode](#stateless-vs-stateful-mode)) is built for serverless: a fresh transport is created per request, nothing is kept in memory between invocations, and responses are plain JSON (no SSE) — exactly the request/response shape API Gateway and Lambda Function URLs expect.
+
+Use [`@ttoss/http-server-serverless`](https://github.com/ttoss/ttoss/tree/main/packages/http-server-serverless) as the Lambda adapter. It wraps `serverless-http` and additionally populates `req.rawHeaders` from the API Gateway event before the request reaches Koa. Without this step, `@hono/node-server` — used internally by the MCP transport — drops all headers (including `Accept`) and every `initialize` request returns HTTP 406.
 
 ```mermaid
 flowchart LR
     Client[MCP Client] -->|POST /mcp| GW[API Gateway / Function URL]
     GW --> L[Lambda]
     subgraph L[Lambda]
-        H[serverless-http handler] --> App[Koa App + createMcpRouter]
+        H[toLambdaHandler] -->|rawHeaders populated| App[Koa App + createMcpRouter]
     end
 ```
 
 ```typescript
-import serverless from 'serverless-http';
 import { App, bodyParser } from '@ttoss/http-server';
 import { createMcpRouter, McpServer, z } from '@ttoss/http-server-mcp';
+import { toLambdaHandler } from '@ttoss/http-server-serverless';
 
 const mcpServer = new McpServer({ name: 'my-mcp-server', version: '1.0.0' });
 
@@ -675,7 +677,7 @@ app.use(bodyParser());
 // Stateless by default — no sessionIdGenerator
 app.use(createMcpRouter(mcpServer).routes());
 
-export const handler = serverless(app.callback());
+export const handler = toLambdaHandler(app);
 ```
 
 Keep the following in mind:
@@ -689,6 +691,7 @@ Keep the following in mind:
 ## Related Packages
 
 - [@ttoss/http-server](https://ttoss.dev/docs/modules/packages/http-server) - HTTP server foundation
+- [@ttoss/http-server-serverless](https://github.com/ttoss/ttoss/tree/main/packages/http-server-serverless) - AWS Lambda adapter (required for MCP on Lambda)
 - [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/sdk) - MCP SDK
 
 ## Resources

--- a/packages/http-server-serverless/README.md
+++ b/packages/http-server-serverless/README.md
@@ -1,0 +1,102 @@
+# @ttoss/http-server-serverless
+
+AWS Lambda adapter for [@ttoss/http-server](https://github.com/ttoss/ttoss/tree/main/packages/http-server) applications.
+
+## The problem
+
+When you wrap a Koa app with `serverless-http` and front it with API Gateway, routes that go through `@hono/node-server` — including the MCP transport in `@ttoss/http-server-mcp` — return **HTTP 406 Not Acceptable** on every request, even when the client sends correct headers.
+
+The root cause is that `@hono/node-server` builds its internal Web `Request` object exclusively from `req.rawHeaders` (`newHeadersFromIncoming`), but `serverless-http`'s synthetic `IncomingMessage` populates `req.headers` and leaves `req.rawHeaders` as an empty array. Every header is dropped in translation, so the `Accept: application/json, text/event-stream` header that MCP requires is never seen by the transport.
+
+## The solution
+
+`@ttoss/http-server-serverless` wraps `serverless-http` and reconstructs `req.rawHeaders` from the original API Gateway event before the request enters the Koa pipeline, where the original headers are still available.
+
+## Installation
+
+```bash
+pnpm add @ttoss/http-server-serverless
+```
+
+## Usage
+
+```typescript
+import { App, bodyParser } from '@ttoss/http-server';
+import { toLambdaHandler } from '@ttoss/http-server-serverless';
+
+const app = new App();
+app.use(bodyParser());
+// ... add routes
+
+export const handler = toLambdaHandler(app);
+```
+
+### MCP on Lambda
+
+```typescript
+import { App, bodyParser } from '@ttoss/http-server';
+import { createMcpRouter, McpServer, z } from '@ttoss/http-server-mcp';
+import { toLambdaHandler } from '@ttoss/http-server-serverless';
+
+const mcpServer = new McpServer({ name: 'my-mcp-server', version: '1.0.0' });
+
+mcpServer.registerTool(
+  'get-weather',
+  {
+    description: 'Get weather for a location',
+    inputSchema: { location: z.string() },
+  },
+  async ({ location }) => ({
+    content: [{ type: 'text', text: `Weather in ${location}: Sunny` }],
+  })
+);
+
+const app = new App();
+app.use(bodyParser());
+// Stateless by default — do not pass sessionIdGenerator on Lambda
+app.use(createMcpRouter(mcpServer).routes());
+
+export const handler = toLambdaHandler(app);
+```
+
+```mermaid
+flowchart LR
+    Client[MCP Client] -->|POST /mcp| GW[API Gateway / Function URL]
+    GW --> L[Lambda]
+    subgraph L[Lambda]
+        H[toLambdaHandler] -->|rawHeaders populated| App[Koa App + createMcpRouter]
+    end
+```
+
+## API
+
+### `toLambdaHandler(app)`
+
+Wraps a Koa `App` in an AWS Lambda handler compatible with API Gateway HTTP API (v2), API Gateway REST API (v1), and Lambda Function URLs.
+
+| Parameter | Type  | Description                        |
+| --------- | ----- | ---------------------------------- |
+| `app`     | `App` | A `@ttoss/http-server` application |
+
+Returns an async Lambda handler `(event, context) => Promise<Response>`.
+
+### `buildRawHeaders(event)`
+
+Builds a flat `[name, value, name, value, ...]` array from an API Gateway event, suitable for assigning to `req.rawHeaders`.
+
+Handles:
+
+- **v1** (`event.multiValueHeaders`) — preserves original casing and genuine duplicates
+- **v2** (`event.headers` + `event.cookies[]`) — reconstructs combined headers and separate cookie entries
+
+## Notes
+
+- Use **stateless mode** (no `sessionIdGenerator`) — stateful mode keeps an in-memory transport that does not survive across Lambda containers.
+- Authentication via the `@ttoss/http-server-auth` or `@ttoss/http-server-mcp` `auth` option works normally and pairs naturally with API Gateway authorizers.
+- SSE streaming is not used in stateless MCP mode, so a standard API Gateway integration is sufficient.
+
+## Related packages
+
+- [@ttoss/http-server](https://github.com/ttoss/ttoss/tree/main/packages/http-server) — HTTP server foundation
+- [@ttoss/http-server-mcp](https://github.com/ttoss/ttoss/tree/main/packages/http-server-mcp) — MCP integration
+- [@ttoss/http-server-auth](https://github.com/ttoss/ttoss/tree/main/packages/http-server-auth) — Authentication middleware

--- a/packages/http-server-serverless/jest.config.ts
+++ b/packages/http-server-serverless/jest.config.ts
@@ -1,0 +1,3 @@
+import { jestRootConfig } from '@ttoss/config';
+
+export default jestRootConfig();

--- a/packages/http-server-serverless/package.json
+++ b/packages/http-server-serverless/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@ttoss/http-server-serverless",
+  "version": "0.1.0",
+  "description": "AWS Lambda adapter for @ttoss/http-server — populates rawHeaders so @hono/node-server routes work correctly behind API Gateway",
+  "keywords": [
+    "aws",
+    "koa",
+    "lambda",
+    "server",
+    "serverless"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ttoss/ttoss.git",
+    "directory": "packages/http-server-serverless"
+  },
+  "license": "MIT",
+  "author": "ttoss",
+  "contributors": [
+    "Pedro Arantes <pedro@arantespp.com> (https://arantespp.com)"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "jest --projects tests/unit"
+  },
+  "dependencies": {
+    "serverless-http": "^3.2.0"
+  },
+  "devDependencies": {
+    "@ttoss/config": "workspace:^",
+    "@ttoss/http-server": "workspace:^",
+    "@types/koa": "^3.0.3",
+    "jest": "^30.4.2",
+    "tsdown": "^0.22.2"
+  },
+  "peerDependencies": {
+    "@ttoss/http-server": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "types": "./dist/index.d.mts"
+      }
+    },
+    "provenance": true
+  }
+}

--- a/packages/http-server-serverless/src/index.ts
+++ b/packages/http-server-serverless/src/index.ts
@@ -1,0 +1,62 @@
+import type { App } from '@ttoss/http-server';
+import serverless from 'serverless-http';
+
+type GatewayEvent = Record<string, unknown> | null | undefined;
+
+const buildV1RawHeaders = (multiValueHeaders: Record<string, string[]>) => {
+  const raw: string[] = [];
+  for (const [key, values] of Object.entries(multiValueHeaders)) {
+    for (const v of values) raw.push(key, v);
+  }
+  return raw;
+};
+
+const buildV2RawHeaders = (
+  headers: Record<string, unknown>,
+  cookies: string[]
+) => {
+  const raw: string[] = [];
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined) raw.push(key, String(value));
+  }
+  for (const cookie of cookies) raw.push('cookie', cookie);
+  return raw;
+};
+
+/**
+ * Build a flat `rawHeaders` array from an API Gateway event so that
+ * `@hono/node-server`'s `newHeadersFromIncoming` can read all headers.
+ *
+ * Supports API Gateway REST (v1) `multiValueHeaders` and HTTP API (v2)
+ * `headers` + `cookies` event shapes.
+ */
+export const buildRawHeaders = (event: unknown): string[] => {
+  const ev = event as GatewayEvent;
+  if (ev?.multiValueHeaders) {
+    return buildV1RawHeaders(ev.multiValueHeaders as Record<string, string[]>);
+  }
+  return buildV2RawHeaders(
+    (ev?.headers as Record<string, unknown>) ?? {},
+    (ev?.cookies as string[]) ?? []
+  );
+};
+
+/**
+ * Wrap a `@ttoss/http-server` `App` in an AWS Lambda handler.
+ *
+ * Compared to using `serverless-http` directly, this adapter populates
+ * `req.rawHeaders` from the original API Gateway event headers before the
+ * request reaches the application. That is required because
+ * `@hono/node-server` (used internally by `@ttoss/http-server-mcp`) builds
+ * Web `Request` headers exclusively from `req.rawHeaders` — which
+ * `serverless-http` leaves empty — causing every header to be dropped and
+ * MCP `initialize` requests to fail with HTTP 406.
+ */
+export const toLambdaHandler = (app: App) => {
+  return serverless(app.callback(), {
+    request: (req: Record<string, unknown>, event: unknown) => {
+      const rawHeaders = req.rawHeaders as string[] | undefined;
+      if (!rawHeaders?.length) req.rawHeaders = buildRawHeaders(event);
+    },
+  });
+};

--- a/packages/http-server-serverless/tests/unit/babel.config.cjs
+++ b/packages/http-server-serverless/tests/unit/babel.config.cjs
@@ -1,0 +1,3 @@
+const { babelConfig } = require('@ttoss/config');
+
+module.exports = babelConfig();

--- a/packages/http-server-serverless/tests/unit/jest.config.ts
+++ b/packages/http-server-serverless/tests/unit/jest.config.ts
@@ -1,0 +1,12 @@
+import { jestUnitConfig } from '@ttoss/config';
+
+export default jestUnitConfig({
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+});

--- a/packages/http-server-serverless/tests/unit/tests/toLambdaHandler.test.ts
+++ b/packages/http-server-serverless/tests/unit/tests/toLambdaHandler.test.ts
@@ -1,0 +1,207 @@
+import { App } from '@ttoss/http-server';
+import serverless from 'serverless-http';
+import { buildRawHeaders, toLambdaHandler } from 'src/index';
+
+jest.mock('serverless-http', () => {
+  return jest.fn().mockReturnValue(jest.fn());
+});
+
+const mockedServerless = jest.mocked(serverless);
+
+describe('buildRawHeaders', () => {
+  describe('API Gateway REST v1 (multiValueHeaders)', () => {
+    test('builds raw headers from multiValueHeaders', () => {
+      const event = {
+        multiValueHeaders: {
+          accept: ['application/json, text/event-stream'],
+          'content-type': ['application/json'],
+        },
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toEqual([
+        'accept',
+        'application/json, text/event-stream',
+        'content-type',
+        'application/json',
+      ]);
+    });
+
+    test('preserves duplicate header values', () => {
+      const event = {
+        multiValueHeaders: {
+          'x-custom': ['value1', 'value2'],
+        },
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toEqual(['x-custom', 'value1', 'x-custom', 'value2']);
+    });
+
+    test('returns once multiValueHeaders is found, ignoring headers/cookies', () => {
+      const event = {
+        multiValueHeaders: { accept: ['application/json'] },
+        headers: { 'x-other': 'should-be-ignored' },
+        cookies: ['session=abc'],
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toEqual(['accept', 'application/json']);
+      expect(raw).not.toContain('x-other');
+      expect(raw).not.toContain('cookie');
+    });
+  });
+
+  describe('API Gateway HTTP API v2 (headers + cookies)', () => {
+    test('builds raw headers from headers object', () => {
+      const event = {
+        headers: {
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+        },
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toEqual([
+        'accept',
+        'application/json, text/event-stream',
+        'content-type',
+        'application/json',
+      ]);
+    });
+
+    test('appends each cookie as a separate cookie header', () => {
+      const event = {
+        headers: { accept: 'application/json' },
+        cookies: ['session=abc123', 'theme=dark'],
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toContain('cookie');
+      const cookieIdx = raw.indexOf('cookie');
+      expect(raw[cookieIdx + 1]).toBe('session=abc123');
+      expect(raw).toContain('theme=dark');
+    });
+
+    test('skips headers with undefined values', () => {
+      const event = {
+        headers: {
+          accept: 'application/json',
+          'x-undefined': undefined,
+        },
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toContain('accept');
+      expect(raw).not.toContain('x-undefined');
+    });
+
+    test('coerces non-string header values to strings', () => {
+      const event = {
+        headers: { 'x-count': 42 },
+      };
+
+      const raw = buildRawHeaders(event);
+
+      expect(raw).toEqual(['x-count', '42']);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('returns empty array for empty event', () => {
+      expect(buildRawHeaders({})).toEqual([]);
+    });
+
+    test('returns empty array for null event', () => {
+      expect(buildRawHeaders(null)).toEqual([]);
+    });
+
+    test('returns empty array for undefined event', () => {
+      expect(buildRawHeaders(undefined)).toEqual([]);
+    });
+
+    test('returns empty array when headers object is missing', () => {
+      expect(buildRawHeaders({ cookies: ['a=b'] })).toEqual(['cookie', 'a=b']);
+    });
+  });
+});
+
+describe('toLambdaHandler', () => {
+  beforeEach(() => {
+    mockedServerless.mockReturnValue(jest.fn());
+  });
+
+  test('returns a function (Lambda handler)', () => {
+    const app = new App();
+    const handler = toLambdaHandler(app);
+    expect(typeof handler).toBe('function');
+  });
+
+  test('passes app.callback() and a request transform to serverless-http', () => {
+    const app = new App();
+    toLambdaHandler(app);
+
+    expect(mockedServerless).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ request: expect.any(Function) })
+    );
+  });
+
+  describe('request transform', () => {
+    const getTransform = () => {
+      const app = new App();
+      toLambdaHandler(app);
+      const [, options] = mockedServerless.mock.calls[0];
+      return options.request as (
+        req: Record<string, unknown>,
+        event: unknown
+      ) => void;
+    };
+
+    test('populates rawHeaders when empty', () => {
+      const transform = getTransform();
+      const req: Record<string, unknown> = { rawHeaders: [] };
+      const event = {
+        multiValueHeaders: {
+          accept: ['application/json, text/event-stream'],
+        },
+      };
+
+      transform(req, event);
+
+      expect(req.rawHeaders).toEqual([
+        'accept',
+        'application/json, text/event-stream',
+      ]);
+    });
+
+    test('does not overwrite rawHeaders that are already populated', () => {
+      const transform = getTransform();
+      const existing = ['accept', 'text/plain'];
+      const req: Record<string, unknown> = { rawHeaders: existing };
+      const event = {
+        multiValueHeaders: { accept: ['application/json'] },
+      };
+
+      transform(req, event);
+
+      expect(req.rawHeaders).toBe(existing);
+    });
+
+    test('populates rawHeaders when the property is undefined', () => {
+      const transform = getTransform();
+      const req: Record<string, unknown> = {};
+      const event = { headers: { 'x-api-key': 'secret' } };
+
+      transform(req, event);
+
+      expect(req.rawHeaders).toEqual(['x-api-key', 'secret']);
+    });
+  });
+});

--- a/packages/http-server-serverless/tsconfig.json
+++ b/packages/http-server-serverless/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ttoss/config/tsconfig.json"
+}

--- a/packages/http-server-serverless/tsdown.config.ts
+++ b/packages/http-server-serverless/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { tsdownConfig } from '@ttoss/config';
+
+export default tsdownConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1316,6 +1316,28 @@ importers:
         specifier: ^0.22.2
         version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
 
+  packages/http-server-serverless:
+    dependencies:
+      serverless-http:
+        specifier: ^3.2.0
+        version: 3.2.0
+    devDependencies:
+      '@ttoss/config':
+        specifier: workspace:^
+        version: link:../config
+      '@ttoss/http-server':
+        specifier: workspace:^
+        version: link:../http-server
+      '@types/koa':
+        specifier: ^3.0.3
+        version: 3.0.3
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+
   packages/i18n-cli:
     dependencies:
       '@formatjs/cli-lib':
@@ -14330,6 +14352,10 @@ packages:
     resolution: {integrity: sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  serverless-http@3.2.0:
+    resolution: {integrity: sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==}
+    engines: {node: '>=12.0'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -31331,6 +31357,8 @@ snapshots:
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
+
+  serverless-http@3.2.0: {}
 
   set-blocking@2.0.0: {}
 


### PR DESCRIPTION
## Summary

- Introduces `@ttoss/http-server-serverless` — a new package exposing `toLambdaHandler(app)` that wraps `serverless-http` and reconstructs `req.rawHeaders` from the original API Gateway event before the request enters Koa
- Fixes the root cause of HTTP 406 on MCP `initialize` under Lambda: `@hono/node-server` builds its internal Web `Request` exclusively from `req.rawHeaders`, which `serverless-http` leaves empty, dropping all headers including `Accept`
- Supports API Gateway REST v1 (`multiValueHeaders`), HTTP API v2 (`headers` + `cookies[]`), and Lambda Function URLs
- Updates `@ttoss/http-server-mcp` README Lambda section to use the new adapter

## Root cause recap

`serverless-http` creates a synthetic `IncomingMessage` that populates `req.headers` but never `req.rawHeaders` (stays `[]`). `@hono/node-server`'s `newHeadersFromIncoming` reads only `req.rawHeaders`, so every header is silently dropped. The MCP transport then sees no `Accept` header and returns 406. Pure-Koa routes (OAuth, health check) are unaffected because they read `ctx.headers` directly.

## API

```typescript
import { toLambdaHandler } from '@ttoss/http-server-serverless';
import { app } from './server';

export const handler = toLambdaHandler(app);
```

## Test plan

- [x] 16 unit tests covering `buildRawHeaders` (v1/v2 events, cookies, edge cases) and `toLambdaHandler` (return type, request transform wiring, rawHeaders population and non-overwrite)
- [x] 100% statement/branch/function/line coverage
- [x] Lint passes (complexity reduced by extracting `buildV1RawHeaders` / `buildV2RawHeaders` helpers)
- [x] `syncpack lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWvxVvS1Uj9mpfHDRkjGDf)_