### PR TITLE
feat(components): add clientLogoUrl prop to OAuthConsent

### DIFF
--- a/docs/storybook/stories/components/OAuthConsent.stories.tsx
+++ b/docs/storybook/stories/components/OAuthConsent.stories.tsx
@@ -42,6 +42,48 @@ export default {
 } as Meta<OAuthConsentProps>;
 
 // ---------------------------------------------------------------------------
+// With client logo
+// ---------------------------------------------------------------------------
+
+const PLACEHOLDER_LOGO =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Crect width='48' height='48' rx='10' fill='%234a90e2'/%3E%3Ctext x='50%25' y='55%25' font-family='sans-serif' font-size='26' fill='white' text-anchor='middle' dominant-baseline='middle'%3EC%3C/text%3E%3C/svg%3E";
+
+export const WithClientLogo: StoryFn<OAuthConsentProps> = () => {
+  return (
+    <OAuthConsent
+      clientName="Claude"
+      clientLogoUrl={PLACEHOLDER_LOGO}
+      scopes={[
+        {
+          key: 'read',
+          label: 'Read',
+          description: 'List ad accounts and campaigns',
+          required: true,
+        },
+        {
+          key: 'write',
+          label: 'Write',
+          description: 'Pause and activate campaigns',
+        },
+      ]}
+      onAuthorize={noop}
+      onAuthorized={action('onAuthorized')}
+      onDeny={action('onDeny')}
+      labels={defaultLabels}
+    />
+  );
+};
+WithClientLogo.parameters = {
+  docs: {
+    description: {
+      story:
+        'When `clientLogoUrl` is provided, the client logo is rendered above the heading. ' +
+        'If the image fails to load, the first letter of `clientName` is shown as a fallback.',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Flat scopes (OCA read/write case)
 // ---------------------------------------------------------------------------
 

--- a/packages/components/src/components/OAuthConsent/ClientLogo.tsx
+++ b/packages/components/src/components/OAuthConsent/ClientLogo.tsx
@@ -1,0 +1,54 @@
+import { Flex, Text } from '@ttoss/ui';
+import * as React from 'react';
+
+type ClientLogoProps = {
+  src: string;
+  clientName: string;
+};
+
+export const ClientLogo = ({ src, clientName }: ClientLogoProps) => {
+  const [errored, setErrored] = React.useState(false);
+
+  if (errored) {
+    return (
+      <Flex
+        aria-hidden="true"
+        sx={{
+          width: 48,
+          height: 48,
+          borderRadius: 'lg',
+          backgroundColor: 'display.background.muted.default',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Text
+          sx={{
+            fontSize: 'xl',
+            fontWeight: 'bold',
+            color: 'display.text.muted.default',
+          }}
+        >
+          {clientName.charAt(0).toUpperCase()}
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={`${clientName} logo`}
+      onError={() => {
+        return setErrored(true);
+      }}
+      style={{
+        width: 48,
+        height: 48,
+        borderRadius: 8,
+        objectFit: 'contain',
+        display: 'block',
+      }}
+    />
+  );
+};

--- a/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
+++ b/packages/components/src/components/OAuthConsent/OAuthConsent.tsx
@@ -10,6 +10,8 @@ import {
 } from '@ttoss/ui';
 import * as React from 'react';
 
+import { ClientLogo } from './ClientLogo';
+
 /**
  * A single OAuth scope, optionally with implied child scopes.
  */
@@ -63,6 +65,12 @@ export type OAuthConsentLabels = {
 export type OAuthConsentProps = {
   /** Display name or identifier of the requesting OAuth client. */
   clientName: string;
+  /**
+   * URL of the client's logo or icon. When provided, renders the image above
+   * the consent heading. Falls back to the first letter of `clientName` if the
+   * image fails to load. When omitted, no logo is shown (backward-compatible).
+   */
+  clientLogoUrl?: string;
   /** Scope tree to render. */
   scopes: ConsentScope[];
   /**
@@ -315,6 +323,7 @@ const ConsentCard = ({ children }: { children: React.ReactNode }) => {
  */
 export const OAuthConsent = ({
   clientName,
+  clientLogoUrl,
   scopes,
   onAuthorize,
   onAuthorized,
@@ -387,6 +396,12 @@ export const OAuthConsent = ({
 
   return (
     <ConsentCard>
+      {clientLogoUrl && (
+        <Box sx={{ marginBottom: 4 }}>
+          <ClientLogo src={clientLogoUrl} clientName={clientName} />
+        </Box>
+      )}
+
       <Heading
         as="h1"
         sx={{

--- a/packages/components/tests/unit/tests/OAuthConsent.test.tsx
+++ b/packages/components/tests/unit/tests/OAuthConsent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, userEvent } from '@ttoss/test-utils/react';
+import { act, render, screen, userEvent } from '@ttoss/test-utils/react';
 
 import type {
   ConsentScope,
@@ -412,6 +412,40 @@ describe('OAuthConsent', () => {
       screen.getByRole('button', { name: 'Authorize' })
     ).toBeInTheDocument();
     expect(screen.queryByText('Invalid request')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // clientLogoUrl
+  // ---------------------------------------------------------------------------
+
+  test('renders client logo image when clientLogoUrl is provided', () => {
+    render(
+      <OAuthConsent
+        {...makeProps({ clientLogoUrl: 'https://example.com/logo.png' })}
+      />
+    );
+    const img = screen.getByRole('img', { name: 'TestApp logo' });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/logo.png');
+  });
+
+  test('does not render a logo image when clientLogoUrl is omitted', () => {
+    render(<OAuthConsent {...makeProps()} />);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  test('renders first-letter fallback when logo image fails to load', async () => {
+    render(
+      <OAuthConsent
+        {...makeProps({ clientLogoUrl: 'https://example.com/broken.png' })}
+      />
+    );
+    const img = screen.getByRole('img', { name: 'TestApp logo' });
+    await act(async () => {
+      img.dispatchEvent(new Event('error', { bubbles: true }));
+    });
+    expect(screen.getByText('T')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds optional `clientLogoUrl?: string` prop to `OAuthConsent` — renders the client's logo above the consent heading (GitHub OAuth style)
- Falls back to the first letter of `clientName` if the image fails to load
- Fully backward-compatible: omitting the prop preserves existing behavior unchanged
- `ClientLogo` extracted to its own file (`ClientLogo.tsx`) to stay within the ESLint `max-lines` limit

## Test plan

- [ ] All 31 existing tests pass (`pnpm run test --testPathPatterns=OAuthConsent`)
- [ ] 3 new tests cover: logo renders when URL provided, no logo when URL omitted, first-letter fallback on image error
- [ ] `ClientLogo.tsx` at 100% coverage
- [ ] Lint passes (`pnpm run -w lint`)
- [ ] New `WithClientLogo` Storybook story added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWqtMuVkFs4DZpLgmBWxxk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWqtMuVkFs4DZpLgmBWxxk)_