### PR TITLE
feat(@ttoss/postgresdb): add advisory-locked schema sync (syncWithAdvisoryLock)

### DIFF
--- a/packages/postgresdb/README.md
+++ b/packages/postgresdb/README.md
@@ -117,6 +117,44 @@ pnpm dlx @ttoss/postgresdb-cli sync
 
 This imports `db` from `src/db.ts` and syncs the schema.
 
+### Advisory-Locked Sync (multi-instance boot)
+
+Calling `sequelize.sync({ alter: true })` on boot behind more than one instance
+(rolling deploys, auto-scale-out, instance refresh) races: the generated
+`ALTER TABLE` DDL runs concurrently against the same database and can deadlock,
+error, or leave the schema inconsistent.
+
+`syncWithAdvisoryLock` serializes the sync across instances using a Postgres
+session-level advisory lock (`pg_advisory_lock`). One instance runs the sync
+while the others block, then run against the already-migrated schema (a no-op).
+The lock is acquired and released on a single dedicated connection and is
+always released on both the success and failure paths.
+
+```typescript
+import { syncWithAdvisoryLock } from '@ttoss/postgresdb';
+
+await syncWithAdvisoryLock({
+  sequelize,
+  key: 0x50a7_5c_00, // stable, caller-chosen 64-bit key kept constant across releases
+  sync: { alter: true },
+});
+```
+
+You can also run it as part of `initialize` via the `syncLock` option:
+
+```typescript
+const db = await initialize({
+  models,
+  syncLock: { key: 0x50a7_5c_00, sync: { alter: true } },
+});
+```
+
+A blocking session-level lock (not `pg_try_advisory_lock`) is used on purpose:
+waiters must block until the holder finishes rather than skip the sync. The
+lock `key` is caller-supplied and must be a stable 64-bit integer kept constant
+across releases so every instance competes for the same lock. Single-instance
+boot is unaffected — the lock is acquired and released with no contention.
+
 ### CRUD Operations
 
 All models are accessible via the `db` object. See [Sequelize documentation](https://sequelize.org/master/manual/model-querying-basics.html) for complete query API.
@@ -364,6 +402,18 @@ Initializes database connection and loads models.
 **Options:** All [Sequelize options](https://sequelize.org/api/v6/class/src/sequelize.js~sequelize#instance-constructor-constructor) except `dialect` (always `postgres`), plus:
 
 - `models` (required): Object mapping model names to model classes
+- `createVectorExtension` (optional): Creates the pgvector extension when `true`
+- `syncLock` (optional): Runs an advisory-locked `sequelize.sync()` after connecting. Accepts `{ key, sync }` — see `syncWithAdvisoryLock`
+
+### `syncWithAdvisoryLock(options)`
+
+Serializes a boot-time `sequelize.sync()` across concurrently-starting instances using a Postgres session-level advisory lock.
+
+**Options:**
+
+- `sequelize` (required): The Sequelize instance to synchronize
+- `key` (required): A stable, caller-chosen 64-bit integer used as the advisory lock key. Keep it constant across releases
+- `sync` (optional): Options forwarded to `sequelize.sync()` (e.g. `{ alter: true }`)
 
 ### Decorators
 

--- a/packages/postgresdb/src/index.ts
+++ b/packages/postgresdb/src/index.ts
@@ -1,4 +1,8 @@
 export { initialize } from './initialize';
 export type { ModelColumns } from './ModelColumns';
 export * from './sequelize-typescript';
+export {
+  syncWithAdvisoryLock,
+  type SyncWithAdvisoryLockOptions,
+} from './syncWithAdvisoryLock';
 export { DatabaseError, Op } from 'sequelize';

--- a/packages/postgresdb/src/initialize.ts
+++ b/packages/postgresdb/src/initialize.ts
@@ -3,6 +3,10 @@ import {
   Sequelize,
   type SequelizeOptions,
 } from './sequelize-typescript';
+import {
+  syncWithAdvisoryLock,
+  type SyncWithAdvisoryLockOptions,
+} from './syncWithAdvisoryLock';
 
 let sequelize: Sequelize;
 
@@ -14,11 +18,20 @@ export type Options<Models> = Omit<SequelizeOptions, 'models' | 'dialect'> & {
    * @default false
    */
   createVectorExtension?: boolean;
+  /**
+   * If provided, runs `sequelize.sync()` after connecting, serialized across
+   * concurrently-starting instances with a Postgres session-level advisory
+   * lock. Use this when multiple instances may boot at once (rolling deploys,
+   * auto-scale-out) and each runs `sync()` against the same database.
+   * @default undefined
+   */
+  syncLock?: Omit<SyncWithAdvisoryLockOptions, 'sequelize'>;
 };
 
 export const initialize = async <Models extends { [key: string]: ModelCtor }>({
   models,
   createVectorExtension = false,
+  syncLock,
   ...restOptions
 }: Options<Models>): Promise<
   {
@@ -53,13 +66,22 @@ export const initialize = async <Models extends { [key: string]: ModelCtor }>({
     });
   }
 
-  if (username && password && database && host && port) {
+  const hasCredentials = [username, password, database, host, port].every(
+    Boolean
+  );
+
+  if (hasCredentials) {
     await sequelize.authenticate();
   }
 
   // Create the pgvector extension
   if (createVectorExtension) {
     await sequelize.query('CREATE EXTENSION IF NOT EXISTS vector;');
+  }
+
+  // Run an advisory-locked schema sync when requested.
+  if (syncLock) {
+    await syncWithAdvisoryLock({ sequelize, ...syncLock });
   }
 
   const close = sequelize.close;

--- a/packages/postgresdb/src/sequelize-typescript.ts
+++ b/packages/postgresdb/src/sequelize-typescript.ts
@@ -2,11 +2,12 @@
  * Exports the necessary classes from the sequelize-typescript package.
  */
 import pgvector from 'pgvector/sequelize';
-import type { DataType as DataTypeInterface } from 'sequelize';
+import type { DataType as DataTypeInterface, SyncOptions } from 'sequelize';
 import { DataType as SequelizeDataType, Sequelize } from 'sequelize-typescript';
 
 pgvector.registerType(Sequelize);
 
+export type { SyncOptions };
 export type { ModelCtor, SequelizeOptions } from 'sequelize-typescript';
 export {
   // Hook decorators

--- a/packages/postgresdb/src/syncWithAdvisoryLock.ts
+++ b/packages/postgresdb/src/syncWithAdvisoryLock.ts
@@ -1,0 +1,71 @@
+import type { Sequelize, SyncOptions } from './sequelize-typescript';
+
+export type SyncWithAdvisoryLockOptions = {
+  /**
+   * The Sequelize instance whose schema will be synchronized.
+   */
+  sequelize: Sequelize;
+  /**
+   * A stable, caller-chosen 64-bit integer used as the Postgres advisory lock
+   * key. It must be kept constant across releases so that every instance
+   * competes for the same lock.
+   */
+  key: number;
+  /**
+   * Options forwarded to `sequelize.sync()` (e.g. `{ alter: true }`).
+   * @default undefined
+   */
+  sync?: SyncOptions;
+};
+
+/**
+ * Serializes a boot-time `sequelize.sync()` across concurrently-starting
+ * application instances using a Postgres session-level advisory lock
+ * (`pg_advisory_lock`).
+ *
+ * Any app that runs `sequelize.sync({ alter: true })` on boot behind more than
+ * one instance (rolling deploys, auto-scale-out, instance refresh) faces a
+ * race: the DDL runs concurrently against the same database and can deadlock,
+ * error, or leave the schema inconsistent. This helper ensures only one
+ * instance runs the sync at a time; the others block until the holder finishes
+ * and then run against the already-migrated schema (a no-op).
+ *
+ * The lock is acquired and released on a single dedicated connection — a naive
+ * `sequelize.query()` lock/unlock pair can land on different pooled backends
+ * and try to unlock a lock the current connection never held. The lock is
+ * always released on both the success and failure paths.
+ *
+ * @example
+ * ```ts
+ * await syncWithAdvisoryLock({
+ *   sequelize,
+ *   key: 0x50a7_5c_00, // stable, caller-chosen 64-bit key
+ *   sync: { alter: true },
+ * });
+ * ```
+ */
+export const syncWithAdvisoryLock = async ({
+  sequelize,
+  key,
+  sync,
+}: SyncWithAdvisoryLockOptions): Promise<void> => {
+  const connectionManager = sequelize.connectionManager;
+
+  const connection = (await connectionManager.getConnection({
+    type: 'write',
+  })) as {
+    query: (sql: string, values?: unknown[]) => Promise<unknown>;
+  };
+
+  try {
+    await connection.query('SELECT pg_advisory_lock($1)', [key]);
+
+    try {
+      await sequelize.sync(sync);
+    } finally {
+      await connection.query('SELECT pg_advisory_unlock($1)', [key]);
+    }
+  } finally {
+    connectionManager.releaseConnection(connection);
+  }
+};

--- a/packages/postgresdb/tests/models/index.ts
+++ b/packages/postgresdb/tests/models/index.ts
@@ -5,6 +5,7 @@ import {
   DataType,
   initialize,
   Model,
+  syncWithAdvisoryLock,
   Table,
 } from '@ttoss/postgresdb';
 
@@ -94,4 +95,4 @@ export const models = {
   Product,
 };
 
-export { initialize };
+export { initialize, syncWithAdvisoryLock };

--- a/packages/postgresdb/tests/unit/tests/syncWithAdvisoryLock.test.ts
+++ b/packages/postgresdb/tests/unit/tests/syncWithAdvisoryLock.test.ts
@@ -1,0 +1,140 @@
+import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import type { Sequelize } from 'sequelize';
+
+import { initialize, models, syncWithAdvisoryLock } from '../../models/dist';
+
+jest.setTimeout(120000);
+
+const LOCK_KEY = 0x50a7_5c_00;
+
+let sequelize: Sequelize;
+let postgresContainer: StartedPostgreSqlContainer;
+
+const connect = async () => {
+  const db = await initialize({
+    models,
+    logging: false,
+    username: postgresContainer.getUsername(),
+    password: postgresContainer.getPassword(),
+    database: postgresContainer.getDatabase(),
+    host: postgresContainer.getHost(),
+    port: postgresContainer.getPort(),
+    createVectorExtension: true,
+    define: {
+      underscored: true,
+    },
+  });
+
+  return db.sequelize;
+};
+
+beforeAll(async () => {
+  postgresContainer = await new PostgreSqlContainer(
+    'pgvector/pgvector:0.8.1-pg18-trixie'
+  ).start();
+
+  sequelize = await connect();
+});
+
+afterAll(async () => {
+  await sequelize.close();
+  await postgresContainer.stop();
+});
+
+describe('syncWithAdvisoryLock', () => {
+  test('should sync the schema so models are usable', async () => {
+    await syncWithAdvisoryLock({
+      sequelize,
+      key: LOCK_KEY,
+      sync: { alter: true },
+    });
+
+    const user = await models.User.create({
+      email: 'advisory@domain.com',
+      name: 'Advisory User',
+    });
+
+    const found = await models.User.findByPk(user.id);
+    expect(found?.email).toBe('advisory@domain.com');
+  });
+
+  test('should release the advisory lock after syncing', async () => {
+    await syncWithAdvisoryLock({ sequelize, key: LOCK_KEY });
+
+    // If the lock had leaked, this try would fail to acquire it. A successful
+    // acquisition proves the previous call released it.
+    const [rows] = (await sequelize.query(
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      { bind: [LOCK_KEY] }
+    )) as [Array<{ acquired: boolean }>, unknown];
+
+    expect(rows[0].acquired).toBe(true);
+
+    await sequelize.query('SELECT pg_advisory_unlock($1)', {
+      bind: [LOCK_KEY],
+    });
+  });
+
+  test('should release the lock even when sync fails', async () => {
+    const error = new Error('sync failed');
+
+    const syncSpy = jest
+      .spyOn(sequelize, 'sync')
+      .mockRejectedValueOnce(error as never);
+
+    await expect(
+      syncWithAdvisoryLock({ sequelize, key: LOCK_KEY })
+    ).rejects.toThrow('sync failed');
+
+    syncSpy.mockRestore();
+
+    // The lock must have been released despite the failure.
+    const [rows] = (await sequelize.query(
+      'SELECT pg_try_advisory_lock($1) AS acquired',
+      { bind: [LOCK_KEY] }
+    )) as [Array<{ acquired: boolean }>, unknown];
+
+    expect(rows[0].acquired).toBe(true);
+
+    await sequelize.query('SELECT pg_advisory_unlock($1)', {
+      bind: [LOCK_KEY],
+    });
+  });
+
+  test('should serialize concurrent syncs against the same key', async () => {
+    const events: string[] = [];
+
+    const holderConnection = (await sequelize.connectionManager.getConnection({
+      type: 'write',
+    })) as { query: (sql: string, values?: unknown[]) => Promise<unknown> };
+
+    // Simulate a first instance that already holds the lock.
+    await holderConnection.query('SELECT pg_advisory_lock($1)', [LOCK_KEY]);
+    events.push('holder-acquired');
+
+    // A second instance tries to sync; it must block until the holder releases.
+    const waiter = syncWithAdvisoryLock({ sequelize, key: LOCK_KEY }).then(
+      () => {
+        events.push('waiter-synced');
+      }
+    );
+
+    // Give the waiter time to attempt acquisition; it should still be blocked.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+    events.push('holder-releasing');
+
+    await holderConnection.query('SELECT pg_advisory_unlock($1)', [LOCK_KEY]);
+    sequelize.connectionManager.releaseConnection(holderConnection);
+
+    await waiter;
+
+    expect(events).toEqual([
+      'holder-acquired',
+      'holder-releasing',
+      'waiter-synced',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a generic, reusable helper to `@ttoss/postgresdb` that serializes boot-time `sequelize.sync()` across concurrently-starting application instances using a **Postgres session-level advisory lock**.

Any app that runs `sequelize.sync({ alter: true })` on boot behind more than one instance (rolling deploys, auto-scale-out, instance refresh) faces a race — the generated `ALTER TABLE` DDL runs concurrently against the same database and can deadlock, error, or leave the schema inconsistent. Previously every consumer had to solve this themselves.

## What changed

- **New standalone export `syncWithAdvisoryLock({ sequelize, key, sync })`** (`src/syncWithAdvisoryLock.ts`) — the cleaner primitive that keeps `initialize` free of sync policy.
- **New `initialize({ syncLock })` option** that runs the advisory-locked sync right after connecting.
- Exported `SyncOptions` type from the sequelize re-export module.
- Documented the feature in the package `README.md` (usage + API reference).
- Added tests in `tests/unit/tests/syncWithAdvisoryLock.test.ts`.

## Correctness properties

- **Single dedicated connection**: the lock is acquired and released on one connection grabbed from the connection manager, so the unlock always targets the backend that actually holds the lock (a naive `sequelize.query()` pair could land on different pooled backends).
- **Blocking session-level lock**: uses `pg_advisory_lock`, not `pg_try_advisory_lock`, so waiters block until the holder finishes and then run against the already-migrated schema (a no-op) rather than skipping the sync.
- **Always released**: the lock is released on both the success and failure paths via nested `finally` blocks, and the connection is always returned to the pool.
- **No behavioral change for single-instance boot** — the lock is acquired and released with no contention.

## Usage

```ts
import { syncWithAdvisoryLock } from '@ttoss/postgresdb';

await syncWithAdvisoryLock({
  sequelize,
  key: 0x50a7_5c_00, // stable, caller-chosen 64-bit key kept constant across releases
  sync: { alter: true },
});

// or via initialize
const db = await initialize({
  models,
  syncLock: { key: 0x50a7_5c_00, sync: { alter: true } },
});
```

## Testing

The package's test suite uses Testcontainers (Docker), which isn't available in this environment, so the new tests were not executed here — same constraint as the existing `setup`/`hooks` suites. The changed source typechecks cleanly and `pnpm run -w lint` passes. The added tests cover: schema sync usability, lock release on success, lock release on sync failure, and serialization of concurrent syncs against the same key.

## Downstream follow-up

Once released, `ttoss/soat` can drop its local copy of this helper and call the `@ttoss/postgresdb` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159v8gKyc9VjWWpMD3xSr4C

---
_Generated by [Claude Code](https://claude.ai/code/session_0159v8gKyc9VjWWpMD3xSr4C)_