### PR TITLE
feat(http-server-mcp): generic getIdentity<T>, stateless docs, testing guide

### DIFF
--- a/docs/website/docs/engineering/guidelines/mcp-server-oauth.md
+++ b/docs/website/docs/engineering/guidelines/mcp-server-oauth.md
@@ -103,13 +103,16 @@ const mcpRouter = createMcpRouter(mcpServer, {
     // Emit RFC 9728 discovery on 401.
     resourceMetadataUrl:
       'https://mcp.example.com/.well-known/oauth-protected-resource',
-    // Defaults to ['initialize', 'tools/list'].
-    publicMethods: ['initialize', 'tools/list'],
+    // Set publicMethods: [] when you need OAuth clients to authenticate
+    // before anything else (see note below). Defaults to ['initialize', 'tools/list'].
+    publicMethods: [],
   },
 });
 ```
 
 Setting both `resourceServerUrl` and `authorizationServerUrl` also serves that metadata document at `/.well-known/oauth-protected-resource`, completing the discovery chain the `WWW-Authenticate` header points to.
+
+**`publicMethods` and the OAuth flow.** With the default `['initialize', 'tools/list']`, an OAuth-aware client (Claude connector, Cursor) receives `200` on `initialize` and concludes the server is public — it never starts the OAuth PKCE flow, while `notifications/initialized` still returns `401`, silently breaking the handshake. The visible symptom is "connected, no tools available, no sign-in prompt". Setting `publicMethods: []` makes `initialize` return `401 + WWW-Authenticate`, which is what triggers the client's OAuth discovery and login. Use the default only when auth is handled outside the client-initiated OAuth flow (e.g. API keys or tokens injected by a gateway); set `publicMethods: []` whenever you want the client to authenticate itself before any other interaction.
 
 ## Authorization server: issuing tokens
 

--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -213,15 +213,19 @@ The router emits `401 Unauthorized` whenever `verifyToken` throws, regardless of
 Inside any tool handler, call `getIdentity()` to retrieve the verified JWT payload:
 
 ```typescript
-import { getIdentity, createMcpRouter, McpServer } from '@ttoss/http-server-mcp';
+import {
+  getIdentity,
+  createMcpRouter,
+  McpServer,
+} from '@ttoss/http-server-mcp';
 
 mcpServer.registerTool(
   'get-profile',
-  { description: 'Return the caller's profile', inputSchema: {} },
+  { description: "Return the caller's profile", inputSchema: {} },
   async () => {
-    const identity = getIdentity() as { sub: string; email: string };
+    const identity = getIdentity<{ sub: string; email: string }>();
     return {
-      content: [{ type: 'text', text: `Hello, ${identity.email}` }],
+      content: [{ type: 'text', text: `Hello, ${identity?.email}` }],
     };
   }
 );
@@ -253,7 +257,7 @@ mcpServer.registerTool(
   async ({ userId }) => {
     checkScopes(['admin', 'write:users']); // throws if either scope is missing
 
-    const identity = getIdentity() as { sub: string };
+    const identity = getIdentity<{ sub: string }>();
     // proceed with deletion...
     return { content: [{ type: 'text', text: `Deleted ${userId}` }] };
   }
@@ -404,11 +408,14 @@ Generic HTTP helper for use inside MCP tool handlers.
 
 **Returns:** `Promise<unknown>` — Parsed JSON response body
 
-### `getIdentity()`
+### `getIdentity<T>()`
 
 Returns the verified JWT payload for the current MCP request. Only available inside a tool handler when `auth` is configured. Returns `undefined` when called outside an authenticated context.
 
-**Returns:** `unknown` — Verified token payload (cast to your expected shape)
+Accepts an optional type parameter so tool handlers can avoid manual casts:
+`getIdentity<{ sub: string; scope: string }>()` returns `T | undefined` instead of `unknown`.
+
+**Returns:** `T | undefined` — Verified token payload typed as `T` (defaults to `unknown`)
 
 ### `checkScopes(required)`
 
@@ -659,8 +666,64 @@ This package implements the [Model Context Protocol](https://spec.modelcontextpr
 
 ### Stateless vs stateful mode
 
-- **Stateless** (default, `sessionIdGenerator: undefined`) — a fresh transport is created per HTTP request. No session tracking. Suitable for serverless environments and simple integrations.
-- **Stateful** (`sessionIdGenerator` provided) — a single shared transport handles all requests and tracks sessions by ID.
+The router runs **stateless by default**: each request creates a fresh transport, and no `Mcp-Session-Id` is issued. This is the right mode for Bearer/API-token auth, serverless functions, and any multi-instance deployment, because every request carries its own identity through `auth.verifyToken` — there is no session to coordinate across instances.
+
+Pass `sessionIdGenerator` only when you have a genuine session requirement: server-initiated events over SSE, or streaming that must preserve context across multiple requests. Stateful mode keeps a single shared transport per session, so it needs session affinity (or shared state) when running behind more than one instance.
+
+If you authenticate with `auth.verifyToken`, you do not need `sessionIdGenerator`. The identity is resolved from the token on every request, so adding session tracking only adds coordination cost. Mixing the two — stateful transport plus per-request token auth — is the common source of "tools/call fails after initialize" bugs: the client binds to a session the auth layer never consults.
+
+| Mode                            | When                                          | Trade-off                             |
+| ------------------------------- | --------------------------------------------- | ------------------------------------- |
+| Stateless (default)             | Bearer/API tokens, serverless, multi-instance | DB/verify hit per request             |
+| Stateful (`sessionIdGenerator`) | SSE events, context-preserving streams        | Needs session affinity / shared state |
+
+## Testing an MCP server
+
+MCP requests are plain JSON-RPC POSTs to the router path. The `initialize` and `tools/list` methods are public by default, so they need no auth header; `tools/call` runs through `auth.verifyToken`. The client must send `Accept: application/json, text/event-stream` — the transport rejects requests that do not accept the event-stream media type.
+
+```typescript
+const res = await request(app.callback())
+  .post('/mcp')
+  .set('Content-Type', 'application/json')
+  .set('Accept', 'application/json, text/event-stream')
+  .send({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '1.0.0' },
+    },
+  });
+expect(res.status).toBe(200);
+// Stateless mode (default): no session header is issued.
+// Stateful mode (sessionIdGenerator set): assert the header instead.
+expect(res.headers['mcp-session-id']).toBeUndefined();
+
+// A tool call carries identity through the Authorization header, not a session.
+const call = await request(app.callback())
+  .post('/mcp')
+  .set('Content-Type', 'application/json')
+  .set('Accept', 'application/json, text/event-stream')
+  .set('Authorization', `Bearer ${token}`)
+  .send({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name: 'my-tool', arguments: {} },
+  });
+expect(call.status).toBe(200);
+```
+
+### `publicMethods` and OAuth clients
+
+`auth.publicMethods` defaults to `['initialize', 'tools/list']`, which lets clients discover the server before they have a token. This default has an important effect on OAuth-aware clients (e.g. a Claude connector):
+
+- With the default, `initialize` returns `200` unauthenticated, so an OAuth client concludes the server is public and never starts the OAuth flow — while `notifications/initialized` still returns `401`, breaking the handshake. The visible symptom is "connected, no tools available, no sign-in prompt".
+- Setting `publicMethods: []` makes `initialize` return `401` + `WWW-Authenticate`, which triggers the client's OAuth discovery and PKCE flow.
+
+Use the default when token auth is handled outside the OAuth flow (Cognito, API keys, Bearer tokens). Set `publicMethods: []` only when you want OAuth clients to self-discover and authenticate before anything else.
 
 ## AWS Lambda Deployment
 

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -237,9 +237,13 @@ export const apiCall = async (
 /**
  * Returns the verified JWT payload for the current MCP request.
  * Only available inside a tool handler when `auth` is configured on the router.
+ *
+ * Accepts an optional type parameter to avoid casting at call sites:
+ * `getIdentity<{ sub: string; email: string }>()` returns `T | undefined`.
+ * Omitting the type parameter keeps the return type as `unknown | undefined`.
  */
-export const getIdentity = (): unknown => {
-  return requestContextStore.getStore()?.identity;
+export const getIdentity = <T = unknown>(): T | undefined => {
+  return requestContextStore.getStore()?.identity as T | undefined;
 };
 
 /**


### PR DESCRIPTION
## Summary

Three non-breaking improvements to `@ttoss/http-server-mcp` that came out of the upstream issue about stateless-vs-stateful confusion and missing `getIdentity` typing:

- **`getIdentity<T>()`** is now generic — returns `T | undefined` instead of `unknown`, removing casts in tool handlers. Existing callers that omit the type parameter keep `unknown`.
- **Stateless vs stateful** section in the README is expanded with a decision table and an explanation of why `sessionIdGenerator` is unnecessary (and causes the `tools/call` failure) when `auth.verifyToken` already resolves identity per request.
- **Testing an MCP server** section added to the README with a working `supertest` snippet showing the required `Accept` header and the `mcp-session-id: undefined` assertion for stateless mode.
- **`publicMethods` / OAuth client** note added explaining the `initialize`-returns-200 footgun and when to set `publicMethods: []` to trigger the OAuth flow.

## Test plan

- [x] All 72 existing unit tests pass (`pnpm run test` in `packages/http-server-mcp`)
- [x] No TypeScript errors — `getIdentity<T>()` is source-compatible; callers without a type param still compile
- [x] Prettier and ESLint pass (pre-commit hook green)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8GCLL2iCNAaqAD3Y4U9xh)_