### PR TITLE
fix: changing geovisLegend structure

### DIFF
--- a/packages/geovis-workspace/README.md
+++ b/packages/geovis-workspace/README.md
@@ -96,10 +96,17 @@ its own group. Read the current selection anywhere inside the workspace with
 
 ### `GeovisWorkspaceConfig`
 
-| Property       | Type                               | Description                            |
-| -------------- | ---------------------------------- | -------------------------------------- |
-| `leftSidebar`  | `{ menus: GeovisWorkspaceMenu[] }` | Left sidebar config. Omit to hide it.  |
-| `rightSidebar` | `GeovisWorkspaceRightSidebar`      | Right sidebar config. Omit to hide it. |
+| Property       | Type                          | Description                            |
+| -------------- | ----------------------------- | -------------------------------------- |
+| `leftSidebar`  | `GeovisWorkspaceLeftSidebar`  | Left sidebar config. Omit to hide it.  |
+| `rightSidebar` | `GeovisWorkspaceRightSidebar` | Right sidebar config. Omit to hide it. |
+
+### `GeovisWorkspaceLeftSidebar`
+
+| Property       | Type                    | Description                                              |
+| -------------- | ----------------------- | -------------------------------------------------------- |
+| `menus`        | `GeovisWorkspaceMenu[]` | Menu groups rendered in the sidebar.                     |
+| `initialState` | `'open' \| 'closed'`    | Whether the sidebar starts open. Defaults to `'closed'`. |
 
 ### `GeovisWorkspaceMenu`
 
@@ -112,10 +119,11 @@ its own group. Read the current selection anywhere inside the workspace with
 
 ### `GeovisWorkspaceRightSidebar`
 
-| Property          | Type                             | Description                            |
-| ----------------- | -------------------------------- | -------------------------------------- |
-| `title`           | `string`                         | Title shown at the top of the sidebar. |
-| `legendWithColor` | `GeovisWorkspaceLegendWithColor` | Color-legend panel. Omit to hide it.   |
+| Property          | Type                             | Description                                              |
+| ----------------- | -------------------------------- | -------------------------------------------------------- |
+| `title`           | `string`                         | Title shown at the top of the sidebar.                   |
+| `legendWithColor` | `GeovisWorkspaceLegendWithColor` | Color-legend panel. Omit to hide it.                     |
+| `initialState`    | `'open' \| 'closed'`             | Whether the sidebar starts open. Defaults to `'closed'`. |
 
 ### `GeovisWorkspaceLegendWithColor`
 

--- a/packages/geovis-workspace/src/GeovisWorkspaceProvider.tsx
+++ b/packages/geovis-workspace/src/GeovisWorkspaceProvider.tsx
@@ -65,9 +65,13 @@ export const GeovisWorkspaceProvider = ({
 
   const currentSelection = isControlled ? selection : internalSelection;
 
-  const [isLeftSidebarOpen, setIsLeftSidebarOpen] = React.useState(false);
+  const [isLeftSidebarOpen, setIsLeftSidebarOpen] = React.useState(() => {
+    return config.leftSidebar?.initialState === 'open';
+  });
 
-  const [isRightSidebarOpen, setIsRightSidebarOpen] = React.useState(false);
+  const [isRightSidebarOpen, setIsRightSidebarOpen] = React.useState(() => {
+    return config.rightSidebar?.initialState === 'open';
+  });
 
   const setSelection = React.useCallback(
     ({ menuId, value }: { menuId: string; value: string }) => {

--- a/packages/geovis-workspace/src/context/GeovisWorkspaceContext.ts
+++ b/packages/geovis-workspace/src/context/GeovisWorkspaceContext.ts
@@ -21,6 +21,8 @@ export interface GeovisWorkspaceMenu {
 export interface GeovisWorkspaceLeftSidebar {
   /** Menu groups rendered in the left sidebar. */
   menus: GeovisWorkspaceMenu[];
+  /** Whether the sidebar starts open or closed. Defaults to `'closed'`. */
+  initialState?: 'open' | 'closed';
 }
 
 export interface GeovisWorkspaceLegendItem {
@@ -65,6 +67,8 @@ export interface GeovisWorkspaceRightSidebar {
   title?: string;
   /** Color legend panel: description, class swatches and data sources. */
   legendWithColor?: GeovisWorkspaceLegendWithColor;
+  /** Whether the sidebar starts open or closed. Defaults to `'closed'`. */
+  initialState?: 'open' | 'closed';
 }
 
 export interface GeovisWorkspaceConfig {

--- a/packages/geovis-workspace/tests/unit/tests/GeovisWorkspace.test.tsx
+++ b/packages/geovis-workspace/tests/unit/tests/GeovisWorkspace.test.tsx
@@ -109,6 +109,39 @@ test('closing the left sidebar brings the open button back', async () => {
   expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
 });
 
+test('left sidebar starts open when initialState is "open"', () => {
+  render(
+    <GeovisWorkspace
+      config={{
+        ...config,
+        leftSidebar: { ...config.leftSidebar!, initialState: 'open' },
+      }}
+      visualizationSpec={visualizationSpec}
+    />,
+    { wrapper: Provider }
+  );
+
+  expect(screen.getByText('População')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Open menu' })
+  ).not.toBeInTheDocument();
+});
+
+test('left sidebar stays closed when initialState is "closed"', () => {
+  render(
+    <GeovisWorkspace
+      config={{
+        ...config,
+        leftSidebar: { ...config.leftSidebar!, initialState: 'closed' },
+      }}
+      visualizationSpec={visualizationSpec}
+    />,
+    { wrapper: Provider }
+  );
+
+  expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
+});
+
 test('selecting an item marks it active without affecting other groups', async () => {
   render(
     <GeovisWorkspace config={config} visualizationSpec={visualizationSpec} />,
@@ -331,6 +364,24 @@ test('closing the right sidebar brings its open button back', async () => {
   expect(
     screen.getByRole('button', { name: 'Open details' })
   ).toBeInTheDocument();
+});
+
+test('right sidebar starts open when initialState is "open"', () => {
+  render(
+    <GeovisWorkspace
+      config={{
+        ...config,
+        rightSidebar: { title: 'Camadas', initialState: 'open' },
+      }}
+      visualizationSpec={visualizationSpec}
+    />,
+    { wrapper: Provider }
+  );
+
+  expect(screen.getByText('Camadas')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Open details' })
+  ).not.toBeInTheDocument();
 });
 
 test('getInitialSelection seeds the selection from menu defaultValues', () => {

--- a/packages/geovis/src/react/GeoVisProvider.tsx
+++ b/packages/geovis/src/react/GeoVisProvider.tsx
@@ -10,6 +10,7 @@ import { createRuntime } from '../runtime/createRuntime';
 import { resolveSpecFromMapType } from '../spec/mapTypeDefaults';
 import type { PolicyViolation, VisualizationSpec } from '../spec/types';
 import { GeoVisHoverTooltip } from '../ui/GeoVisHoverTooltip';
+import { GeoVisLegend } from '../ui/GeoVisLegend';
 import {
   GeoVisClickContext,
   GeoVisContext,
@@ -60,6 +61,26 @@ const checkPolicies = (spec: VisualizationSpec): PolicyViolation[] => {
   }
 
   return violations;
+};
+
+/**
+ * Collects the ids of every legend that declares a `position`. A positioned
+ * legend is meant to overlay the map, so the provider mounts a
+ * `<GeoVisLegend>` for it automatically — mirroring the auto-mounted
+ * `hoverTooltip` — and consumers do not place it by hand. Scans both the
+ * top-level `spec.legends` registry and per-layer `legends`.
+ */
+const collectPositionedLegendIds = (spec: VisualizationSpec): string[] => {
+  const ids = new Set<string>();
+  for (const legend of spec.legends ?? []) {
+    if (legend.position) ids.add(legend.id);
+  }
+  for (const layer of spec.layers) {
+    for (const legend of layer.legends ?? []) {
+      if (legend.position) ids.add(legend.id);
+    }
+  }
+  return Array.from(ids);
 };
 
 const resolveAdapter = async (
@@ -179,6 +200,10 @@ export const GeoVisProvider = ({ spec, children }: GeoVisProviderProps) => {
     return checkPolicies(effectiveSpec);
   }, [effectiveSpec]);
 
+  const positionedLegendIds = React.useMemo(() => {
+    return collectPositionedLegendIds(resolvedSpec);
+  }, [resolvedSpec]);
+
   React.useEffect(() => {
     let cancelled = false;
     let activeRuntime: GeoVisRuntime | null = null;
@@ -257,6 +282,12 @@ export const GeoVisProvider = ({ spec, children }: GeoVisProviderProps) => {
           {children}
         </HoverProvider>
       </ClickProvider>
+      {/* Spec-driven legend overlays: mount one <GeoVisLegend> per positioned
+          legend so consumers get the overlay just by declaring `position` on
+          a legend, exactly like the auto-mounted hoverTooltip. */}
+      {positionedLegendIds.map((id) => {
+        return <GeoVisLegend key={id} legendId={id} />;
+      })}
     </GeoVisContext.Provider>
   );
 };

--- a/packages/geovis/tests/unit/tests/GeoVisSpecLegend.test.tsx
+++ b/packages/geovis/tests/unit/tests/GeoVisSpecLegend.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { GeoVisProvider, useGeoVis } from 'src/react/GeoVisProvider';
+import type { QuantitativeColorBy, VisualizationSpec } from 'src/spec/types';
+
+jest.mock('src/adapters/maplibre/MapLibreAdapter', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => {
+      return {
+        id: 'maplibre',
+        getCapabilities: jest.fn(),
+        mount: jest.fn(() => {
+          return { viewId: 'v', container: {}, destroy: jest.fn() };
+        }),
+        update: jest.fn(),
+        destroy: jest.fn(),
+        getNativeInstance: jest.fn(() => {
+          return undefined;
+        }),
+      };
+    }),
+  };
+});
+
+const buildColorBy = (): QuantitativeColorBy => {
+  return {
+    type: 'quantitative',
+    property: 'value',
+    scale: 'threshold',
+    thresholds: [100, 200],
+    colors: ['#aaa', '#bbb', '#ccc'],
+  };
+};
+
+const buildSpec = ({
+  legends,
+  layers,
+}: {
+  legends?: VisualizationSpec['legends'];
+  layers?: VisualizationSpec['layers'];
+}): VisualizationSpec => {
+  return {
+    id: 'spec-legend',
+    engine: 'maplibre',
+    view: { center: [0, 0], zoom: 1 },
+    sources: [
+      {
+        id: 'districts',
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      },
+    ],
+    layers: layers ?? [
+      {
+        id: 'districts-fill',
+        sourceId: 'districts',
+        geometry: 'polygon',
+        activeLegendId: 'pop',
+      },
+    ],
+    legends,
+  };
+};
+
+const ExposeRuntime = ({ onReady }: { onReady: () => void }) => {
+  const { runtime } = useGeoVis();
+  React.useEffect(() => {
+    if (runtime) onReady();
+  }, [runtime, onReady]);
+  return null;
+};
+
+describe('spec-driven legend overlay (legend.position)', () => {
+  test('does not mount a legend overlay when no legend declares position', async () => {
+    const onReady = jest.fn();
+    render(
+      <GeoVisProvider
+        spec={buildSpec({
+          legends: [
+            { id: 'pop', title: 'Population', colorBy: buildColorBy() },
+          ],
+        })}
+      >
+        <ExposeRuntime onReady={onReady} />
+      </GeoVisProvider>
+    );
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalled();
+    });
+
+    expect(document.querySelector('ul[aria-label="Population"]')).toBeNull();
+  });
+
+  test('mounts a positioned overlay for a top-level legend that declares position', async () => {
+    render(
+      <GeoVisProvider
+        spec={buildSpec({
+          legends: [
+            {
+              id: 'pop',
+              title: 'Population',
+              subtitle: 'people per district',
+              position: 'bottom-right',
+              colorBy: buildColorBy(),
+            },
+          ],
+        })}
+      >
+        <div />
+      </GeoVisProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('ul[aria-label="Population"]')
+      ).not.toBeNull();
+    });
+
+    const list = document.querySelector(
+      'ul[aria-label="Population"]'
+    ) as HTMLElement;
+    // One swatch per threshold bin (2 thresholds ⇒ 3 bins).
+    expect(list.querySelectorAll('li')).toHaveLength(3);
+
+    // The overlay container is absolutely positioned in the bottom-right.
+    const container = list.closest('div') as HTMLElement;
+    expect(container.style.position).toBe('absolute');
+    expect(container.style.right).toBe('10px');
+    expect(container.style.bottom).toBe('10px');
+  });
+
+  test('mounts an overlay for a layer-level legend that declares position', async () => {
+    render(
+      <GeoVisProvider
+        spec={buildSpec({
+          layers: [
+            {
+              id: 'districts-fill',
+              sourceId: 'districts',
+              geometry: 'polygon',
+              activeLegendId: 'pop',
+              legends: [
+                {
+                  id: 'pop',
+                  title: 'Population',
+                  position: 'bottom-right',
+                  colorBy: buildColorBy(),
+                },
+              ],
+            },
+          ],
+        })}
+      >
+        <div />
+      </GeoVisProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('ul[aria-label="Population"]')
+      ).not.toBeNull();
+    });
+  });
+
+  test('mounts one overlay per positioned legend', async () => {
+    render(
+      <GeoVisProvider
+        spec={buildSpec({
+          legends: [
+            {
+              id: 'pop',
+              title: 'Population',
+              position: 'bottom-right',
+              colorBy: buildColorBy(),
+            },
+            {
+              id: 'density',
+              title: 'Density',
+              position: 'top-left',
+              colorBy: buildColorBy(),
+            },
+          ],
+        })}
+      >
+        <div />
+      </GeoVisProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('ul[aria-label="Population"]')
+      ).not.toBeNull();
+    });
+    expect(document.querySelector('ul[aria-label="Density"]')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Summary

  Legends that declare a position are now mounted automatically by GeoVisProvider, mirroring the existing auto-mounted hoverTooltip. Consumers no longer need to manually render a <GeoVisLegend> — declaring position on a legend in the spec is enough to overlay it on the map.

I also added a new feature so that the user can control the initial state of the sidebars through the spec.

  Changes

  - GeoVisProvider.tsx
    - Added collectPositionedLegendIds(spec), which scans both the top-level spec.legends registry and per-layer layer.legends, collecting the ids of every legend
  that declares a position (deduplicated via a Set).
    - Memoized the resulting positionedLegendIds from the resolved spec.
    - Rendered one <GeoVisLegend legendId={id} /> per positioned legend after children.
  - GeoVisSpecLegend.test.tsx (new) — covers:
    - No overlay is mounted when no legend declares position.
    - A top-level legend with position mounts an overlay (asserts swatch count and absolute bottom-right placement).
    - A layer-level legend with position mounts an overlay.
    - One overlay is mounted per positioned legend.

  Testing

  - pnpm run test in packages/geovis — 457 tests passing across 32 suites, coverage thresholds met.
  - Lint and syncpack pass.