### PR TITLE
Suppress color items in proportionalCircles auto legend

### DIFF
--- a/packages/geovis/README.md
+++ b/packages/geovis/README.md
@@ -698,6 +698,15 @@ once. Its `id` is checked against every already-merged legend before being
 added, so a legend the user already matched (by `id` or positional fallback)
 is never duplicated as an extra unmatched entry.
 
+The `proportionalCircles` auto legend's `colorBy` is display-only for the
+adapter, never for the legend UI: it exists so `resolveCircleColor` always has
+a legend to build a `circle-color` expression from, but every bin it defines
+resolves to the same flat color, so `<GeoVisLegend>` never renders it as a
+value-band list — that legend's UI content is the circle reference key only
+(`shouldShowColorItems` in `GeoVisLegend.utils.tsx` suppresses it by the
+legend's deterministic id). A separate, user-authored color legend (e.g. a
+choropleth-style `colorBy` on its own `id`) still renders its bands normally.
+
 ### Architecture note
 
 `resolveSpecFromMapType` is called in two places: `GeoVisProvider` (for React

--- a/packages/geovis/src/ui/GeoVisLegend.tsx
+++ b/packages/geovis/src/ui/GeoVisLegend.tsx
@@ -21,6 +21,7 @@ import {
   resolveLegend,
   rowStyle,
   shouldShowCircleItems,
+  shouldShowColorItems,
   shouldShowTopDivider,
   swatchBase,
 } from './GeoVisLegend.utils';
@@ -170,8 +171,9 @@ export const GeoVisLegend = ({
   }, [formatValue, circleConfig]);
 
   const items = React.useMemo(() => {
+    if (!shouldShowColorItems(legend, spec)) return [];
     return buildColorItems(legend, normalizedBreaks, resolvedFormatValue);
-  }, [legend, normalizedBreaks, resolvedFormatValue]);
+  }, [legend, normalizedBreaks, resolvedFormatValue, spec]);
 
   const circleItems = React.useMemo(() => {
     if (!shouldShowCircleItems(circleConfig, legend, spec)) return [];

--- a/packages/geovis/src/ui/GeoVisLegend.utils.tsx
+++ b/packages/geovis/src/ui/GeoVisLegend.utils.tsx
@@ -230,6 +230,23 @@ export const shouldShowCircleItems = (
   return true;
 };
 
+/**
+ * The proportionalCircles auto-generated legend always carries a `colorBy`
+ * (`buildColorBy` in `mapTypeDefaults/proportionalCircles.ts`) purely so the
+ * adapter has a legend to build a `circle-color` expression from — every bin
+ * it defines resolves to the same flat color, so it carries no real visual
+ * distinction. Rendering it as a value-band list would just duplicate the
+ * circle size key with meaningless identical-color rows; this legend's UI
+ * job is the circle reference key only (see `shouldShowCircleItems`).
+ */
+export const shouldShowColorItems = (
+  legend: LegendSpec | undefined,
+  spec: VisualizationSpec
+): boolean => {
+  if (legend?.id === getProportionalCirclesAutoLegendId(spec)) return false;
+  return true;
+};
+
 export const resolveFormatter = (
   explicit: ((value: number) => string) | undefined,
   circleConfig: ProportionalCirclesConfig | null

--- a/packages/geovis/tests/unit/jest.config.ts
+++ b/packages/geovis/tests/unit/jest.config.ts
@@ -10,9 +10,9 @@ export default jestUnitConfig({
   },
   coverageThreshold: {
     global: {
-      statements: 90.4,
-      branches: 80.8,
-      functions: 95.7,
+      statements: 90.5,
+      branches: 81.1,
+      functions: 95.8,
       lines: 93.6,
     },
   },

--- a/packages/geovis/tests/unit/tests/ui/circleAutoLegendColorSuppression.test.ts
+++ b/packages/geovis/tests/unit/tests/ui/circleAutoLegendColorSuppression.test.ts
@@ -1,0 +1,81 @@
+import { resolveSpecFromMapType } from 'src/spec/mapTypeDefaults';
+import { getProportionalCirclesAutoLegendId } from 'src/spec/mapTypeDefaults/proportionalCircles';
+import type { VisualizationSpec } from 'src/spec/types';
+import {
+  buildColorItems,
+  resolveLegend,
+  shouldShowColorItems,
+} from 'src/ui/GeoVisLegend.utils';
+
+const buildProportionalCirclesSpec = (): VisualizationSpec => {
+  return {
+    id: 'input',
+    engine: 'maplibre',
+    mapType: 'proportionalCircles',
+    scaleMaxValue: 500_000,
+    sources: [
+      {
+        id: 'centroids',
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      },
+    ],
+    layers: [],
+    mapData: [
+      {
+        mapDataId: 'population',
+        mapId: 'centroids',
+        stateKey: 'total',
+        dimension: 'size',
+        data: [
+          { geometryId: 1, value: 100 },
+          { geometryId: 2, value: 400 },
+        ],
+      },
+    ],
+  } as unknown as VisualizationSpec;
+};
+
+describe('the proportionalCircles auto legend never renders colorBy value bands', () => {
+  test('the resolver still attaches a colorBy to the auto legend (needed for circle-color painting)', () => {
+    const resolved = resolveSpecFromMapType(buildProportionalCirclesSpec());
+    const autoLegendId = getProportionalCirclesAutoLegendId(resolved);
+    const autoLegend = resolveLegend(resolved, autoLegendId);
+    expect(autoLegend?.colorBy).toBeDefined();
+  });
+
+  test('shouldShowColorItems is false for the auto legend despite its colorBy', () => {
+    const resolved = resolveSpecFromMapType(buildProportionalCirclesSpec());
+    const autoLegendId = getProportionalCirclesAutoLegendId(resolved);
+    const autoLegend = resolveLegend(resolved, autoLegendId);
+    expect(shouldShowColorItems(autoLegend, resolved)).toBe(false);
+  });
+
+  test('buildColorItems is skipped by callers for the auto legend, so no value-band rows are produced', () => {
+    const resolved = resolveSpecFromMapType(buildProportionalCirclesSpec());
+    const autoLegendId = getProportionalCirclesAutoLegendId(resolved);
+    const autoLegend = resolveLegend(resolved, autoLegendId);
+
+    const items = shouldShowColorItems(autoLegend, resolved)
+      ? buildColorItems(autoLegend, [], (v) => {
+          return `${v}`;
+        })
+      : [];
+
+    expect(items).toEqual([]);
+  });
+
+  test('shouldShowColorItems stays true for a regular, user-authored color legend', () => {
+    const resolved = resolveSpecFromMapType(buildProportionalCirclesSpec());
+    const userColorLegend = {
+      id: 'gender',
+      title: 'Gender',
+      colorBy: {
+        type: 'categorical' as const,
+        property: 'gender',
+        mapping: { men: '#3b82f6', women: '#ec4899' },
+      },
+    };
+    expect(shouldShowColorItems(userColorLegend, resolved)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Prevents the proportionalCircles auto-generated legend from rendering color value-band rows in the UI, while preserving its internal `colorBy` configuration needed for circle-color painting.

## Changes

- **Added `shouldShowColorItems` utility** (`GeoVisLegend.utils.tsx`): New export that returns `false` specifically for the proportionalCircles auto legend (identified by its deterministic id), allowing the adapter to maintain a `colorBy` for expression building without displaying meaningless identical-color rows in the legend UI. User-authored color legends continue to render normally.

- **Updated `GeoVisLegend` component** (`GeoVisLegend.tsx`): Integrated `shouldShowColorItems` check before building color items, skipping the color-band list entirely when the condition is false. Added `spec` to the dependency array to ensure the check re-evaluates correctly.

- **Added comprehensive test suite** (`circleAutoLegendColorSuppression.test.ts`): Four tests validating that:
  - The auto legend still has a `colorBy` attached (needed for adapter)
  - `shouldShowColorItems` correctly returns `false` for the auto legend
  - No color items are produced as a result
  - Regular user-authored color legends still render their bands

- **Updated coverage thresholds** (`jest.config.ts`): Incremented to reflect new test coverage (statements: 90.5%, branches: 81.1%, functions: 95.8%).

- **Updated README** (`README.md`): Documented the display-only nature of the proportionalCircles auto legend's `colorBy` and clarified that user-authored color legends render independently.

## Implementation Details

The proportionalCircles auto legend's `colorBy` is purely for the adapter layer—every bin it defines resolves to the same flat color, making it unsuitable for rendering as a value-band list. The legend's UI role is limited to the circle reference key only. This change prevents duplicate/meaningless rows while maintaining the internal contract that `resolveCircleColor` always has a legend to build expressions from.

https://claude.ai/code/session_012inrPPA1cgnRywGToR9NMb