### PR TITLE
fix(repo): invalidate @docs/website cache when package docs change

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,9 +15,24 @@
       "dependsOn": ["^build", "i18n"],
       "outputs": ["dist/**", "build/**", ".next/**", "storybook-static/**"]
     },
+    "@docs/website#build": {
+      "dependsOn": ["^build", "i18n"],
+      "inputs": [
+        "**/*",
+        "$TURBO_ROOT$/packages/*/README.md",
+        "$TURBO_ROOT$/packages/*/src/**",
+        "$TURBO_ROOT$/packages/*/package.json"
+      ],
+      "outputs": ["build/**"]
+    },
     "@docs/website#deploy": {
       "dependsOn": ["build"],
-      "inputs": ["**/*", "../packages/*/README.md"],
+      "inputs": [
+        "**/*",
+        "$TURBO_ROOT$/packages/*/README.md",
+        "$TURBO_ROOT$/packages/*/src/**",
+        "$TURBO_ROOT$/packages/*/package.json"
+      ],
       "env": ["AWS_*", "CARLIN_*", "ENVIRONMENT"],
       "outputs": [".carlin/**"]
     },


### PR DESCRIPTION
## Summary

The docs site at https://ttoss.dev was not updating when a package's docs changed (e.g. the `@ttoss/postgresdb` README/API after #1134). The `main` CI run completed successfully, but Turbo served the docs deploy from cache and replayed a stale build — nothing new was uploaded.

Evidence from run [#1712](https://github.com/ttoss/ttoss/actions/runs/29421284443) (the #1134 merge):

```
@docs/website:deploy      cache hit, replaying logs 319ed872855143a6   ← replayed, not run
@docs/storybook:deploy    cache bypass, force executing
@terezinha-farm/vite-app:deploy  cache bypass, force executing
```

`@docs/website:deploy` was the only deploy that got a cache hit.

## Root cause

In `turbo.json`, the `@docs/website#deploy` override is cacheable (unlike the generic `deploy` task, it does not set `cache: false`), but its cache key did not track the sources the docs site is generated from:

- The glob `../packages/*/README.md` was relative to the `@docs/website` package (`docs/website/`), so it resolved to `docs/packages/*` — which doesn't exist. Package READMEs live at repo-root `packages/`.
- Only READMEs were listed. The API reference is generated from each package's `src/index.ts` via `docusaurus-plugin-typedoc`, so signature changes (like the new `syncWithAdvisoryLock` export) weren't tracked either.

So a package-only change never invalidated the website cache, and Turbo replayed a stale deploy.

## Changes

- Add an `@docs/website#build` override so the docs build itself is invalidated when package docs change.
- Fix both `build` and `deploy` `inputs` to reference the real sources via the `$TURBO_ROOT$` microsyntax:
  - `$TURBO_ROOT$/packages/*/README.md`
  - `$TURBO_ROOT$/packages/*/src/**`
  - `$TURBO_ROOT$/packages/*/package.json` (feeds typedoc entry-point resolution)

Verified with `turbo run deploy --filter=@docs/website --dry=json`: the inputs now resolve to `../../packages/*/README.md` and `.../src/**` across all packages (627 tracked files), so any package docs change will now bust the cache and trigger a real rebuild + redeploy. `$TURBO_ROOT$` requires Turbo ≥ 2.1 (repo is on 2.9.15).

This fixes docs propagation for **all** packages, not just postgresdb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159v8gKyc9VjWWpMD3xSr4C

---
_Generated by [Claude Code](https://claude.ai/code/session_0159v8gKyc9VjWWpMD3xSr4C)_