### PR TITLE
fix(cicd): include dependents in turbo deploy filter so Storybook deploys

### DIFF
--- a/.cicd/commands/main.sh
+++ b/.cicd/commands/main.sh
@@ -55,7 +55,10 @@ if pnpm lerna changed --since=$LATEST_TAG; then
   # would bust the turbo input hash, causing all affected packages to rebuild
   # from scratch even when their source code hasn't changed.
   # https://turbo.build/repo/docs/core-concepts/caching#missing-the-cache
-  pnpm turbo run i18n build test --filter=[$LATEST_TAG_SHA]
+  #
+  # The `...` prefix includes dependents of the changed packages so consumers
+  # like `@docs/storybook` are built/tested when a package they consume changes.
+  pnpm turbo run i18n build test --filter=...[$LATEST_TAG_SHA]
 
   # Undo all files that were changed by the build command—this happens because
   # the build can change files with different linting rules and `pnpm run lint`
@@ -87,7 +90,7 @@ if pnpm lerna changed --since=$LATEST_TAG; then
   # files reflect the new package versions if any package embeds its own version.
   # Tests are skipped here because they already passed above and version bumps
   # do not affect test outcomes.
-  pnpm turbo run build --filter=[$LATEST_TAG_SHA]
+  pnpm turbo run build --filter=...[$LATEST_TAG_SHA]
 
   # Push changes.
   git push --follow-tags
@@ -112,4 +115,8 @@ fi
 # Deploy after publish because there are cases in which a package is versioned
 # and it should be on NPM registry to Lambda Layer create the new version when
 # carlin deploy starts.
-pnpm turbo run build test deploy --filter=[$LATEST_TAG_SHA] --filter=@docs/website
+#
+# The `...` prefix includes dependents of the changed packages so deployable
+# workspaces like `@docs/storybook` are redeployed when a package they consume
+# changes — not only when their own files change.
+pnpm turbo run build test deploy --filter=...[$LATEST_TAG_SHA] --filter=@docs/website

--- a/.cicd/commands/pr.sh
+++ b/.cicd/commands/pr.sh
@@ -14,9 +14,11 @@ pnpm run lint -- --no-stash --allow-empty
 pnpm run syncpack:lint
 
 # Test and build all packages since main
-# and all the workspaces that depends on them.
+# and all the workspaces that depends on them. The `...` prefix includes
+# dependents of the matched workspaces, so e.g. changing a component package
+# also builds/tests `@docs/storybook`, which consumes it.
 # https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependents-of-matched-workspaces
-pnpm turbo run i18n build test --filter=[main]
+pnpm turbo run i18n build test --filter=...[main]
 
 # Undo all files that were changed by the build command—this happens because
 # the build can change files with different linting rules and `pnpm run lint`
@@ -35,7 +37,11 @@ pnpm run lint -- --no-stash --allow-empty
 # packages with bug. As `test` isn't a dependsOn of `deploy` on turbo.json,
 # we need to run them separately. If we run them together and deploy is faster,
 # `deploy` will run even if `test` fails.
-pnpm turbo run build test deploy --filter=[main]
+#
+# The `...` prefix includes dependents of the changed packages, so deployable
+# workspaces like `@docs/storybook` are redeployed when a package they consume
+# (e.g. a component package) changes — not only when their own files change.
+pnpm turbo run build test deploy --filter=...[main]
 
 # Build carlin CLI explicitly so it is available even when no packages changed
 # since main (e.g. PRs that only touch workflow/config files), because the


### PR DESCRIPTION
## What changes

Adds the `...` (include-dependents) prefix to the git-diff turbo filters in the CI/CD deploy commands:

- `.cicd/commands/pr.sh`
  - `i18n build test --filter=[main]` → `--filter=...[main]`
  - `build test deploy --filter=[main]` → `--filter=...[main]`
- `.cicd/commands/main.sh`
  - `i18n build test --filter=[$LATEST_TAG_SHA]` → `--filter=...[$LATEST_TAG_SHA]`
  - `build --filter=[$LATEST_TAG_SHA]` → `--filter=...[$LATEST_TAG_SHA]`
  - `build test deploy --filter=[$LATEST_TAG_SHA] --filter=@docs/website` → `--filter=...[$LATEST_TAG_SHA] --filter=@docs/website`

## Why

`--filter=[main]` (and `[$LATEST_TAG_SHA]`) selects only the packages that changed relative to the base ref — **not** their dependents. `@docs/storybook` is only ever a *dependent* of the component packages it renders; it has the `deploy` script (`carlin deploy static-app`), but its own files rarely change. And the `deploy` task's `^deploy` dependency runs upstream (dependencies), never downstream (dependents), so it couldn't reach Storybook either.

The result: a component-only PR such as #1117 (which touched only `packages/react-dashboard/`) never pulled `@docs/storybook` into the deploy set, so Storybook was never redeployed. The `i18n build test` comment in `pr.sh` already claimed it built "all the workspaces that depend on them" and linked turbo's include-dependents docs, but the `...` prefix was missing.

Adding `...` makes the filters include dependents, matching the documented intent. A change to a package now redeploys the deployable workspaces that consume it, including `@docs/storybook`.

## Verification

`turbo run deploy --filter=...@ttoss/react-dashboard --dry-run` now resolves `@docs/storybook#deploy` into scope (it did not with the bare filter):

```
• Packages in scope: @docs/storybook, ...
• Running deploy in 3 packages
@docs/storybook#deploy
  Command = carlin deploy static-app
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNUAuJTrJvjhmgdFiwfwrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNUAuJTrJvjhmgdFiwfwrZ)_