### PR TITLE
feat(components): add OAuthConsent component with hierarchical scope support

### DIFF
--- a/docs/storybook/stories/components/OAuthConsent.stories.tsx
+++ b/docs/storybook/stories/components/OAuthConsent.stories.tsx
@@ -1,0 +1,268 @@
+import type { Meta, StoryFn } from '@storybook/react-webpack5';
+import type { OAuthConsentProps } from '@ttoss/components';
+import { OAuthConsent } from '@ttoss/components';
+import { action } from 'storybook/actions';
+
+const defaultLabels: OAuthConsentProps['labels'] = {
+  title: 'Authorize access',
+  requestedBy: (name) => {
+    return (
+      <>
+        <strong>{name}</strong> is requesting access to your account.
+      </>
+    );
+  },
+  permissionsHeading: 'Requested permissions',
+  approve: 'Authorize',
+  deny: 'Deny',
+  invalidRequestTitle: 'Invalid request',
+  invalidRequestBody:
+    'The authorization request is missing required parameters. Please return to the application and try again.',
+};
+
+const noop = async (_scopes: string[]) => {
+  action('onAuthorize')(_scopes);
+  return { ok: true };
+};
+
+export default {
+  title: 'Components/OAuthConsent',
+  component: OAuthConsent,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'OAuth consent screen component with support for flat and GitHub-style grouped/hierarchical scopes. ' +
+          'All copy is injected via the `labels` prop — zero hardcoded strings inside the component. ' +
+          'Granting a parent scope automatically locks all descendant scopes (checked + disabled).',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} as Meta<OAuthConsentProps>;
+
+// ---------------------------------------------------------------------------
+// Flat scopes (OCA read/write case)
+// ---------------------------------------------------------------------------
+
+export const FlatScopes: StoryFn<OAuthConsentProps> = () => {
+  return (
+    <OAuthConsent
+      clientName="OneClick Ads"
+      scopes={[
+        {
+          key: 'read',
+          label: 'Read',
+          description: 'List ad accounts and campaigns',
+          required: true,
+        },
+        {
+          key: 'write',
+          label: 'Write',
+          description: 'Pause and activate campaigns',
+        },
+      ]}
+      onAuthorize={noop}
+      onAuthorized={action('onAuthorized')}
+      onDeny={action('onDeny')}
+      labels={defaultLabels}
+    />
+  );
+};
+FlatScopes.parameters = {
+  docs: {
+    description: {
+      story:
+        'Flat read/write scope layout matching the OneClick Ads consent screen. ' +
+        'The `read` scope is marked `required` (always checked, always disabled).',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// GitHub-style grouped / hierarchical scopes
+// ---------------------------------------------------------------------------
+
+export const GroupedScopes: StoryFn<OAuthConsentProps> = () => {
+  return (
+    <OAuthConsent
+      clientName="GitHub App"
+      scopes={[
+        {
+          key: 'repo',
+          label: 'repo',
+          description: 'Full control of private repositories',
+          children: [
+            {
+              key: 'repo:status',
+              label: 'repo:status',
+              description: 'Access commit status',
+            },
+            {
+              key: 'repo:deployment',
+              label: 'repo:deployment',
+              description: 'Access deployment status',
+            },
+            {
+              key: 'public_repo',
+              label: 'public_repo',
+              description: 'Access public repositories',
+            },
+          ],
+        },
+        {
+          key: 'write:packages',
+          label: 'write:packages',
+          description: 'Upload packages to GitHub Packages',
+          children: [
+            {
+              key: 'read:packages',
+              label: 'read:packages',
+              description: 'Download packages from GitHub Packages',
+            },
+          ],
+        },
+        {
+          key: 'admin:org',
+          label: 'admin:org',
+          description:
+            'Fully control orgs and teams, read and write org projects',
+          children: [
+            {
+              key: 'write:org',
+              label: 'write:org',
+              description:
+                'Read and write org and team membership, read and write org projects',
+            },
+            {
+              key: 'read:org',
+              label: 'read:org',
+              description: 'Read org and team membership, read org projects',
+            },
+          ],
+        },
+      ]}
+      onAuthorize={noop}
+      onAuthorized={action('onAuthorized')}
+      onDeny={action('onDeny')}
+      labels={defaultLabels}
+    />
+  );
+};
+GroupedScopes.parameters = {
+  docs: {
+    description: {
+      story:
+        'GitHub-style hierarchical scopes. Checking a parent (`repo`, `write:packages`, `admin:org`) ' +
+        'locks all its children as checked + disabled. Children toggle independently when the parent is unchecked.',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Required baseline scope
+// ---------------------------------------------------------------------------
+
+export const RequiredScope: StoryFn<OAuthConsentProps> = () => {
+  return (
+    <OAuthConsent
+      clientName="My Service"
+      scopes={[
+        {
+          key: 'openid',
+          label: 'OpenID Connect',
+          description: 'Verify your identity',
+          required: true,
+        },
+        {
+          key: 'profile',
+          label: 'Profile',
+          description: 'Read your public profile information',
+        },
+        {
+          key: 'email',
+          label: 'Email',
+          description: 'Read your email address',
+        },
+      ]}
+      onAuthorize={noop}
+      onAuthorized={action('onAuthorized')}
+      onDeny={action('onDeny')}
+      labels={defaultLabels}
+    />
+  );
+};
+RequiredScope.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `openid` scope is `required: true` — it is always checked and disabled. ' +
+        'Optional scopes can be freely toggled.',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Invalid request state
+// ---------------------------------------------------------------------------
+
+export const InvalidRequest: StoryFn<OAuthConsentProps> = () => {
+  return (
+    <OAuthConsent
+      clientName="Unknown App"
+      scopes={[]}
+      isValidRequest={false}
+      onAuthorize={noop}
+      onAuthorized={action('onAuthorized')}
+      onDeny={action('onDeny')}
+      labels={defaultLabels}
+    />
+  );
+};
+InvalidRequest.parameters = {
+  docs: {
+    description: {
+      story:
+        'When `isValidRequest` is `false` (missing `client_id`, `code_challenge`, or `redirect_uri`), ' +
+        'the consent form is replaced by the invalid-request error state.',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Loading / isAuthorizing state
+// ---------------------------------------------------------------------------
+
+export const AuthorizingState: StoryFn<OAuthConsentProps> = () => {
+  return (
+    <OAuthConsent
+      clientName="Slow Service"
+      scopes={[
+        {
+          key: 'read',
+          label: 'Read',
+          description: 'Read access',
+          required: true,
+        },
+        {
+          key: 'write',
+          label: 'Write',
+          description: 'Write access',
+        },
+      ]}
+      isAuthorizing
+      onAuthorize={noop}
+      onAuthorized={action('onAuthorized')}
+      onDeny={action('onDeny')}
+      labels={defaultLabels}
+    />
+  );
+};
+AuthorizingState.parameters = {
+  docs: {
+    description: {
+      story:
+        'When `isAuthorizing` is `true`, both buttons are disabled and the Authorize button shows a loading indicator.',
+    },
+  },
+};

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -14,6 +14,52 @@ pnpm add @ttoss/components @ttoss/ui @emotion/react @ttoss/react-hooks
 
 All components are theme-aware and integrate seamlessly with `@ttoss/ui`.
 
+### OAuthConsent
+
+OAuth consent screen with flat and GitHub-style hierarchical scopes. Granting a parent scope automatically locks all descendants. All visible copy is injected via the `labels` prop — no hardcoded strings. [Docs](https://storybook.ttoss.dev/?path=/docs/components-oauthconsent--docs)
+
+```tsx
+import { OAuthConsent } from '@ttoss/components';
+
+<OAuthConsent
+  clientName="My App"
+  scopes={[
+    {
+      key: 'openid',
+      label: 'OpenID Connect',
+      description: 'Verify your identity',
+      required: true,
+    },
+    {
+      key: 'profile',
+      label: 'Profile',
+      description: 'Read your public profile information',
+    },
+  ]}
+  onAuthorize={async (grantedScopes) => {
+    const res = await authorize({ scopes: grantedScopes });
+    return { ok: res.ok };
+  }}
+  onAuthorized={() => {
+    window.location.href = resumeUrl;
+  }}
+  onDeny={() => navigate('/')}
+  labels={{
+    title: 'Authorize access',
+    requestedBy: (name) => (
+      <>
+        <strong>{name}</strong> is requesting access.
+      </>
+    ),
+    permissionsHeading: 'Requested permissions',
+    approve: 'Authorize',
+    deny: 'Deny',
+    invalidRequestTitle: 'Invalid request',
+    invalidRequestBody: 'Missing required OAuth parameters. Please try again.',
+  }}
+/>;
+```
+
 ### Accordion
 
 Accessible accordion component with collapsible content sections. [Docs](https://storybook.ttoss.dev/?path=/docs/components-accordion--docs)

--- a/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
@@ -441,20 +441,21 @@ export const OAuthConsent = ({
 
       <Flex sx={{ gap: 3, marginTop: 6 }}>
         <Button
-          onClick={handleApprove}
-          disabled={busy}
-          loading={isLoading || isAuthorizing}
-          sx={{ flex: 1, justifyContent: 'center' }}
-        >
-          {labels.approve}
-        </Button>
-        <Button
           variant="secondary"
           onClick={onDeny}
           disabled={busy}
           sx={{ flex: 1, justifyContent: 'center' }}
         >
           {labels.deny}
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleApprove}
+          disabled={busy}
+          loading={isLoading || isAuthorizing}
+          sx={{ flex: 1, justifyContent: 'center' }}
+        >
+          {labels.approve}
         </Button>
       </Flex>
     </ConsentCard>

--- a/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
@@ -1,4 +1,14 @@
-import { Box, Button, Checkbox, Flex, Heading, Label, Text } from '@ttoss/ui';
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Divider,
+  Flex,
+  Heading,
+  Label,
+  Text,
+} from '@ttoss/ui';
 import * as React from 'react';
 
 /**
@@ -130,38 +140,63 @@ const initSelected = (scopes: ConsentScope[]): Set<string> => {
 
 type ScopeRowProps = {
   scope: ConsentScope;
-  depth: number;
   ancestorSelected: boolean;
   selected: Set<string>;
   busy: boolean;
   onToggle: (scope: ConsentScope, ancestorSelected: boolean) => void;
 };
 
+const getScopeRowState = ({
+  scope,
+  ancestorSelected,
+  selected,
+  busy,
+}: Omit<ScopeRowProps, 'onToggle'>) => {
+  const isChecked = ancestorSelected || selected.has(scope.key);
+  const isLocked = !!scope.required || ancestorSelected;
+
+  return {
+    isChecked,
+    isDisabled: isLocked || busy,
+    isInteractive: !isLocked && !busy,
+  };
+};
+
 const ScopeRow = ({
   scope,
-  depth,
   ancestorSelected,
   selected,
   busy,
   onToggle,
 }: ScopeRowProps) => {
-  const isChecked = ancestorSelected || selected.has(scope.key);
-  const isDisabled = scope.required === true || ancestorSelected || busy;
+  const { isChecked, isDisabled, isInteractive } = getScopeRowState({
+    scope,
+    ancestorSelected,
+    selected,
+    busy,
+  });
   const checkboxId = `consent-scope-${scope.key}`;
   const descId = `consent-scope-desc-${scope.key}`;
 
   return (
-    <>
+    <Box as="li" sx={{ listStyle: 'none' }}>
       <Flex
         sx={{
-          pl: depth * 5,
-          py: 2,
-          alignItems: 'flex-start',
           gap: 3,
-          opacity: ancestorSelected ? 0.6 : 1,
+          alignItems: 'flex-start',
+          paddingX: 3,
+          paddingY: 3,
+          borderRadius: 'md',
+          opacity: ancestorSelected ? 0.55 : 1,
+          transition: 'background-color 0.15s ease',
+          ...(isInteractive && {
+            '&:hover': {
+              backgroundColor: 'display.background.muted.default',
+            },
+          }),
         }}
       >
-        <Box sx={{ pt: '2px', flexShrink: 0 }}>
+        <Box sx={{ paddingTop: '3px', flexShrink: 0 }}>
           <Checkbox
             id={checkboxId}
             checked={isChecked}
@@ -172,15 +207,16 @@ const ScopeRow = ({
             }}
           />
         </Box>
-        <Box sx={{ flex: 1 }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
           <Label
             htmlFor={checkboxId}
             sx={{
-              fontWeight: 'bold',
-              cursor: isDisabled ? 'default' : 'pointer',
+              fontWeight: 'semibold',
+              fontSize: 'md',
+              lineHeight: 'short',
+              cursor: isInteractive ? 'pointer' : 'default',
               color: 'display.text.primary.default',
-              fontSize: 'inherit',
-              display: 'block',
+              width: 'fit-content',
             }}
           >
             {scope.label}
@@ -188,29 +224,63 @@ const ScopeRow = ({
           <Text
             id={descId}
             sx={{
-              fontSize: 1,
+              fontSize: 'sm',
+              lineHeight: 'short',
               color: 'display.text.muted.default',
               display: 'block',
+              marginTop: '1',
             }}
           >
             {scope.description}
           </Text>
         </Box>
       </Flex>
-      {scope.children?.map((child) => {
-        return (
-          <ScopeRow
-            key={child.key}
-            scope={child}
-            depth={depth + 1}
-            ancestorSelected={isChecked}
-            selected={selected}
-            busy={busy}
-            onToggle={onToggle}
-          />
-        );
-      })}
-    </>
+      {scope.children?.length ? (
+        <Box
+          as="ul"
+          sx={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            marginLeft: 5,
+            paddingLeft: 2,
+            borderLeft: 'sm',
+            borderColor: 'display.border.muted.default',
+          }}
+        >
+          {scope.children?.map((child) => {
+            return (
+              <ScopeRow
+                key={child.key}
+                scope={child}
+                ancestorSelected={isChecked}
+                selected={selected}
+                busy={busy}
+                onToggle={onToggle}
+              />
+            );
+          })}
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+/** Shared centered card shell for the consent and invalid-request views. */
+const ConsentCard = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Flex sx={{ justifyContent: 'center', paddingX: 4, paddingY: 6 }}>
+      <Card
+        sx={{
+          width: '100%',
+          maxWidth: 480,
+          alignItems: 'stretch',
+          padding: 6,
+        }}
+      >
+        {children}
+      </Card>
+    </Flex>
   );
 };
 
@@ -288,47 +358,78 @@ export const OAuthConsent = ({
 
   if (!isValidRequest) {
     return (
-      <Box sx={{ maxWidth: 480, mx: 'auto', mt: 6, p: 4 }}>
-        <Heading as="h1" sx={{ mb: 3, color: 'display.text.primary.default' }}>
+      <ConsentCard>
+        <Heading
+          as="h1"
+          sx={{
+            fontSize: '3xl',
+            color: 'display.text.primary.default',
+            marginBottom: 3,
+          }}
+        >
           {labels.invalidRequestTitle}
         </Heading>
-        <Text sx={{ color: 'display.text.secondary.default' }}>
+        <Text
+          sx={{
+            fontSize: 'md',
+            lineHeight: 'moderate',
+            color: 'display.text.secondary.default',
+          }}
+        >
           {labels.invalidRequestBody}
         </Text>
-      </Box>
+      </ConsentCard>
     );
   }
 
   return (
-    <Box sx={{ maxWidth: 480, mx: 'auto', mt: 6, p: 4 }}>
-      <Heading as="h1" sx={{ mb: 2, color: 'display.text.primary.default' }}>
+    <ConsentCard>
+      <Heading
+        as="h1"
+        sx={{
+          fontSize: '3xl',
+          lineHeight: 'shorter',
+          color: 'display.text.primary.default',
+          marginBottom: 2,
+        }}
+      >
         {labels.title}
       </Heading>
 
-      <Text sx={{ mb: 4, color: 'display.text.secondary.default' }}>
+      <Text
+        sx={{
+          fontSize: 'md',
+          lineHeight: 'moderate',
+          color: 'display.text.secondary.default',
+        }}
+      >
         {labels.requestedBy(clientName)}
       </Text>
 
-      <Heading as="h3" sx={{ mb: 3, color: 'display.text.primary.default' }}>
+      <Divider
+        sx={{ marginY: 5, borderColor: 'display.border.muted.default' }}
+      />
+
+      <Heading
+        as="h3"
+        sx={{
+          fontSize: 'xs',
+          fontWeight: 'semibold',
+          letterSpacing: 'wider',
+          textTransform: 'uppercase',
+          color: 'display.text.muted.default',
+          marginBottom: 2,
+        }}
+      >
         {labels.permissionsHeading}
       </Heading>
 
-      <Box
-        sx={{
-          mb: 4,
-          border: 'sm',
-          borderColor: 'display.border.muted.default',
-          borderRadius: 'md',
-          px: 3,
-          py: 1,
-        }}
-      >
+      <Box as="ul" sx={{ listStyle: 'none', margin: 0, padding: 0 }}>
         {scopes.map((scope) => {
           return (
             <ScopeRow
               key={scope.key}
               scope={scope}
-              depth={0}
               ancestorSelected={false}
               selected={selected}
               busy={busy}
@@ -338,12 +439,12 @@ export const OAuthConsent = ({
         })}
       </Box>
 
-      <Flex sx={{ gap: 3 }}>
+      <Flex sx={{ gap: 3, marginTop: 6 }}>
         <Button
           onClick={handleApprove}
           disabled={busy}
           loading={isLoading || isAuthorizing}
-          sx={{ flex: 1 }}
+          sx={{ flex: 1, justifyContent: 'center' }}
         >
           {labels.approve}
         </Button>
@@ -351,11 +452,11 @@ export const OAuthConsent = ({
           variant="secondary"
           onClick={onDeny}
           disabled={busy}
-          sx={{ flex: 1 }}
+          sx={{ flex: 1, justifyContent: 'center' }}
         >
           {labels.deny}
         </Button>
       </Flex>
-    </Box>
+    </ConsentCard>
   );
 };

--- a/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
@@ -1,0 +1,361 @@
+import { Box, Button, Checkbox, Flex, Heading, Label, Text } from '@ttoss/ui';
+import * as React from 'react';
+
+/**
+ * A single OAuth scope, optionally with implied child scopes.
+ */
+export type ConsentScope = {
+  /** OAuth scope token, e.g. 'repo', 'write:packages', 'read'. */
+  key: string;
+  /** Bold display name shown on the left. Pre-translated by the consumer. */
+  label: string;
+  /** Scope description shown below the label. Pre-translated by the consumer. */
+  description: string;
+  /**
+   * Child scopes implied by this one. When this scope is granted, every
+   * descendant is granted and locked (checked + disabled).
+   */
+  children?: ConsentScope[];
+  /**
+   * Pre-checked on mount.
+   * @default false
+   */
+  defaultGranted?: boolean;
+  /**
+   * Always granted; cannot be unchecked. Renders checked + disabled.
+   * @default false
+   */
+  required?: boolean;
+};
+
+/**
+ * All visible copy for the consent screen. Pre-translated by the consumer.
+ */
+export type OAuthConsentLabels = {
+  /** Page heading, e.g. "Authorize access". */
+  title: string;
+  /** Client request line. Receives the client identifier for interpolation. */
+  requestedBy: (clientName: string) => React.ReactNode;
+  /** Section heading above the scope list, e.g. "Requested permissions". */
+  permissionsHeading: string;
+  /** Approve button label, e.g. "Authorize". */
+  approve: string;
+  /** Deny button label, e.g. "Deny". */
+  deny: string;
+  /** Heading shown when required OAuth params are missing. */
+  invalidRequestTitle: string;
+  /** Body text shown when required OAuth params are missing. */
+  invalidRequestBody: string;
+};
+
+/**
+ * Props for the OAuthConsent component.
+ */
+export type OAuthConsentProps = {
+  /** Display name or identifier of the requesting OAuth client. */
+  clientName: string;
+  /** Scope tree to render. */
+  scopes: ConsentScope[];
+  /**
+   * Called when the user approves. Receives the minimal granted scope set
+   * (top-most selected keys; implied descendants omitted). Return `{ ok: true }`
+   * to signal success; the component then calls `onAuthorized`.
+   */
+  onAuthorize: (grantedScopes: string[]) => Promise<{ ok: boolean }>;
+  /**
+   * Called after a successful `onAuthorize`. Use this to redirect to the OAuth
+   * server's resumed /authorize URL. The component does not navigate itself.
+   */
+  onAuthorized: () => void;
+  /** Called when the user clicks Deny. Use this to navigate away. */
+  onDeny: () => void;
+  /**
+   * True while the authorize call is in flight (disables both buttons).
+   * The component also tracks its own internal loading state.
+   */
+  isAuthorizing?: boolean;
+  /**
+   * When false, renders the invalid-request error state instead of the form.
+   * @default true
+   */
+  isValidRequest?: boolean;
+  /** All visible copy. Pre-translated by the consumer. */
+  labels: OAuthConsentLabels;
+};
+
+/**
+ * Walk the scope tree and return the minimal set of granted scope keys.
+ * When a node is selected, its key is emitted and its subtree is skipped
+ * (the server expands parent scopes to their children). Nodes not in
+ * `selected` are recursed into so that individually-selected children
+ * are still captured.
+ */
+export const collectGrantedScopes = (
+  scopes: ConsentScope[],
+  selected: Set<string>
+): string[] => {
+  const result: string[] = [];
+
+  const walk = (nodes: ConsentScope[]) => {
+    for (const node of nodes) {
+      if (selected.has(node.key)) {
+        result.push(node.key);
+      } else if (node.children) {
+        walk(node.children);
+      }
+    }
+  };
+
+  walk(scopes);
+  return result;
+};
+
+const initSelected = (scopes: ConsentScope[]): Set<string> => {
+  const selected = new Set<string>();
+
+  const walk = (nodes: ConsentScope[]) => {
+    for (const node of nodes) {
+      if (node.required || node.defaultGranted) {
+        selected.add(node.key);
+      }
+      if (node.children) {
+        walk(node.children);
+      }
+    }
+  };
+
+  walk(scopes);
+  return selected;
+};
+
+type ScopeRowProps = {
+  scope: ConsentScope;
+  depth: number;
+  ancestorSelected: boolean;
+  selected: Set<string>;
+  busy: boolean;
+  onToggle: (scope: ConsentScope, ancestorSelected: boolean) => void;
+};
+
+const ScopeRow = ({
+  scope,
+  depth,
+  ancestorSelected,
+  selected,
+  busy,
+  onToggle,
+}: ScopeRowProps) => {
+  const isChecked = ancestorSelected || selected.has(scope.key);
+  const isDisabled = scope.required === true || ancestorSelected || busy;
+  const checkboxId = `consent-scope-${scope.key}`;
+  const descId = `consent-scope-desc-${scope.key}`;
+
+  return (
+    <>
+      <Flex
+        sx={{
+          pl: depth * 5,
+          py: 2,
+          alignItems: 'flex-start',
+          gap: 3,
+          opacity: ancestorSelected ? 0.6 : 1,
+        }}
+      >
+        <Box sx={{ pt: '2px', flexShrink: 0 }}>
+          <Checkbox
+            id={checkboxId}
+            checked={isChecked}
+            disabled={isDisabled}
+            aria-describedby={descId}
+            onChange={() => {
+              onToggle(scope, ancestorSelected);
+            }}
+          />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Label
+            htmlFor={checkboxId}
+            sx={{
+              fontWeight: 'bold',
+              cursor: isDisabled ? 'default' : 'pointer',
+              color: 'display.text.primary.default',
+              fontSize: 'inherit',
+              display: 'block',
+            }}
+          >
+            {scope.label}
+          </Label>
+          <Text
+            id={descId}
+            sx={{
+              fontSize: 1,
+              color: 'display.text.muted.default',
+              display: 'block',
+            }}
+          >
+            {scope.description}
+          </Text>
+        </Box>
+      </Flex>
+      {scope.children?.map((child) => {
+        return (
+          <ScopeRow
+            key={child.key}
+            scope={child}
+            depth={depth + 1}
+            ancestorSelected={isChecked}
+            selected={selected}
+            busy={busy}
+            onToggle={onToggle}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+/**
+ * Accessible, framework-agnostic OAuth consent screen component.
+ *
+ * Renders a standards-compliant "authorize this client" page with support for
+ * flat and GitHub-style grouped/hierarchical scopes. Granting a parent scope
+ * automatically locks all descendant scopes (checked + disabled). All visible
+ * copy is injected via `labels`; no strings are hardcoded inside this component.
+ *
+ * @example
+ * ```tsx
+ * <OAuthConsent
+ *   clientName="My App"
+ *   scopes={[
+ *     { key: 'read', label: 'Read', description: 'Read access', required: true },
+ *     { key: 'write', label: 'Write', description: 'Write access' },
+ *   ]}
+ *   onAuthorize={async (scopes) => {
+ *     const res = await authorize({ variables: { scopes } });
+ *     return { ok: !!res.ok };
+ *   }}
+ *   onAuthorized={() => { window.location.href = resumeUrl; }}
+ *   onDeny={() => navigate('/')}
+ *   labels={labels}
+ * />
+ * ```
+ */
+export const OAuthConsent = ({
+  clientName,
+  scopes,
+  onAuthorize,
+  onAuthorized,
+  onDeny,
+  isAuthorizing = false,
+  isValidRequest = true,
+  labels,
+}: OAuthConsentProps) => {
+  const [selected, setSelected] = React.useState<Set<string>>(() => {
+    return initSelected(scopes);
+  });
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const busy = isAuthorizing || isLoading;
+
+  const handleToggle = React.useCallback(
+    (scope: ConsentScope, ancestorSelected: boolean) => {
+      if (scope.required || ancestorSelected) return;
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(scope.key)) {
+          next.delete(scope.key);
+        } else {
+          next.add(scope.key);
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleApprove = React.useCallback(async () => {
+    const grantedScopes = collectGrantedScopes(scopes, selected);
+    setIsLoading(true);
+    try {
+      const result = await onAuthorize(grantedScopes);
+      if (result.ok) {
+        onAuthorized();
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scopes, selected, onAuthorize, onAuthorized]);
+
+  if (!isValidRequest) {
+    return (
+      <Box sx={{ maxWidth: 480, mx: 'auto', mt: 6, p: 4 }}>
+        <Heading as="h1" sx={{ mb: 3, color: 'display.text.primary.default' }}>
+          {labels.invalidRequestTitle}
+        </Heading>
+        <Text sx={{ color: 'display.text.secondary.default' }}>
+          {labels.invalidRequestBody}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ maxWidth: 480, mx: 'auto', mt: 6, p: 4 }}>
+      <Heading as="h1" sx={{ mb: 2, color: 'display.text.primary.default' }}>
+        {labels.title}
+      </Heading>
+
+      <Text sx={{ mb: 4, color: 'display.text.secondary.default' }}>
+        {labels.requestedBy(clientName)}
+      </Text>
+
+      <Heading as="h3" sx={{ mb: 3, color: 'display.text.primary.default' }}>
+        {labels.permissionsHeading}
+      </Heading>
+
+      <Box
+        sx={{
+          mb: 4,
+          border: 'sm',
+          borderColor: 'display.border.muted.default',
+          borderRadius: 'md',
+          px: 3,
+          py: 1,
+        }}
+      >
+        {scopes.map((scope) => {
+          return (
+            <ScopeRow
+              key={scope.key}
+              scope={scope}
+              depth={0}
+              ancestorSelected={false}
+              selected={selected}
+              busy={busy}
+              onToggle={handleToggle}
+            />
+          );
+        })}
+      </Box>
+
+      <Flex sx={{ gap: 3 }}>
+        <Button
+          onClick={handleApprove}
+          disabled={busy}
+          loading={isLoading || isAuthorizing}
+          sx={{ flex: 1 }}
+        >
+          {labels.approve}
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={onDeny}
+          disabled={busy}
+          sx={{ flex: 1 }}
+        >
+          {labels.deny}
+        </Button>
+      </Flex>
+    </Box>
+  );
+};

--- a/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
@@ -449,7 +449,7 @@ export const OAuthConsent = ({
           {labels.deny}
         </Button>
         <Button
-          variant="primary"
+          variant="accent"
           onClick={handleApprove}
           disabled={busy}
           loading={isLoading || isAuthorizing}

--- a/packages/components/src/components/OAuthConsent/index.ts
+++ b/packages/components/src/components/OAuthConsent/index.ts
@@ -1,0 +1,1 @@
+export * from './OAuthConsent';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -15,6 +15,7 @@ export * from './components/Modal';
 export * from './components/NavList';
 export * from './components/NotificationCard';
 export * from './components/NotificationsMenu';
+export * from './components/OAuthConsent';
 export * from './components/Search';
 export * from './components/SpotlightCard';
 export * from './components/Table';

--- a/packages/components/tests/unit/jest.config.ts
+++ b/packages/components/tests/unit/jest.config.ts
@@ -6,10 +6,10 @@ export default jestUnitConfig({
   transformIgnorePatterns: ['node_modules/(?!rehype-raw)/'],
   coverageThreshold: {
     global: {
-      statements: 92.5,
-      branches: 87.4,
-      lines: 93.1,
-      functions: 93.1,
+      statements: 93.3,
+      branches: 88.2,
+      lines: 94.0,
+      functions: 94.0,
     },
   },
   coveragePathIgnorePatterns: ['/index.ts$'],

--- a/packages/components/tests/unit/tests/OAuthConsent.test.tsx
+++ b/packages/components/tests/unit/tests/OAuthConsent.test.tsx
@@ -1,0 +1,431 @@
+import { render, screen, userEvent } from '@ttoss/test-utils/react';
+
+import type {
+  ConsentScope,
+  OAuthConsentProps,
+} from '../../../src/components/OAuthConsent';
+import {
+  collectGrantedScopes,
+  OAuthConsent,
+} from '../../../src/components/OAuthConsent';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const flatScopes: ConsentScope[] = [
+  {
+    key: 'read',
+    label: 'Read',
+    description: 'Read access',
+    required: true,
+  },
+  {
+    key: 'write',
+    label: 'Write',
+    description: 'Write access',
+  },
+];
+
+const groupedScopes: ConsentScope[] = [
+  {
+    key: 'repo',
+    label: 'repo',
+    description: 'Full control of repositories',
+    children: [
+      {
+        key: 'repo:status',
+        label: 'repo:status',
+        description: 'Access commit status',
+      },
+      {
+        key: 'repo:deployment',
+        label: 'repo:deployment',
+        description: 'Access deployment status',
+      },
+    ],
+  },
+  {
+    key: 'write:packages',
+    label: 'write:packages',
+    description: 'Upload packages',
+    children: [
+      {
+        key: 'read:packages',
+        label: 'read:packages',
+        description: 'Download packages',
+      },
+    ],
+  },
+  {
+    key: 'admin:org',
+    label: 'admin:org',
+    description: 'Full control of orgs',
+    children: [
+      {
+        key: 'write:org',
+        label: 'write:org',
+        description: 'Read and write org',
+      },
+      {
+        key: 'read:org',
+        label: 'read:org',
+        description: 'Read org',
+      },
+    ],
+  },
+];
+
+const defaultLabels: OAuthConsentProps['labels'] = {
+  title: 'Authorize access',
+  requestedBy: (name) => {
+    return `${name} is requesting access`;
+  },
+  permissionsHeading: 'Requested permissions',
+  approve: 'Authorize',
+  deny: 'Deny',
+  invalidRequestTitle: 'Invalid request',
+  invalidRequestBody:
+    'The authorization request is missing required parameters.',
+};
+
+const makeProps = (
+  overrides: Partial<OAuthConsentProps> = {}
+): OAuthConsentProps => {
+  return {
+    clientName: 'TestApp',
+    scopes: flatScopes,
+    onAuthorize: jest.fn().mockResolvedValue({ ok: true }),
+    onAuthorized: jest.fn(),
+    onDeny: jest.fn(),
+    labels: defaultLabels,
+    ...overrides,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// collectGrantedScopes unit tests (§7 table)
+// ---------------------------------------------------------------------------
+
+describe('collectGrantedScopes', () => {
+  test('repo checked (children auto-locked) → [repo]', () => {
+    const selected = new Set(['repo', 'repo:status', 'repo:deployment']);
+    expect(collectGrantedScopes(groupedScopes, selected)).toEqual(['repo']);
+  });
+
+  test('only repo:status checked, repo off → [repo:status]', () => {
+    const selected = new Set(['repo:status']);
+    expect(collectGrantedScopes(groupedScopes, selected)).toEqual([
+      'repo:status',
+    ]);
+  });
+
+  test('write:packages checked → read:packages locked → [write:packages]', () => {
+    const selected = new Set(['write:packages', 'read:packages']);
+    expect(collectGrantedScopes(groupedScopes, selected)).toEqual([
+      'write:packages',
+    ]);
+  });
+
+  test('only read:packages checked → [read:packages]', () => {
+    const selected = new Set(['read:packages']);
+    expect(collectGrantedScopes(groupedScopes, selected)).toEqual([
+      'read:packages',
+    ]);
+  });
+
+  test('admin:org off, read:org + write:org checked → [write:org, read:org]', () => {
+    const selected = new Set(['write:org', 'read:org']);
+    const result = collectGrantedScopes(groupedScopes, selected);
+    expect(result).toContain('write:org');
+    expect(result).toContain('read:org');
+    expect(result).not.toContain('admin:org');
+    expect(result).toHaveLength(2);
+  });
+
+  test('required read + optional write checked → [read, write]', () => {
+    const selected = new Set(['read', 'write']);
+    expect(collectGrantedScopes(flatScopes, selected)).toEqual([
+      'read',
+      'write',
+    ]);
+  });
+
+  test('empty selected set → []', () => {
+    expect(collectGrantedScopes(flatScopes, new Set())).toEqual([]);
+  });
+
+  test('only required read checked → [read]', () => {
+    const selected = new Set(['read']);
+    expect(collectGrantedScopes(flatScopes, selected)).toEqual(['read']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OAuthConsent rendering
+// ---------------------------------------------------------------------------
+
+describe('OAuthConsent', () => {
+  test('renders title, request line, permissions heading, and buttons', () => {
+    render(<OAuthConsent {...makeProps()} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Authorize access', level: 1 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('TestApp is requesting access')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Requested permissions', level: 3 })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Authorize' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeInTheDocument();
+  });
+
+  test('renders scope labels and descriptions', () => {
+    render(<OAuthConsent {...makeProps()} />);
+
+    expect(screen.getByText('Read')).toBeInTheDocument();
+    expect(screen.getByText('Read access')).toBeInTheDocument();
+    expect(screen.getByText('Write')).toBeInTheDocument();
+    expect(screen.getByText('Write access')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // required scopes
+  // ---------------------------------------------------------------------------
+
+  test('required scope is checked and disabled', () => {
+    render(<OAuthConsent {...makeProps()} />);
+    const readCheckbox = screen.getByRole('checkbox', { name: 'Read' });
+    expect(readCheckbox).toBeChecked();
+    expect(readCheckbox).toBeDisabled();
+  });
+
+  test('required scope remains checked after click attempt', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps()} />);
+    const readCheckbox = screen.getByRole('checkbox', { name: 'Read' });
+    await user.click(readCheckbox);
+    expect(readCheckbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // optional flat scope toggle
+  // ---------------------------------------------------------------------------
+
+  test('optional scope starts unchecked and can be toggled on', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps()} />);
+    const writeCheckbox = screen.getByRole('checkbox', { name: 'Write' });
+    expect(writeCheckbox).not.toBeChecked();
+    await user.click(writeCheckbox);
+    expect(writeCheckbox).toBeChecked();
+  });
+
+  test('checked optional scope can be toggled off', async () => {
+    const user = userEvent.setup();
+    render(
+      <OAuthConsent
+        {...makeProps({
+          scopes: [
+            {
+              key: 'write',
+              label: 'Write',
+              description: 'Write',
+              defaultGranted: true,
+            },
+          ],
+        })}
+      />
+    );
+    const writeCheckbox = screen.getByRole('checkbox', { name: 'Write' });
+    expect(writeCheckbox).toBeChecked();
+    await user.click(writeCheckbox);
+    expect(writeCheckbox).not.toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hierarchical / grouped scope behavior
+  // ---------------------------------------------------------------------------
+
+  test('checking a parent locks and checks all descendants', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps({ scopes: groupedScopes })} />);
+
+    const repoCheckbox = screen.getByRole('checkbox', { name: 'repo' });
+    expect(repoCheckbox).not.toBeChecked();
+
+    await user.click(repoCheckbox);
+
+    expect(screen.getByRole('checkbox', { name: 'repo' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'repo:status' })).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'repo:status' })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', { name: 'repo:deployment' })
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'repo:deployment' })
+    ).toBeDisabled();
+  });
+
+  test('unchecking parent releases descendants to independent state', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps({ scopes: groupedScopes })} />);
+
+    const repoCheckbox = screen.getByRole('checkbox', { name: 'repo' });
+    await user.click(repoCheckbox); // check parent
+    await user.click(repoCheckbox); // uncheck parent
+
+    expect(screen.getByRole('checkbox', { name: 'repo' })).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'repo:status' })
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', { name: 'repo:deployment' })
+    ).not.toBeDisabled();
+  });
+
+  test('children can be toggled independently when parent is unchecked', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps({ scopes: groupedScopes })} />);
+
+    const statusCheckbox = screen.getByRole('checkbox', {
+      name: 'repo:status',
+    });
+    expect(statusCheckbox).not.toBeChecked();
+    await user.click(statusCheckbox);
+    expect(statusCheckbox).toBeChecked();
+
+    // sibling stays unchecked
+    expect(
+      screen.getByRole('checkbox', { name: 'repo:deployment' })
+    ).not.toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // onAuthorize / onAuthorized / onDeny callbacks
+  // ---------------------------------------------------------------------------
+
+  test('onAuthorize receives minimal scope set on Authorize click', async () => {
+    const user = userEvent.setup();
+    const onAuthorize = jest.fn().mockResolvedValue({ ok: true });
+    const onAuthorized = jest.fn();
+
+    render(<OAuthConsent {...makeProps({ onAuthorize, onAuthorized })} />);
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    expect(onAuthorize).toHaveBeenCalledWith(['read']);
+    expect(onAuthorized).toHaveBeenCalled();
+  });
+
+  test('onAuthorize receives write scope when write is also checked', async () => {
+    const user = userEvent.setup();
+    const onAuthorize = jest.fn().mockResolvedValue({ ok: true });
+    render(<OAuthConsent {...makeProps({ onAuthorize })} />);
+
+    await user.click(screen.getByRole('checkbox', { name: 'Write' }));
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    expect(onAuthorize).toHaveBeenCalledWith(
+      expect.arrayContaining(['read', 'write'])
+    );
+    expect(onAuthorize).toHaveBeenCalledWith(
+      expect.not.arrayContaining(['extra'])
+    );
+  });
+
+  test('onAuthorized is NOT called when onAuthorize returns { ok: false }', async () => {
+    const user = userEvent.setup();
+    const onAuthorize = jest.fn().mockResolvedValue({ ok: false });
+    const onAuthorized = jest.fn();
+
+    render(<OAuthConsent {...makeProps({ onAuthorize, onAuthorized })} />);
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    expect(onAuthorized).not.toHaveBeenCalled();
+  });
+
+  test('onDeny is called when Deny is clicked', async () => {
+    const user = userEvent.setup();
+    const onDeny = jest.fn();
+
+    render(<OAuthConsent {...makeProps({ onDeny })} />);
+    await user.click(screen.getByRole('button', { name: 'Deny' }));
+
+    expect(onDeny).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // isAuthorizing prop
+  // ---------------------------------------------------------------------------
+
+  test('buttons are disabled when isAuthorizing is true', () => {
+    render(<OAuthConsent {...makeProps({ isAuthorizing: true })} />);
+    expect(screen.getByRole('button', { name: /Authorize/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeDisabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // isValidRequest={false}
+  // ---------------------------------------------------------------------------
+
+  test('renders invalid-request state when isValidRequest is false', () => {
+    render(<OAuthConsent {...makeProps({ isValidRequest: false })} />);
+    expect(screen.getByText('Invalid request')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The authorization request is missing required parameters.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Authorize' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders consent form when isValidRequest is true (default)', () => {
+    render(<OAuthConsent {...makeProps({ isValidRequest: true })} />);
+    expect(
+      screen.getByRole('button', { name: 'Authorize' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Invalid request')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hierarchical onAuthorize minimal set
+  // ---------------------------------------------------------------------------
+
+  test('onAuthorize receives [repo] when repo is checked (children implied)', async () => {
+    const user = userEvent.setup();
+    const onAuthorize = jest.fn().mockResolvedValue({ ok: true });
+    render(
+      <OAuthConsent {...makeProps({ scopes: groupedScopes, onAuthorize })} />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'repo' }));
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    expect(onAuthorize).toHaveBeenCalledWith(['repo']);
+  });
+
+  test('onAuthorize receives [read:org, write:org] when children checked and parent unchecked', async () => {
+    const user = userEvent.setup();
+    const onAuthorize = jest.fn().mockResolvedValue({ ok: true });
+    render(
+      <OAuthConsent {...makeProps({ scopes: groupedScopes, onAuthorize })} />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'read:org' }));
+    await user.click(screen.getByRole('checkbox', { name: 'write:org' }));
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    const called = onAuthorize.mock.calls[0][0] as string[];
+    expect(called).toContain('read:org');
+    expect(called).toContain('write:org');
+    expect(called).not.toContain('admin:org');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `OAuthConsent` component to `@ttoss/components` — a reusable, framework-agnostic OAuth consent screen with zero hardcoded strings (all copy via `labels` prop)
- Supports **flat scopes** and **GitHub-style grouped/hierarchical scopes**: checking a parent scope locks all descendant checkboxes (checked + disabled), mirroring GitHub's `repo` → `repo:status` behavior
- Exports `collectGrantedScopes` — a pure helper that returns the minimal top-most scope set (implied descendants omitted), unit-tested against all 6 cases from the PRD §7 table
- Adds 5 Storybook stories: flat scopes, grouped scopes, required scope, invalid-request state, and loading/authorizing state
- 26 new unit tests; overall coverage improved from 92.5% → 93.3% statements

## Component API highlights

```ts
<OAuthConsent
  clientName="MyApp"
  scopes={[
    { key: 'read', label: 'Read', description: '...', required: true },
    { key: 'write', label: 'Write', description: '...' },
  ]}
  onAuthorize={async (scopes) => ({ ok: true })}
  onAuthorized={() => { window.location.href = resumeUrl; }}
  onDeny={() => navigate('/')}
  isValidRequest={!!clientId && !!codeChallenge}
  labels={labels}
/>
```

## Test plan

- [x] `collectGrantedScopes` unit tests for all §7 table rows pass
- [x] Checking a parent locks + checks all descendants; unchecking releases them
- [x] `required` scope cannot be unchecked
- [x] `onAuthorize` receives the minimal set; `onAuthorized` fires only on `{ ok: true }`
- [x] `onDeny` fires on Deny; buttons disabled when `isAuthorizing`
- [x] Invalid-request state renders when `isValidRequest={false}`
- [x] All 255 tests in `@ttoss/components` pass
- [x] Lint and syncpack checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDexBRaj6xyQvFvUAALuth

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDexBRaj6xyQvFvUAALuth)_