### PR TITLE
fix(components): make entire OAuthConsent scope row toggle the checkbox

### DIFF
--- a/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
@@ -6,7 +6,6 @@ import {
   Divider,
   Flex,
   Heading,
-  Label,
   Text,
 } from '@ttoss/ui';
 import * as React from 'react';
@@ -176,11 +175,13 @@ const ScopeRow = ({
     busy,
   });
   const checkboxId = `consent-scope-${scope.key}`;
+  const labelId = `consent-scope-label-${scope.key}`;
   const descId = `consent-scope-desc-${scope.key}`;
 
   return (
     <Box as="li" sx={{ listStyle: 'none' }}>
       <Flex
+        as="label"
         sx={{
           gap: 3,
           alignItems: 'flex-start',
@@ -189,6 +190,7 @@ const ScopeRow = ({
           borderRadius: 'md',
           opacity: ancestorSelected ? 0.55 : 1,
           transition: 'background-color 0.15s ease',
+          cursor: isInteractive ? 'pointer' : 'default',
           ...(isInteractive && {
             '&:hover': {
               backgroundColor: 'display.background.muted.default',
@@ -201,6 +203,7 @@ const ScopeRow = ({
             id={checkboxId}
             checked={isChecked}
             disabled={isDisabled}
+            aria-labelledby={labelId}
             aria-describedby={descId}
             onChange={() => {
               onToggle(scope, ancestorSelected);
@@ -208,19 +211,19 @@ const ScopeRow = ({
           />
         </Box>
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Label
-            htmlFor={checkboxId}
+          <Text
+            as="span"
+            id={labelId}
             sx={{
               fontWeight: 'semibold',
               fontSize: 'md',
               lineHeight: 'short',
-              cursor: isInteractive ? 'pointer' : 'default',
               color: 'display.text.primary.default',
-              width: 'fit-content',
+              display: 'block',
             }}
           >
             {scope.label}
-          </Label>
+          </Text>
           <Text
             id={descId}
             sx={{

--- a/packages/components/tests/unit/jest.config.ts
+++ b/packages/components/tests/unit/jest.config.ts
@@ -6,10 +6,10 @@ export default jestUnitConfig({
   transformIgnorePatterns: ['node_modules/(?!rehype-raw)/'],
   coverageThreshold: {
     global: {
-      statements: 93.3,
-      branches: 88.2,
-      lines: 94.0,
-      functions: 94.0,
+      statements: 93.5,
+      branches: 88.4,
+      lines: 94.1,
+      functions: 94.1,
     },
   },
   coveragePathIgnorePatterns: ['/index.ts$'],

--- a/packages/components/tests/unit/tests/OAuthConsent.test.tsx
+++ b/packages/components/tests/unit/tests/OAuthConsent.test.tsx
@@ -225,6 +225,25 @@ describe('OAuthConsent', () => {
     expect(writeCheckbox).toBeChecked();
   });
 
+  test('clicking the description text toggles the scope', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps()} />);
+    const writeCheckbox = screen.getByRole('checkbox', { name: 'Write' });
+    expect(writeCheckbox).not.toBeChecked();
+    await user.click(screen.getByText('Write access'));
+    expect(writeCheckbox).toBeChecked();
+  });
+
+  test('clicking the label title toggles the scope exactly once', async () => {
+    const user = userEvent.setup();
+    render(<OAuthConsent {...makeProps()} />);
+    const writeCheckbox = screen.getByRole('checkbox', { name: 'Write' });
+    expect(writeCheckbox).not.toBeChecked();
+    await user.click(screen.getByText('Write'));
+    // A single click must result in a single toggle (no double-fire).
+    expect(writeCheckbox).toBeChecked();
+  });
+
   test('checked optional scope can be toggled off', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Problem

In the `OAuthConsent` component, clicking the **description text** (e.g. "Listar contas de anúncio e campanhas") under a scope label did not toggle the checkbox. Only the **bold label title** (wrapped in `<Label htmlFor>` with `width: fit-content`) was clickable, even though the entire row visually implies it is interactive (hover background + cursor change).

## Fix

Rather than bolting an `onClick` onto the row `<Flex>` (which would double-fire when clicking the label — the `htmlFor` association forwards a synthetic click to the checkbox *and* the click bubbles to the row handler, toggling twice and canceling out), the row is now a `<label>` that wraps the checkbox.

This uses theme-ui's idiomatic `<Label><Checkbox/> …</Label>` pattern, so native click-forwarding covers the **whole row** (title + description + padding) with exactly **one** toggle, full keyboard support, and no JS click handler.

Details:
- Outer `<Flex>` renders `as="label"` with `cursor: pointer` when interactive.
- The bold title becomes a styled `<Text as="span">` (avoids invalid nested `<label>`).
- The checkbox keeps a clean accessible name via `aria-labelledby` (so the implicit label text doesn't merge title + description into the name) and retains `aria-describedby`.

This is non-breaking — the public props are unchanged.

## Why not `@ttoss/forms`?

Not needed. There are no validated input fields here — the component tracks a single `Set<string>` of selected scope keys over a hierarchical tree and transforms it on submit via `collectGrantedScopes`. A form library would add a peer dependency and awkward field modeling without addressing the bug, which was purely about the click target.

## Tests

- Added a test asserting clicking the description text toggles the scope.
- Added a test asserting clicking the label title toggles exactly once (guards against double-fire regressions).
- Full `@ttoss/components` unit suite passes (257 tests); coverage rose, thresholds bumped accordingly in `jest.config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRGmseWzorobuxcjxR93uc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRGmseWzorobuxcjxR93uc)_