### PR TITLE
fix(terezinha-farm): review fixes for PR #1007 subscription example

### DIFF
--- a/terezinha-farm/vite-app/src/amplify.ts
+++ b/terezinha-farm/vite-app/src/amplify.ts
@@ -4,7 +4,7 @@ import { sessionStorage } from 'aws-amplify/utils';
 
 const graphQLRegion =
   import.meta.env.VITE_APPSYNC_REGION ||
-  import.meta.env.VITE_USER_POOL_ID.split('_')[0];
+  import.meta.env.VITE_USER_POOL_ID?.split('_')?.[0];
 
 const config: ResourcesConfig = {
   API: {

--- a/terezinha-farm/vite-app/src/modules/FarmNotification/FarmNotificationSubscription.tsx
+++ b/terezinha-farm/vite-app/src/modules/FarmNotification/FarmNotificationSubscription.tsx
@@ -74,9 +74,10 @@ const uiText = {
   publishMutationCode: 'publishFarmNotification',
   publishButton: 'Send test notification',
   publishMutateCode: 'appSyncClient.mutate()',
-  publishHelpPrefix: 'Trigger uses the same ',
-  publishHelpSuffix: ' mutation that a backend Lambda would call with ',
-  publishHelpSuffixAfterCode: '.',
+  publishHelpPrefix: 'This demo publishes the ',
+  publishHelpSuffix:
+    ' mutation from the browser. A backend Lambda would trigger the same mutation with ',
+  publishHelpSuffixAfterCode: ' using IAM credentials.',
   publishingButton: 'Publishing…',
   stopButton: 'Stop',
   subscribeButton: 'Subscribe',
@@ -137,8 +138,8 @@ const FarmNotificationListener = ({ farmId }: { farmId: string }) => {
             // eslint-disable-next-line no-console
             console.error('FarmNotification subscription error:', error);
           },
-          complete: (): void => {
-            throw new Error('Function not implemented.');
+          complete: () => {
+            // The stream closed normally; nothing to do.
           },
         }
       );


### PR DESCRIPTION
Follow-up fixes from reviewing #1007. Targets that PR's branch so the diff shows only the changes on top of it.

## Changes

- **Bug: `complete` handler threw.** The local `graphql-sse` subscription's `complete` callback in `FarmNotificationSubscription.tsx` was a leftover stub (`throw new Error('Function not implemented.')`). A normal stream close would surface an uncaught error. Replaced with a no-op.
- **Misleading UI help text.** The demo publishes the `publishFarmNotification` mutation from the browser via Amplify's `client.graphql()`, but the help text implied it uses `appSyncClient.mutate()` like a backend Lambda. Reworded to say the demo publishes from the browser and that a backend Lambda would trigger the same mutation via IAM.
- **Region fallback guard.** `amplify.ts` derived the GraphQL region from `VITE_USER_POOL_ID.split('_')[0]`, which throws at module load if the env var is undefined. Added optional chaining.

## Verification

- `eslint` passes clean on both changed files.
- Changes are scoped to the terezinha-farm example app; no package/public-API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfRveRikE2WVUAFo2EcXQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfRveRikE2WVUAFo2EcXQK)_