### PR TITLE
feat(postgresdb): bound syncWithAdvisoryLock wait with optional lockTimeoutMs

### DIFF
--- a/packages/postgresdb/src/syncWithAdvisoryLock.ts
+++ b/packages/postgresdb/src/syncWithAdvisoryLock.ts
@@ -16,6 +16,25 @@ export type SyncWithAdvisoryLockOptions = {
    * @default undefined
    */
   sync?: SyncOptions;
+  /**
+   * Upper bound in milliseconds on how long to wait to *acquire* the advisory
+   * lock, enforced via Postgres `lock_timeout`. When omitted the wait is
+   * unbounded (the historical behavior).
+   *
+   * Why bound it: a session-level advisory lock held by an instance that died
+   * mid-sync (SIGKILL, OOM) stays held until its backend is reaped — behind a
+   * connection pooler or Aurora that can take minutes. Without a bound, every
+   * later boot blocks on `pg_advisory_lock` forever and the whole deploy
+   * deadlocks. With it, acquisition fails fast with `canceling statement due to
+   * lock timeout`, which the caller can surface (e.g. exit the process) instead
+   * of hanging silently.
+   *
+   * It must be **larger than a legitimate `sync` duration**, so an instance that
+   * is merely waiting for a live peer's migration waits it out rather than
+   * aborting. Must be a positive integer; other values are ignored.
+   * @default undefined
+   */
+  lockTimeoutMs?: number;
 };
 
 /**
@@ -48,6 +67,7 @@ export const syncWithAdvisoryLock = async ({
   sequelize,
   key,
   sync,
+  lockTimeoutMs,
 }: SyncWithAdvisoryLockOptions): Promise<void> => {
   const connectionManager = sequelize.connectionManager;
 
@@ -57,7 +77,20 @@ export const syncWithAdvisoryLock = async ({
     query: (sql: string, values?: unknown[]) => Promise<unknown>;
   };
 
+  const bounded =
+    typeof lockTimeoutMs === 'number' &&
+    Number.isInteger(lockTimeoutMs) &&
+    lockTimeoutMs > 0;
+
   try {
+    if (bounded) {
+      // `lockTimeoutMs` is validated as a positive integer here, so inlining it
+      // is safe — SET does not accept bind parameters. If the lock is held
+      // beyond this, pg_advisory_lock below rejects with
+      // "canceling statement due to lock timeout".
+      await connection.query(`SET lock_timeout = ${lockTimeoutMs}`);
+    }
+
     await connection.query('SELECT pg_advisory_lock($1)', [key]);
 
     try {
@@ -66,6 +99,14 @@ export const syncWithAdvisoryLock = async ({
       await connection.query('SELECT pg_advisory_unlock($1)', [key]);
     }
   } finally {
+    if (bounded) {
+      // Restore the default so the timeout does not leak onto later borrowers
+      // of this pooled connection. Best-effort: the connection may already be
+      // in an error state.
+      await connection.query('SET lock_timeout = 0').catch(() => {
+        return undefined;
+      });
+    }
     connectionManager.releaseConnection(connection);
   }
 };

--- a/packages/postgresdb/tests/unit/tests/syncWithAdvisoryLock.test.ts
+++ b/packages/postgresdb/tests/unit/tests/syncWithAdvisoryLock.test.ts
@@ -102,6 +102,39 @@ describe('syncWithAdvisoryLock', () => {
     });
   });
 
+  test('should fail fast when the lock is held longer than lockTimeoutMs', async () => {
+    const holderConnection = (await sequelize.connectionManager.getConnection({
+      type: 'write',
+    })) as { query: (sql: string, values?: unknown[]) => Promise<unknown> };
+
+    // A peer holds the lock and never releases it within the timeout window,
+    // simulating an instance that died mid-sync while holding the lock.
+    await holderConnection.query('SELECT pg_advisory_lock($1)', [LOCK_KEY]);
+
+    const syncSpy = jest.spyOn(sequelize, 'sync');
+
+    try {
+      await expect(
+        syncWithAdvisoryLock({ sequelize, key: LOCK_KEY, lockTimeoutMs: 500 })
+      ).rejects.toThrow(/lock timeout/i);
+
+      // It aborted at acquisition, so sync must never have run.
+      expect(syncSpy).not.toHaveBeenCalled();
+    } finally {
+      syncSpy.mockRestore();
+      await holderConnection.query('SELECT pg_advisory_unlock($1)', [LOCK_KEY]);
+      sequelize.connectionManager.releaseConnection(holderConnection);
+    }
+
+    // The waiter released its connection cleanly, and lock_timeout did not leak:
+    // a fresh bounded sync against the now-free lock succeeds.
+    await syncWithAdvisoryLock({
+      sequelize,
+      key: LOCK_KEY,
+      lockTimeoutMs: 5000,
+    });
+  });
+
   test('should serialize concurrent syncs against the same key', async () => {
     const events: string[] = [];
 


### PR DESCRIPTION
## Problem

`syncWithAdvisoryLock` serializes boot-time `sequelize.sync()` with a **session-level** advisory lock (`pg_advisory_lock`), which waits **indefinitely**. If an instance is killed (SIGKILL / OOM) *while holding the lock mid-sync*, its Postgres backend can linger — behind a connection pooler or a managed engine that reuses connections, for minutes — so the session lock is never released. Every subsequent boot then blocks forever on acquisition, and rolling deploys / scale-out deadlock: each new instance waits on the stuck lock, fails its health check, is replaced, and blocks again.

## Change

Add an optional **`lockTimeoutMs`** to `syncWithAdvisoryLock`:

- When set, issues `SET lock_timeout = <ms>` on the dedicated connection **before** `pg_advisory_lock`, so a lock held past the bound fails fast with `canceling statement due to lock timeout` instead of hanging silently. The caller can surface that (e.g. exit the process) so the platform restarts it cleanly.
- Resets `lock_timeout` to the default before returning the connection to the pool, so the setting never leaks onto later borrowers.
- **Opt-in and non-breaking**: omitting it preserves the current unbounded wait.

The bound must exceed a legitimate `sync` duration, so an instance *merely waiting* for a live peer's migration waits it out rather than aborting — documented on the option.

## Tests

Added a real-Postgres (testcontainer) test: with the lock held by another session, `syncWithAdvisoryLock({ lockTimeoutMs: 500 })` rejects with a lock-timeout error and never runs `sync`; a subsequent bounded call against the freed lock succeeds (proving the connection was released cleanly and `lock_timeout` did not leak). Full `@ttoss/postgresdb` suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)