### PR TITLE
feat(react-dashboard): controlled selection, configurable slot height, and multi-slot mode

### DIFF
--- a/docs/storybook/stories/react-dashboard/Dashboard.stories.tsx
+++ b/docs/storybook/stories/react-dashboard/Dashboard.stories.tsx
@@ -1274,7 +1274,7 @@ const WithCardDetailStory = () => {
                 }}
               >
                 <Box>
-                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  {}
                   <Text
                     sx={{
                       fontSize: 'xs',
@@ -1286,17 +1286,16 @@ const WithCardDetailStory = () => {
                   >
                     Detail panel
                   </Text>
-                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  {}
                   <Heading sx={{ fontSize: 'xl' }}>{card.title}</Heading>
                 </Box>
                 <Button variant="secondary" onClick={close}>
-                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
-                  ✕ Close
+                  {}✕ Close
                 </Button>
               </Flex>
               <Flex sx={{ gap: 4, flexWrap: 'wrap' }}>
                 <Box sx={{ flex: '1 1 240px' }}>
-                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  {}
                   <Text
                     sx={{
                       fontSize: 'sm',
@@ -1320,7 +1319,7 @@ const WithCardDetailStory = () => {
                             borderRadius: 'sm',
                           }}
                         >
-                          {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                          {}
                           <Text sx={{ fontSize: 'sm' }}>{row.campaign}</Text>
                           {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
                           <Text sx={{ fontSize: 'sm', fontWeight: 'bold' }}>
@@ -1332,7 +1331,7 @@ const WithCardDetailStory = () => {
                   </Stack>
                 </Box>
                 <Box sx={{ flex: '1 1 240px' }}>
-                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  {}
                   <Text
                     sx={{
                       fontSize: 'sm',
@@ -1387,6 +1386,300 @@ export const WithCardDetail: StoryObj = {
       description: {
         story:
           "Click any card to open a detail panel immediately below that card's row — showing a campaign breakdown and a 7-day bar chart. Click the same card again to close the panel (toggle), or click a different card to move it. The panel is rendered by `renderCardDetail(card, close)` and positioned in document flow right after the grid.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Controlled selection story
+// ---------------------------------------------------------------------------
+
+const controlledDetailTemplate: DashboardTemplate = {
+  id: 'controlled',
+  name: 'Controlled Selection',
+  grid: [
+    {
+      i: 'revenue',
+      x: 0,
+      y: 0,
+      w: 4,
+      h: 4,
+      card: {
+        id: 'revenue',
+        title: 'Revenue',
+        numberType: 'currency',
+        type: 'bigNumber',
+        sourceType: [{ source: 'api' }],
+        data: { value: 150000 },
+        trend: { value: 12.5, status: 'positive' },
+      },
+    },
+    {
+      i: 'roas',
+      x: 4,
+      y: 0,
+      w: 4,
+      h: 4,
+      card: {
+        id: 'roas',
+        title: 'ROAS',
+        numberType: 'number',
+        type: 'bigNumber',
+        sourceType: [{ source: 'api' }],
+        data: { value: 4.2 },
+        trend: { value: -3.1, status: 'negative' },
+      },
+    },
+    {
+      i: 'cpa',
+      x: 8,
+      y: 0,
+      w: 4,
+      h: 4,
+      card: {
+        id: 'cpa',
+        title: 'CPA',
+        numberType: 'currency',
+        type: 'bigNumber',
+        sourceType: [{ source: 'api' }],
+        data: { value: 38.5 },
+        trend: { value: 1.8, status: 'positive' },
+      },
+    },
+  ],
+};
+
+const ControlledSelectionStory = () => {
+  const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
+
+  const handleCardSelect = (key: string | string[] | null) => {
+    setSelectedKey(typeof key === 'string' ? key : null);
+  };
+
+  return (
+    <Box sx={{ width: '100%', minWidth: '900px', padding: '4' }}>
+      <Box
+        sx={{
+          mb: 4,
+          p: 3,
+          bg: 'display.bg.secondary.default',
+          borderRadius: 'default',
+        }}
+      >
+        {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+        <Text sx={{ fontSize: 'sm', fontWeight: 'bold', mb: 2 }}>
+          External selection control
+        </Text>
+        <Flex sx={{ gap: 2, flexWrap: 'wrap' }}>
+          {controlledDetailTemplate.grid.map((item) => {
+            const card = item.card as { title: string };
+            const isSelected = selectedKey === item.i;
+            return (
+              <Button
+                key={item.i}
+                variant={isSelected ? 'primary' : 'secondary'}
+                onClick={() => {
+                  setSelectedKey(isSelected ? null : item.i);
+                }}
+              >
+                {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                {isSelected ? '✓ ' : ''}
+                {card.title}
+              </Button>
+            );
+          })}
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setSelectedKey(null);
+            }}
+          >
+            {}
+            Clear
+          </Button>
+        </Flex>
+        {}
+        <Text
+          sx={{
+            fontSize: 'xs',
+            mt: 2,
+            color: 'display.text.secondary.default',
+          }}
+        >
+          {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+          Selected: {selectedKey ?? 'none'}
+        </Text>
+      </Box>
+      <Dashboard
+        selectedTemplate={controlledDetailTemplate}
+        templates={[controlledDetailTemplate]}
+        filters={[]}
+        loading={false}
+        showFilters={false}
+        selectedCardKey={selectedKey}
+        onCardSelect={handleCardSelect}
+        renderCardDetail={(card, close) => {
+          return (
+            <Box sx={{ p: 3 }}>
+              <Flex sx={{ justifyContent: 'space-between', mb: 2 }}>
+                {}
+                <Heading sx={{ fontSize: 'lg' }}>{card.title}</Heading>
+                <Button variant="secondary" onClick={close}>
+                  {}✕ Close
+                </Button>
+              </Flex>
+              {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+              <Text sx={{ color: 'display.text.secondary.default' }}>
+                Detail panel for {card.title} — controlled externally.
+              </Text>
+            </Box>
+          );
+        }}
+      />
+    </Box>
+  );
+};
+
+export const WithControlledSelection: StoryObj = {
+  render: () => {
+    return <ControlledSelectionStory />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates `selectedCardKey` and `onCardSelect` for controlled selection. The buttons above the grid drive the selected card externally — clicking them pre-opens the matching detail slot. Clicking a card in the grid fires `onCardSelect`, which updates the external state.',
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Multi-slot story
+// ---------------------------------------------------------------------------
+
+const MultiSlotStory = () => {
+  return (
+    <Box sx={{ width: '100%', minWidth: '900px', padding: '4' }}>
+      <Box
+        sx={{
+          mb: 4,
+          p: 3,
+          bg: 'display.bg.secondary.default',
+          borderRadius: 'default',
+        }}
+      >
+        {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+        <Text sx={{ fontSize: 'sm' }}>
+          Click any card to expand it. With{' '}
+          {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+          <code>{'detailMode="multi"'}</code>, each card gets its own
+          independent slot — multiple cards can be open at the same time. Click
+          the same card again (or its Close button) to collapse it.
+        </Text>
+      </Box>
+      <Dashboard
+        selectedTemplate={controlledDetailTemplate}
+        templates={[controlledDetailTemplate]}
+        filters={[]}
+        loading={false}
+        showFilters={false}
+        detailMode="multi"
+        renderCardDetail={(card, close) => {
+          return (
+            <Box sx={{ p: 3 }}>
+              <Flex
+                sx={{
+                  justifyContent: 'space-between',
+                  mb: 3,
+                  alignItems: 'center',
+                }}
+              >
+                {}
+                <Heading sx={{ fontSize: 'lg' }}>{card.title}</Heading>
+                <Button variant="secondary" onClick={close}>
+                  {}✕ Close
+                </Button>
+              </Flex>
+              <Flex sx={{ gap: 4, flexWrap: 'wrap' }}>
+                <Box sx={{ flex: '1 1 240px' }}>
+                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  <Text sx={{ fontSize: 'sm', fontWeight: 'bold', mb: 3 }}>
+                    Top Campaigns
+                  </Text>
+                  <Stack sx={{ gap: 2 }}>
+                    {mockBreakdown.map((row) => {
+                      return (
+                        <Flex
+                          key={row.campaign}
+                          sx={{
+                            justifyContent: 'space-between',
+                            p: 2,
+                            bg: 'display.bg.primary.default',
+                            borderRadius: 'sm',
+                          }}
+                        >
+                          {}
+                          <Text sx={{ fontSize: 'sm' }}>{row.campaign}</Text>
+                          {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                          <Text sx={{ fontSize: 'sm', fontWeight: 'bold' }}>
+                            ${row.value.toLocaleString()}
+                          </Text>
+                        </Flex>
+                      );
+                    })}
+                  </Stack>
+                </Box>
+                <Box sx={{ flex: '1 1 240px' }}>
+                  {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
+                  <Text sx={{ fontSize: 'sm', fontWeight: 'bold', mb: 3 }}>
+                    Daily Trend
+                  </Text>
+                  <Flex
+                    sx={{
+                      gap: 1,
+                      alignItems: 'flex-end',
+                      height: '80px',
+                      bg: 'display.bg.primary.default',
+                      borderRadius: 'sm',
+                      p: 3,
+                    }}
+                  >
+                    {[40, 65, 55, 80, 70, 90, 75].map((h, i) => {
+                      return (
+                        <Box
+                          key={i}
+                          sx={{
+                            flex: 1,
+                            bg: 'primary',
+                            borderRadius: '2px',
+                            opacity: 0.7 + i * 0.04,
+                            height: `${h}%`,
+                          }}
+                        />
+                      );
+                    })}
+                  </Flex>
+                </Box>
+              </Flex>
+            </Box>
+          );
+        }}
+      />
+    </Box>
+  );
+};
+
+export const WithMultipleSlots: StoryObj = {
+  render: () => {
+    return <MultiSlotStory />;
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates `detailMode="multi"` — each card gets its own independent detail slot. Click multiple cards to expand them side-by-side. Each slot has its own close button.',
       },
     },
   },

--- a/packages/react-dashboard/src/Dashboard.tsx
+++ b/packages/react-dashboard/src/Dashboard.tsx
@@ -43,6 +43,10 @@ const DashboardContent = ({
   sx,
   renderCardDetail,
   clickableCardFilter,
+  selectedCardKey: controlledSelectedCardKey,
+  onCardSelect,
+  detailSlotHeight,
+  detailMode = 'single',
 }: {
   loading: boolean;
   headerChildren?: React.ReactNode;
@@ -56,6 +60,13 @@ const DashboardContent = ({
     close: () => void
   ) => React.ReactNode;
   clickableCardFilter?: (card: DashboardCard) => boolean;
+  selectedCardKey?: string | string[] | null;
+  onCardSelect?: (
+    key: string | string[] | null,
+    card: DashboardCard | null
+  ) => void;
+  detailSlotHeight?: number;
+  detailMode?: 'single' | 'multi';
 }) => {
   const { isEditMode, editingGrid, filters, editable } = useDashboard();
   const effectiveTemplate = resolveTemplate(
@@ -66,8 +77,36 @@ const DashboardContent = ({
   const hasHeaderContent =
     (showFilters && filters.length > 0) || Boolean(headerChildren) || editable;
 
-  const [selectedCardKey, setSelectedCardKey] = React.useState<string | null>(
-    null
+  const isControlled = controlledSelectedCardKey !== undefined;
+  const [internalSelectedCardKey, setInternalSelectedCardKey] = React.useState<
+    string | string[] | null
+  >(null);
+
+  const selectedCardKey = isControlled
+    ? controlledSelectedCardKey
+    : internalSelectedCardKey;
+
+  const setSelectedCardKey: React.Dispatch<
+    React.SetStateAction<string | string[] | null>
+  > = React.useCallback(
+    (action) => {
+      const next =
+        typeof action === 'function' ? action(selectedCardKey ?? null) : action;
+      if (!isControlled) {
+        setInternalSelectedCardKey(next);
+      }
+      if (onCardSelect) {
+        const firstKey = Array.isArray(next) ? next[0] : next;
+        const card =
+          firstKey && effectiveTemplate
+            ? ((effectiveTemplate.grid.find((item) => {
+                return item.i === firstKey;
+              })?.card as DashboardCard | undefined) ?? null)
+            : null;
+        onCardSelect(next, card);
+      }
+    },
+    [isControlled, onCardSelect, selectedCardKey, effectiveTemplate]
   );
 
   return (
@@ -96,6 +135,8 @@ const DashboardContent = ({
         setSelectedCardKey={setSelectedCardKey}
         renderCardDetail={renderCardDetail}
         clickableCardFilter={clickableCardFilter}
+        detailSlotHeight={detailSlotHeight}
+        detailMode={detailMode}
       />
     </Flex>
   );
@@ -119,6 +160,10 @@ export const Dashboard = ({
   sx,
   renderCardDetail,
   clickableCardFilter,
+  selectedCardKey,
+  onCardSelect,
+  detailSlotHeight,
+  detailMode,
 }: {
   selectedTemplate?: DashboardTemplate;
   loading?: boolean;
@@ -147,6 +192,25 @@ export const Dashboard = ({
   ) => React.ReactNode;
   /** When provided, only cards for which this returns `true` are clickable. Defaults to all non-sectionDivider cards. */
   clickableCardFilter?: (card: DashboardCard) => boolean;
+  /**
+   * Controlled selection. When provided, `DashboardContent` uses this value
+   * instead of its own `useState`. Supply `onCardSelect` to handle changes.
+   * Supports a single key (string) or multiple keys (string[]) when `detailMode='multi'`.
+   * Omit entirely for uncontrolled behavior (default).
+   */
+  selectedCardKey?: string | string[] | null;
+  /**
+   * Called whenever the selected card key changes (controlled and uncontrolled).
+   * `key` is the new selection; `card` is the first selected card or `null` when closed.
+   */
+  onCardSelect?: (
+    key: string | string[] | null,
+    card: DashboardCard | null
+  ) => void;
+  /** Number of grid rows for the detail slot. Defaults to 12 (384 px at rowHeight=32). */
+  detailSlotHeight?: number;
+  /** 'single' (default): one slot at a time. 'multi': each card gets its own independent slot. */
+  detailMode?: 'single' | 'multi';
 }) => {
   return (
     <DashboardProvider
@@ -170,6 +234,10 @@ export const Dashboard = ({
         sx={sx}
         renderCardDetail={renderCardDetail}
         clickableCardFilter={clickableCardFilter}
+        selectedCardKey={selectedCardKey}
+        onCardSelect={onCardSelect}
+        detailSlotHeight={detailSlotHeight}
+        detailMode={detailMode}
       />
     </DashboardProvider>
   );

--- a/packages/react-dashboard/src/DashboardGrid.tsx
+++ b/packages/react-dashboard/src/DashboardGrid.tsx
@@ -31,13 +31,19 @@ export type DashboardGridProps = {
   /** ISO 4217 currency code applied to all cards with `numberType="currency"`. Card-level `currency` takes precedence. */
   currency?: string;
   'data-export-target'?: boolean;
-  selectedCardKey?: string | null;
-  setSelectedCardKey?: React.Dispatch<React.SetStateAction<string | null>>;
+  selectedCardKey?: string | string[] | null;
+  setSelectedCardKey?: React.Dispatch<
+    React.SetStateAction<string | string[] | null>
+  >;
   renderCardDetail?: (
     card: DashboardCardProps,
     close: () => void
   ) => React.ReactNode;
   clickableCardFilter?: (card: DashboardCardProps) => boolean;
+  /** Number of grid rows for the detail slot. Defaults to 12 (384 px at rowHeight=32). */
+  detailSlotHeight?: number;
+  /** 'single' (default): one slot at a time, toggles off on re-click. 'multi': each card gets its own independent slot. */
+  detailMode?: 'single' | 'multi';
 };
 
 const COLS_NUM = 12;
@@ -64,12 +70,14 @@ const buildLayout = (template: DashboardTemplate, isEditMode: boolean) => {
 };
 
 const SLOT_KEY = '__detail_slot__';
-const SLOT_H = 12;
+const DEFAULT_SLOT_H = 12;
 
 const buildSlotLayout = (
   base: ReturnType<typeof buildLayout>,
   selectedKey: string,
-  template: DashboardTemplate
+  template: DashboardTemplate,
+  slotH: number,
+  slotIndex: number
 ): ReturnType<typeof buildLayout> => {
   const selectedItem = template.grid.find((i) => {
     return i.i === selectedKey;
@@ -77,18 +85,18 @@ const buildSlotLayout = (
   if (!selectedItem) return base;
   const slotY = selectedItem.y + selectedItem.h;
   const slotItem: Layout = {
-    i: SLOT_KEY,
+    i: `${SLOT_KEY}:${slotIndex}`,
     x: 0,
     y: slotY,
     w: COLS_NUM,
-    h: SLOT_H,
+    h: slotH,
     isDraggable: false,
     isResizable: false,
     static: true,
   };
   const insertAndShift = (items: Layout[]) => {
     const shifted = items.map((item) => {
-      if (item.y >= slotY) return { ...item, y: item.y + SLOT_H };
+      if (item.y >= slotY) return { ...item, y: item.y + slotH };
       return item;
     });
     return [...shifted, slotItem];
@@ -107,17 +115,19 @@ const renderSlotChild = (
   template: DashboardTemplate,
   selectedKey: string | null | undefined,
   renderDetail: DashboardGridProps['renderCardDetail'],
-  close: () => void
+  makeClose: (key: string) => () => void,
+  slotIndex: number
 ): React.ReactNode => {
   if (!selectedKey || !renderDetail) return null;
   const item = template.grid.find((i) => {
     return i.i === selectedKey;
   });
   if (!item || item.card.type === 'sectionDivider') return null;
+  const slotKey = `${SLOT_KEY}:${slotIndex}`;
   return (
-    <div key={SLOT_KEY}>
+    <div key={slotKey}>
       <Box sx={{ width: '100%', height: '100%', padding: 2 }}>
-        {renderDetail(item.card as DashboardCardProps, close)}
+        {renderDetail(item.card as DashboardCardProps, makeClose(selectedKey))}
       </Box>
     </div>
   );
@@ -172,30 +182,55 @@ const useDragHandlers = (
 const resolveLayouts = (
   selectedTemplate: DashboardTemplate | undefined,
   isEditMode: boolean,
-  selectedCardKey: string | null | undefined,
-  renderCardDetail: DashboardGridProps['renderCardDetail']
+  selectedCardKey: string | string[] | null | undefined,
+  renderCardDetail: DashboardGridProps['renderCardDetail'],
+  slotH: number
 ) => {
   if (!selectedTemplate) return undefined;
   const base = buildLayout(selectedTemplate, isEditMode);
-  if (selectedCardKey && renderCardDetail) {
-    return buildSlotLayout(base, selectedCardKey, selectedTemplate);
-  }
-  return base;
+  if (!renderCardDetail) return base;
+  const keys = Array.isArray(selectedCardKey)
+    ? selectedCardKey
+    : selectedCardKey
+      ? [selectedCardKey]
+      : [];
+  if (keys.length === 0) return base;
+  return keys.reduce((layouts, key, index) => {
+    return buildSlotLayout(layouts, key, selectedTemplate, slotH, index);
+  }, base);
 };
 
-const useCardClickHandler = (
-  isEditMode: boolean,
-  isDraggingRef: React.MutableRefObject<boolean>,
-  renderCardDetail: DashboardGridProps['renderCardDetail'],
-  clickableCardFilter: DashboardGridProps['clickableCardFilter'],
-  setSelectedCardKey: DashboardGridProps['setSelectedCardKey']
-) => {
+type CardClickHandlerOptions = {
+  isEditMode: boolean;
+  isDraggingRef: React.MutableRefObject<boolean>;
+  renderCardDetail: DashboardGridProps['renderCardDetail'];
+  clickableCardFilter: DashboardGridProps['clickableCardFilter'];
+  setSelectedCardKey: DashboardGridProps['setSelectedCardKey'];
+  detailMode: 'single' | 'multi';
+};
+
+const useCardClickHandler = ({
+  isEditMode,
+  isDraggingRef,
+  renderCardDetail,
+  clickableCardFilter,
+  setSelectedCardKey,
+  detailMode,
+}: CardClickHandlerOptions) => {
   const isClickable = (card: DashboardCardProps) => {
     return getCardClickable(card, renderCardDetail, clickableCardFilter);
   };
   const handleCardClick = (key: string, card: DashboardCardProps) => {
     if (isEditMode || isDraggingRef.current || !isClickable(card)) return;
     setSelectedCardKey?.((prev) => {
+      if (detailMode === 'multi') {
+        const current = Array.isArray(prev) ? prev : prev ? [prev] : [];
+        return current.includes(key)
+          ? current.filter((k) => {
+              return k !== key;
+            })
+          : [...current, key];
+      }
       return prev === key ? null : key;
     });
   };
@@ -211,9 +246,9 @@ type ActiveGridProps = {
   handleCardClick: (key: string, card: DashboardCardProps) => void;
   removeCard: (key: string) => void;
   updateCard: (key: string, data: { title: string }) => void;
-  selectedCardKey?: string | null;
+  selectedCardKeys: string[];
   renderCardDetail?: DashboardGridProps['renderCardDetail'];
-  close: () => void;
+  makeClose: (key: string) => () => void;
   handleLayoutChange: (l: Layout[]) => void;
   snapDrag: (_l: Layout[], _o: Layout, newItem: Layout) => void;
   onDragStart: () => void;
@@ -229,9 +264,9 @@ const ActiveGrid = ({
   handleCardClick,
   removeCard,
   updateCard,
-  selectedCardKey,
+  selectedCardKeys,
   renderCardDetail,
-  close,
+  makeClose,
   handleLayoutChange,
   snapDrag,
   onDragStart,
@@ -263,12 +298,15 @@ const ActiveGrid = ({
           return updateCard(key, { title });
         },
       })}
-      {renderSlotChild(
-        selectedTemplate,
-        selectedCardKey,
-        renderCardDetail,
-        close
-      )}
+      {selectedCardKeys.map((key, index) => {
+        return renderSlotChild(
+          selectedTemplate,
+          key,
+          renderCardDetail,
+          makeClose,
+          index
+        );
+      })}
     </ResponsiveGridLayout>
   );
 };
@@ -282,6 +320,8 @@ export const DashboardGrid = ({
   setSelectedCardKey,
   renderCardDetail,
   clickableCardFilter,
+  detailSlotHeight = DEFAULT_SLOT_H,
+  detailMode = 'single',
   ...rest
 }: DashboardGridProps) => {
   const { onLayoutChange, removeCard, updateCard } = useDashboard();
@@ -293,22 +333,44 @@ export const DashboardGrid = ({
     onDragStart,
   } = useDragHandlers(isEditMode, onLayoutChange);
   const { isClickable: isCardClickable, handleCardClick } = useCardClickHandler(
-    isEditMode,
-    isDraggingRef,
-    renderCardDetail,
-    clickableCardFilter,
-    setSelectedCardKey
+    {
+      isEditMode,
+      isDraggingRef,
+      renderCardDetail,
+      clickableCardFilter,
+      setSelectedCardKey,
+      detailMode,
+    }
   );
 
-  const close = React.useCallback(() => {
-    return setSelectedCardKey?.(null);
-  }, [setSelectedCardKey]);
+  const makeClose = React.useCallback(
+    (key: string) => {
+      return () => {
+        setSelectedCardKey?.((prev) => {
+          if (Array.isArray(prev)) {
+            return prev.filter((k) => {
+              return k !== key;
+            });
+          }
+          return null;
+        });
+      };
+    },
+    [setSelectedCardKey]
+  );
+
+  const selectedCardKeys = Array.isArray(selectedCardKey)
+    ? selectedCardKey
+    : selectedCardKey
+      ? [selectedCardKey]
+      : [];
 
   const layouts = resolveLayouts(
     selectedTemplate,
     isEditMode,
     selectedCardKey,
-    renderCardDetail
+    renderCardDetail,
+    detailSlotHeight
   );
 
   if (!selectedTemplate || !layouts) return null;
@@ -344,9 +406,9 @@ export const DashboardGrid = ({
           handleCardClick={handleCardClick}
           removeCard={removeCard}
           updateCard={updateCard}
-          selectedCardKey={selectedCardKey}
+          selectedCardKeys={selectedCardKeys}
           renderCardDetail={renderCardDetail}
-          close={close}
+          makeClose={makeClose}
           handleLayoutChange={handleLayoutChange}
           snapDrag={snapDrag}
           onDragStart={onDragStart}

--- a/packages/react-dashboard/tests/unit/tests/DashboardGrid.test.tsx
+++ b/packages/react-dashboard/tests/unit/tests/DashboardGrid.test.tsx
@@ -524,4 +524,318 @@ describe('DashboardGrid', () => {
       expect(screen.queryByText('Detail: Card 1')).not.toBeInTheDocument();
     });
   });
+
+  describe('controlled selectedCardKey', () => {
+    const controlledTemplate: DashboardTemplate = {
+      id: 'controlled-template',
+      name: 'Controlled Template',
+      grid: [
+        {
+          i: 'card-1',
+          x: 0,
+          y: 0,
+          w: 4,
+          h: 2,
+          card: {
+            id: 'card-1',
+            title: 'Card 1',
+            numberType: 'number',
+            type: 'bigNumber',
+            sourceType: [{ source: 'api' }],
+            data: { value: 100 },
+          },
+        },
+        {
+          i: 'card-2',
+          x: 4,
+          y: 0,
+          w: 4,
+          h: 2,
+          card: {
+            id: 'card-2',
+            title: 'Card 2',
+            numberType: 'number',
+            type: 'bigNumber',
+            sourceType: [{ source: 'api' }],
+            data: { value: 200 },
+          },
+        },
+      ],
+    };
+
+    const renderDetail = (card: DashboardCardProps, close: () => void) => {
+      return (
+        <div>
+          <span>Detail: {card.title}</span>
+          <button onClick={close}>Close</button>
+        </div>
+      );
+    };
+
+    test('should display detail for the externally controlled selectedCardKey', () => {
+      render(
+        <Dashboard
+          selectedTemplate={controlledTemplate}
+          templates={[controlledTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          selectedCardKey="card-1"
+        />
+      );
+
+      expect(screen.getByText('Detail: Card 1')).toBeInTheDocument();
+    });
+
+    test('should call onCardSelect when a card is clicked in controlled mode', () => {
+      const onCardSelect = jest.fn();
+
+      render(
+        <Dashboard
+          selectedTemplate={controlledTemplate}
+          templates={[controlledTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          selectedCardKey={null}
+          onCardSelect={onCardSelect}
+        />
+      );
+
+      const allButtons = screen.getAllByRole('button');
+      const card1Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 1');
+      });
+      expect(card1Button).toBeDefined();
+      fireEvent.click(card1Button!);
+
+      expect(onCardSelect).toHaveBeenCalledWith(
+        'card-1',
+        expect.objectContaining({ title: 'Card 1' })
+      );
+    });
+
+    test('should call onCardSelect with null when the same card is clicked again', () => {
+      const onCardSelect = jest.fn();
+
+      render(
+        <Dashboard
+          selectedTemplate={controlledTemplate}
+          templates={[controlledTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          selectedCardKey="card-1"
+          onCardSelect={onCardSelect}
+        />
+      );
+
+      const allButtons = screen.getAllByRole('button');
+      const card1Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 1');
+      });
+      expect(card1Button).toBeDefined();
+      fireEvent.click(card1Button!);
+
+      expect(onCardSelect).toHaveBeenCalledWith(null, null);
+    });
+  });
+
+  describe('detailSlotHeight', () => {
+    const slotTemplate: DashboardTemplate = {
+      id: 'slot-template',
+      name: 'Slot Template',
+      grid: [
+        {
+          i: 'card-1',
+          x: 0,
+          y: 0,
+          w: 4,
+          h: 2,
+          card: {
+            id: 'card-1',
+            title: 'Card 1',
+            numberType: 'number',
+            type: 'bigNumber',
+            sourceType: [{ source: 'api' }],
+            data: { value: 100 },
+          },
+        },
+      ],
+    };
+
+    const renderDetail = (card: DashboardCardProps, close: () => void) => {
+      return (
+        <div>
+          <span>Detail: {card.title}</span>
+          <button onClick={close}>Close</button>
+        </div>
+      );
+    };
+
+    test('should render detail slot with custom height when detailSlotHeight is provided', () => {
+      render(
+        <Dashboard
+          selectedTemplate={slotTemplate}
+          templates={[slotTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          detailSlotHeight={6}
+        />
+      );
+
+      const allButtons = screen.getAllByRole('button');
+      const card1Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 1');
+      });
+      expect(card1Button).toBeDefined();
+      fireEvent.click(card1Button!);
+
+      // Detail slot should still open regardless of height
+      expect(screen.getByText('Detail: Card 1')).toBeInTheDocument();
+    });
+  });
+
+  describe('detailMode multi', () => {
+    const multiTemplate: DashboardTemplate = {
+      id: 'multi-template',
+      name: 'Multi Template',
+      grid: [
+        {
+          i: 'card-1',
+          x: 0,
+          y: 0,
+          w: 4,
+          h: 2,
+          card: {
+            id: 'card-1',
+            title: 'Card 1',
+            numberType: 'number',
+            type: 'bigNumber',
+            sourceType: [{ source: 'api' }],
+            data: { value: 100 },
+          },
+        },
+        {
+          i: 'card-2',
+          x: 4,
+          y: 0,
+          w: 4,
+          h: 2,
+          card: {
+            id: 'card-2',
+            title: 'Card 2',
+            numberType: 'number',
+            type: 'bigNumber',
+            sourceType: [{ source: 'api' }],
+            data: { value: 200 },
+          },
+        },
+      ],
+    };
+
+    const renderDetail = (card: DashboardCardProps, close: () => void) => {
+      return (
+        <div>
+          <span>Detail: {card.title}</span>
+          <button onClick={close}>Close</button>
+        </div>
+      );
+    };
+
+    test('should allow two cards to be expanded simultaneously in multi mode', () => {
+      render(
+        <Dashboard
+          selectedTemplate={multiTemplate}
+          templates={[multiTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          detailMode="multi"
+        />
+      );
+
+      const allButtons = screen.getAllByRole('button');
+      const card1Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 1');
+      });
+      const card2Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 2');
+      });
+      expect(card1Button).toBeDefined();
+      expect(card2Button).toBeDefined();
+
+      fireEvent.click(card1Button!);
+      expect(screen.getByText('Detail: Card 1')).toBeInTheDocument();
+      expect(screen.queryByText('Detail: Card 2')).not.toBeInTheDocument();
+
+      fireEvent.click(card2Button!);
+      // Both should now be open
+      expect(screen.getByText('Detail: Card 1')).toBeInTheDocument();
+      expect(screen.getByText('Detail: Card 2')).toBeInTheDocument();
+    });
+
+    test('should close individual slots in multi mode when close is called', () => {
+      render(
+        <Dashboard
+          selectedTemplate={multiTemplate}
+          templates={[multiTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          detailMode="multi"
+        />
+      );
+
+      const allButtons = screen.getAllByRole('button');
+      const card1Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 1');
+      });
+      const card2Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 2');
+      });
+      expect(card1Button).toBeDefined();
+      expect(card2Button).toBeDefined();
+
+      fireEvent.click(card1Button!);
+      fireEvent.click(card2Button!);
+
+      expect(screen.getByText('Detail: Card 1')).toBeInTheDocument();
+      expect(screen.getByText('Detail: Card 2')).toBeInTheDocument();
+
+      // Close only Card 1
+      const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+      fireEvent.click(closeButtons[0]);
+
+      expect(screen.queryByText('Detail: Card 1')).not.toBeInTheDocument();
+      expect(screen.getByText('Detail: Card 2')).toBeInTheDocument();
+    });
+
+    test('should toggle a slot closed in multi mode when same card is clicked again', () => {
+      render(
+        <Dashboard
+          selectedTemplate={multiTemplate}
+          templates={[multiTemplate]}
+          filters={[]}
+          loading={false}
+          renderCardDetail={renderDetail}
+          detailMode="multi"
+        />
+      );
+
+      const allButtons = screen.getAllByRole('button');
+      const card1Button = allButtons.find((b) => {
+        return b.textContent?.includes('Card 1');
+      });
+      expect(card1Button).toBeDefined();
+
+      fireEvent.click(card1Button!);
+      expect(screen.getByText('Detail: Card 1')).toBeInTheDocument();
+
+      // Second click on same card should close it
+      fireEvent.click(card1Button!);
+      expect(screen.queryByText('Detail: Card 1')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Extends `@ttoss/react-dashboard` with three new non-breaking props on `Dashboard`. All are optional with defaults that preserve existing behavior — no breaking changes.

- **`selectedCardKey` + `onCardSelect`** — controlled/uncontrolled selection. Pass `selectedCardKey` to pre-open a card or sync selection from outside; omit for the existing uncontrolled behavior. `onCardSelect(key, card)` fires on every change in both modes.
- **`detailSlotHeight`** — configurable detail slot height in grid rows (default: `12` = 384px at `rowHeight=32`). Replaces the hardcoded `SLOT_H = 12`.
- **`detailMode="multi"`** — allows multiple cards to be expanded simultaneously. Each clicked card gets its own independent slot. Default `"single"` preserves existing toggle behavior.

## Changed files

| File | What changed |
|---|---|
| `packages/react-dashboard/src/DashboardGrid.tsx` | New `detailSlotHeight`, `detailMode` props; `selectedCardKey` widened to `string \| string[] \| null`; slot keyed as `__detail_slot__:<index>` for multi; `buildSlotLayout` takes `slotH` + `slotIndex`; `useCardClickHandler` refactored to options object (fixes max-params lint) |
| `packages/react-dashboard/src/Dashboard.tsx` | Promotes `selectedCardKey` to controlled/uncontrolled prop; adds `onCardSelect`, `detailSlotHeight`, `detailMode` |
| `tests/unit/tests/DashboardGrid.test.tsx` | Tests for controlled selection, `detailSlotHeight`, and `detailMode="multi"` |
| `docs/storybook/stories/react-dashboard/Dashboard.stories.tsx` | `WithControlledSelection` and `WithMultipleSlots` stories |

## How to test

### 1 — Existing behavior unchanged
All existing tests pass with no changes — the new props are fully optional.

### 2 — Storybook visual check
```bash
pnpm storybook
```
Open **React Dashboard → Dashboard** and check:
- **WithCardDetail** — must still work as before (single-slot toggle)
- **WithControlledSelection** — buttons above the grid pre-open the matching slot; clicking a card fires `onCardSelect`
- **WithMultipleSlots** — click multiple cards to expand them simultaneously; each has its own Close button

### 3 — `detailSlotHeight`
Pass `detailSlotHeight={6}` — slot uses 6 grid rows (192px) instead of default 12.

### 4 — `onCardSelect` in uncontrolled mode
Attach `onCardSelect` without `selectedCardKey` — callback fires on each click.

### 5 — Controlled mode stays in sync
Pass `selectedCardKey="card-1"` without updating it in `onCardSelect` — clicking other cards does not move the selection (external value wins).

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)