### PR TITLE
feat(auth-core): add createRedirectConsentOnAuthorize and Postgres consent store

### DIFF
--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -60,6 +60,17 @@ export {
   verifyOneTimeToken,
 } from './oneTimeToken';
 export {
+  type ConsentStoreQuery,
+  createPostgresConsentStore,
+  type CreatePostgresConsentStoreOptions,
+} from './postgresConsentStore';
+export {
+  type ConsentGrant,
+  type ConsentGrantStore,
+  createRedirectConsentOnAuthorize,
+  type CreateRedirectConsentOnAuthorizeOptions,
+} from './redirectConsentOnAuthorize';
+export {
   createRefreshRotation,
   type IssueRefreshTokenArgs,
   type RefreshRotation,

--- a/packages/auth-core/src/postgresConsentStore.ts
+++ b/packages/auth-core/src/postgresConsentStore.ts
@@ -1,0 +1,83 @@
+import type {
+  ConsentGrant,
+  ConsentGrantStore,
+} from './redirectConsentOnAuthorize';
+
+/**
+ * Minimal query interface compatible with both `pg` Pool.query and
+ * `@ttoss/lambda-postgres-query`'s `query` function. The caller injects
+ * whichever runner they use; `@ttoss/auth-core` has no database dependency.
+ */
+export type ConsentStoreQuery = <
+  Row extends Record<string, unknown> = Record<string, unknown>,
+>(params: {
+  text: string;
+  values?: unknown[];
+}) => Promise<{ rows: Row[] }>;
+
+/**
+ * Options for {@link createPostgresConsentStore}.
+ */
+export type CreatePostgresConsentStoreOptions = {
+  /** Injected Postgres query runner. */
+  query: ConsentStoreQuery;
+  /**
+   * Table name for consent grants.
+   * @default 'oauth_consent_grants'
+   */
+  tableName?: string;
+};
+
+type ConsentGrantRow = {
+  subject: string;
+  /** Space-separated scope string as stored in the database. */
+  scopes: string;
+  /** ISO timestamp or epoch milliseconds as a string. */
+  expires_at: string;
+};
+
+/**
+ * Creates a {@link ConsentGrantStore} backed by a Postgres table.
+ *
+ * Expected table schema:
+ * ```sql
+ * CREATE TABLE oauth_consent_grants (
+ *   code_challenge  TEXT PRIMARY KEY,
+ *   subject         TEXT        NOT NULL,
+ *   scopes          TEXT        NOT NULL,
+ *   expires_at      TIMESTAMPTZ NOT NULL
+ * );
+ * ```
+ *
+ * The `query` parameter is injected so the caller can use any runner
+ * (`pg` Pool, `@ttoss/lambda-postgres-query`, etc.).
+ */
+export const createPostgresConsentStore = ({
+  query,
+  tableName = 'oauth_consent_grants',
+}: CreatePostgresConsentStoreOptions): ConsentGrantStore => {
+  return {
+    getConsentGrant: async ({ codeChallenge }) => {
+      const result = await query<ConsentGrantRow>({
+        text: `SELECT subject, scopes, expires_at FROM ${tableName} WHERE code_challenge = $1`,
+        values: [codeChallenge],
+      });
+
+      const row = result.rows[0];
+      if (!row) return undefined;
+
+      return {
+        subject: row.subject,
+        scopes: row.scopes.split(' ').filter(Boolean),
+        expiresAt: new Date(row.expires_at).getTime(),
+      } satisfies ConsentGrant;
+    },
+
+    deleteConsentGrant: async ({ codeChallenge }) => {
+      await query({
+        text: `DELETE FROM ${tableName} WHERE code_challenge = $1`,
+        values: [codeChallenge],
+      });
+    },
+  };
+};

--- a/packages/auth-core/src/redirectConsentOnAuthorize.ts
+++ b/packages/auth-core/src/redirectConsentOnAuthorize.ts
@@ -1,0 +1,88 @@
+import type { OnAuthorizeArgs, OnAuthorizeResult } from './oauthServerTypes';
+
+/**
+ * A consent grant stored by `codeChallenge` (PKCE), representing a
+ * previously-approved authorization that the `onAuthorize` hook can consume.
+ */
+export type ConsentGrant = {
+  /** The authenticated end-user subject identifier. */
+  subject: string;
+  /** The scopes the user approved. */
+  scopes: string[];
+  /** Unix timestamp (milliseconds) after which the grant is invalid. */
+  expiresAt: number;
+};
+
+/**
+ * Persistence contract for consent grants, correlated by PKCE `codeChallenge`.
+ * The write side (creating a grant) lives in the application; this interface
+ * covers only what the `onAuthorize` hook needs: read and single-use consume.
+ */
+export type ConsentGrantStore = {
+  /** Look up a consent grant by its PKCE `codeChallenge`. */
+  getConsentGrant: (params: {
+    codeChallenge: string;
+  }) => Promise<ConsentGrant | undefined>;
+  /** Delete a consent grant (called after consumption to enforce single-use). */
+  deleteConsentGrant: (params: { codeChallenge: string }) => Promise<void>;
+};
+
+/**
+ * Options for {@link createRedirectConsentOnAuthorize}.
+ */
+export type CreateRedirectConsentOnAuthorizeOptions = {
+  /**
+   * Base URL of the external consent screen. OAuth parameters are appended as
+   * query-string values: `client_id`, `redirect_uri`, `code_challenge`,
+   * `code_challenge_method`, `scope`, and `state` (when present).
+   */
+  consentUrl: string;
+} & ConsentGrantStore;
+
+/**
+ * Factory that produces the `onAuthorize` hook for an OAuth server with a
+ * deferred/external consent screen.
+ *
+ * Flow:
+ * 1. If a valid (non-expired) consent grant exists for `request.codeChallenge`,
+ *    it is consumed (deleted, single-use) and `{ approved: true }` is returned.
+ * 2. Otherwise the user is redirected to `consentUrl` with the full OAuth
+ *    request parameters so the consent screen can record its approval and
+ *    restart the authorization flow.
+ */
+export const createRedirectConsentOnAuthorize = ({
+  consentUrl,
+  getConsentGrant,
+  deleteConsentGrant,
+}: CreateRedirectConsentOnAuthorizeOptions) => {
+  return async (args: OnAuthorizeArgs): Promise<OnAuthorizeResult> => {
+    const { request } = args;
+    const {
+      codeChallenge,
+      codeChallengeMethod,
+      clientId,
+      redirectUri,
+      scopes,
+      state,
+    } = request;
+
+    const grant = await getConsentGrant({ codeChallenge });
+
+    if (grant && grant.expiresAt > Date.now()) {
+      await deleteConsentGrant({ codeChallenge });
+      return { approved: true, subject: grant.subject, scopes: grant.scopes };
+    }
+
+    const url = new URL(consentUrl);
+    url.searchParams.set('client_id', clientId);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('code_challenge_method', codeChallengeMethod);
+    url.searchParams.set('scope', scopes.join(' '));
+    if (state !== undefined) {
+      url.searchParams.set('state', state);
+    }
+
+    return { approved: false, redirect: url.toString() };
+  };
+};

--- a/packages/auth-core/tests/unit/tests/postgresConsentStore.test.ts
+++ b/packages/auth-core/tests/unit/tests/postgresConsentStore.test.ts
@@ -1,0 +1,120 @@
+import {
+  type ConsentStoreQuery,
+  createPostgresConsentStore,
+} from '../../../src/index';
+
+const makeQuery = (
+  rows: Record<string, unknown>[] = []
+): jest.MockedFunction<ConsentStoreQuery> => {
+  return jest.fn(async () => {
+    return { rows };
+  });
+};
+
+describe('createPostgresConsentStore', () => {
+  const CODE_CHALLENGE = 'pkce-challenge-abc';
+
+  describe('getConsentGrant', () => {
+    test('returns undefined when no row is found', async () => {
+      const query = makeQuery([]);
+      const store = createPostgresConsentStore({ query });
+
+      const result = await store.getConsentGrant({
+        codeChallenge: CODE_CHALLENGE,
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    test('returns a parsed ConsentGrant when a row is found', async () => {
+      const expiresAt = new Date('2099-01-01T00:00:00.000Z');
+      const query = makeQuery([
+        {
+          subject: 'user-42',
+          scopes: 'openid profile',
+          expires_at: expiresAt.toISOString(),
+        },
+      ]);
+      const store = createPostgresConsentStore({ query });
+
+      const result = await store.getConsentGrant({
+        codeChallenge: CODE_CHALLENGE,
+      });
+
+      expect(result).toEqual({
+        subject: 'user-42',
+        scopes: ['openid', 'profile'],
+        expiresAt: expiresAt.getTime(),
+      });
+    });
+
+    test('queries with the correct code_challenge parameter', async () => {
+      const query = makeQuery([]);
+      const store = createPostgresConsentStore({ query });
+
+      await store.getConsentGrant({ codeChallenge: CODE_CHALLENGE });
+
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({ values: [CODE_CHALLENGE] })
+      );
+    });
+
+    test('uses the default table name in the query', async () => {
+      const query = makeQuery([]);
+      const store = createPostgresConsentStore({ query });
+
+      await store.getConsentGrant({ codeChallenge: CODE_CHALLENGE });
+
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('oauth_consent_grants'),
+        })
+      );
+    });
+
+    test('uses a custom table name when provided', async () => {
+      const query = makeQuery([]);
+      const store = createPostgresConsentStore({
+        query,
+        tableName: 'my_consent_grants',
+      });
+
+      await store.getConsentGrant({ codeChallenge: CODE_CHALLENGE });
+
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('my_consent_grants'),
+        })
+      );
+    });
+  });
+
+  describe('deleteConsentGrant', () => {
+    test('issues a DELETE query with the correct code_challenge', async () => {
+      const query = makeQuery();
+      const store = createPostgresConsentStore({ query });
+
+      await store.deleteConsentGrant({ codeChallenge: CODE_CHALLENGE });
+
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({ values: [CODE_CHALLENGE] })
+      );
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringMatching(/DELETE/i) })
+      );
+    });
+
+    test('uses the default table name in the DELETE query', async () => {
+      const query = makeQuery();
+      const store = createPostgresConsentStore({ query });
+
+      await store.deleteConsentGrant({ codeChallenge: CODE_CHALLENGE });
+
+      expect(query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining('oauth_consent_grants'),
+        })
+      );
+    });
+  });
+});

--- a/packages/auth-core/tests/unit/tests/redirectConsentOnAuthorize.test.ts
+++ b/packages/auth-core/tests/unit/tests/redirectConsentOnAuthorize.test.ts
@@ -1,0 +1,184 @@
+import {
+  type ConsentGrant,
+  type ConsentGrantStore,
+  createRedirectConsentOnAuthorize,
+  type OnAuthorizeArgs,
+} from '../../../src/index';
+
+const CONSENT_URL = 'https://app.example.com/oauth/consent';
+
+const makeArgs = (
+  overrides: Partial<OnAuthorizeArgs['request']> = {}
+): OnAuthorizeArgs => {
+  return {
+    client: {
+      client_id: 'client-abc',
+      redirect_uris: ['https://app.example.com/callback'],
+    },
+    request: {
+      clientId: 'client-abc',
+      redirectUri: 'https://app.example.com/callback',
+      scopes: ['openid', 'profile'],
+      codeChallenge: 'test-code-challenge',
+      codeChallengeMethod: 'S256',
+      state: 'random-state',
+      ...overrides,
+    },
+    headers: {},
+  };
+};
+
+const makeStore = (
+  grant?: ConsentGrant
+): ConsentGrantStore & {
+  deleted: string[];
+} => {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    getConsentGrant: jest.fn(async () => {
+      return grant;
+    }),
+    deleteConsentGrant: jest.fn(async ({ codeChallenge }) => {
+      deleted.push(codeChallenge);
+    }),
+  };
+};
+
+describe('createRedirectConsentOnAuthorize', () => {
+  describe('when no consent grant exists', () => {
+    test('redirects to the consent URL with OAuth parameters', async () => {
+      const store = makeStore(undefined);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      const result = await onAuthorize(makeArgs());
+
+      expect(result).toMatchObject({ approved: false });
+      if (result.approved) throw new Error('should be false');
+
+      const redirectUrl = new URL(result.redirect!);
+      expect(redirectUrl.origin + redirectUrl.pathname).toBe(CONSENT_URL);
+      expect(redirectUrl.searchParams.get('client_id')).toBe('client-abc');
+      expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
+        'https://app.example.com/callback'
+      );
+      expect(redirectUrl.searchParams.get('code_challenge')).toBe(
+        'test-code-challenge'
+      );
+      expect(redirectUrl.searchParams.get('code_challenge_method')).toBe(
+        'S256'
+      );
+      expect(redirectUrl.searchParams.get('scope')).toBe('openid profile');
+      expect(redirectUrl.searchParams.get('state')).toBe('random-state');
+    });
+
+    test('does not include state param when state is undefined', async () => {
+      const store = makeStore(undefined);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      const result = await onAuthorize(makeArgs({ state: undefined }));
+
+      expect(result.approved).toBe(false);
+      if (result.approved) throw new Error('should be false');
+
+      const redirectUrl = new URL(result.redirect!);
+      expect(redirectUrl.searchParams.has('state')).toBe(false);
+    });
+
+    test('does not call deleteConsentGrant', async () => {
+      const store = makeStore(undefined);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      await onAuthorize(makeArgs());
+
+      expect(store.deleteConsentGrant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a valid (non-expired) consent grant exists', () => {
+    test('returns approved: true with subject and scopes', async () => {
+      const grant: ConsentGrant = {
+        subject: 'user-123',
+        scopes: ['openid', 'profile'],
+        expiresAt: Date.now() + 60_000,
+      };
+      const store = makeStore(grant);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      const result = await onAuthorize(makeArgs());
+
+      expect(result).toEqual({
+        approved: true,
+        subject: 'user-123',
+        scopes: ['openid', 'profile'],
+      });
+    });
+
+    test('consumes (deletes) the grant to enforce single-use', async () => {
+      const grant: ConsentGrant = {
+        subject: 'user-123',
+        scopes: ['openid'],
+        expiresAt: Date.now() + 60_000,
+      };
+      const store = makeStore(grant);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      await onAuthorize(makeArgs());
+
+      expect(store.deleteConsentGrant).toHaveBeenCalledWith({
+        codeChallenge: 'test-code-challenge',
+      });
+    });
+  });
+
+  describe('when a consent grant exists but is expired', () => {
+    test('redirects to the consent URL instead of approving', async () => {
+      const grant: ConsentGrant = {
+        subject: 'user-123',
+        scopes: ['openid'],
+        expiresAt: Date.now() - 1, // already expired
+      };
+      const store = makeStore(grant);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      const result = await onAuthorize(makeArgs());
+
+      expect(result.approved).toBe(false);
+    });
+
+    test('does not call deleteConsentGrant for an expired grant', async () => {
+      const grant: ConsentGrant = {
+        subject: 'user-123',
+        scopes: ['openid'],
+        expiresAt: Date.now() - 1,
+      };
+      const store = makeStore(grant);
+      const onAuthorize = createRedirectConsentOnAuthorize({
+        consentUrl: CONSENT_URL,
+        ...store,
+      });
+
+      await onAuthorize(makeArgs());
+
+      expect(store.deleteConsentGrant).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `createRedirectConsentOnAuthorize` factory to `@ttoss/auth-core` — produces an `onAuthorize` hook for OAuth servers with an external/deferred consent screen, correlated by PKCE `code_challenge`
- Adds `createPostgresConsentStore` factory — creates `getConsentGrant`/`deleteConsentGrant` adapters from an injected query function (compatible with `pg` Pool and `@ttoss/lambda-postgres-query`), with a configurable table name (default: `oauth_consent_grants`)
- Full test coverage on both new modules (100%), 141 tests total passing

## Behavior

The `onAuthorize` hook produced by `createRedirectConsentOnAuthorize`:
1. Looks up a consent grant by PKCE `codeChallenge`
2. If the grant exists and is not expired → deletes it (single-use) and returns `{ approved: true, subject, scopes }`
3. Otherwise → redirects to `consentUrl` with OAuth parameters (`client_id`, `redirect_uri`, `code_challenge`, `code_challenge_method`, `scope`, `state?`)

## Expected Postgres schema

```sql
CREATE TABLE oauth_consent_grants (
  code_challenge  TEXT PRIMARY KEY,
  subject         TEXT        NOT NULL,
  scopes          TEXT        NOT NULL,
  expires_at      TIMESTAMPTZ NOT NULL
);
```

## Test plan

- [x] `createRedirectConsentOnAuthorize`: redirects when no grant, redirects when expired, approves + deletes when valid, omits `state` when undefined
- [x] `createPostgresConsentStore`: returns `undefined` when no row, parses row correctly, uses correct `code_challenge` param, respects default and custom table names, issues DELETE with correct params
- [x] All 141 tests pass with no regressions

Closes #[issue number — deferred consent onAuthorize extraction, item 2]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01We54h5CHVhMrLabdMBSmL7

---
_Generated by [Claude Code](https://claude.ai/code/session_01We54h5CHVhMrLabdMBSmL7)_