### PR TITLE
Complete Theme Lab and session layer (F1/F2 features)

### DIFF
--- a/docs/fsl-studio/PRD.md
+++ b/docs/fsl-studio/PRD.md
@@ -639,6 +639,62 @@ themeId)` emits element-scoped selectors (`[data-tt-theme]` /
   tsdown's formatjs plugin fails under 22 (babel ESM linking) — builds here used a standalone
   Node 24, CI is unaffected.
 
+**Pre-Phase-3 completion (2026-07-18):** everything F1/F2 deferred by earlier
+phases now ships; Phases 0–2 are complete against their Definitions of Done.
+
+- **Flat override model supersedes Phase-1 `ColorOverrides`.** The diff is now
+  a flat `path → value` map covering any core leaf and semantic remaps
+  (`semantic.radii.control` → `{core.radii.none}`), unflattened into
+  `createTheme` for preview and export. Diff-as-source-of-truth is unchanged.
+- **F2.1/F2.2 navigator:** semantic layer first, grouped by family, colors
+  sub-grouped by ux context; leaves render only while a disclosure is open.
+  Core sits one level down; its **colors disclosure is default-open** — the
+  brand scale is the SC-1 wow surface and must stay reachable at a glance.
+- **Ref validation is resolution-based, not console-based.** `toFlatTokens`
+  leaves unresolved refs as `{path}` in the output; any surviving brace
+  expression marks a broken token. Same mechanical check as `validateRefs`,
+  but readable as data (browser-safe, no console capture), which resolves the
+  AD-5 production-gating question for good. Ambient surfacing: row badges +
+  peripheral header counter; the one sanctioned escalation is the
+  ConfirmationDialog on export with broken refs (F2 AC).
+- **F2.4 presets:** the style-reference docs (minimalism, neobrutalism,
+  glass, 90s) are still stubs, so the presets are deliberately conservative —
+  a WCAG-checked brand scale plus the style's clearest token-layer signature
+  (radii/elevation/border), each with a `ThemeBrief`. Export codegen inlines
+  an authored preset's overrides under the user diff (diff wins) so the
+  snippet runs anywhere; `bruttal` still exports as `extends: bruttal`.
+- **F2.6 dark contrast** ships: dark tokens = base ⊕ alternate semantic
+  remaps, same projection the CSS emits; both mode lists always render since
+  every preset carries an alternate (asserted in tests).
+- **F1.2/F1.3 session:** `SessionSnapshot` (lens, altitude, theme diff +
+  origins, component selection) → lz-string URL hash; opening a link forks
+  under a new draft id; foreign payloads sanitize field-by-field.
+  `applyToStudio` is deliberately **not** serialized — a shared link must not
+  re-skin the receiver's editor chrome. Drafts autosave debounced (250 ms) to
+  localStorage, last-write-wins documented in-app, write failures swallowed.
+- **Home (§6.2)** is the boot target without a hash: three task cards +
+  the drafts shelf. The studio brand button returns home and clears the hash.
+- **F1.4 altitudes:** `component` (lens subject), `page` (selected or first
+  example page), `grid` (all example pages — the semantic-drift view), owned
+  by the session and persistent across lens switches.
+- **F1.5 ⌘K palette:** commands derive from the same sources as the
+  navigators (lenses, altitudes, presets, catalog, pages, apply-toggle,
+  home) — no second registry to drift. Combobox + listbox +
+  `aria-activedescendant`. `prefers-reduced-motion` covered for the chrome
+  (fsl-theme CSS already carries token-level reduced-motion).
+- **Toast example page** unblocked by the queue API (`createToastQueue` +
+  `ToastRegion`): one queue per page instance so each stage pane keeps its
+  own stack. TextField's preview now also shows the `isInvalid` runtime
+  state (F3.2), snippet unchanged.
+- **Axe CI gate** (F1 AC): home, both lenses, and the open palette. Two rules
+  excluded with cause: `color-contrast` (jsdom paints nothing; contrast is
+  checked as data by the Theme Lab) and `aria-allowed-attr` — **upstream
+  finding (report, don't fix here — §2):** React Aria's Meter renders the
+  standard fallback `role="meter progressbar"`, which axe misreads as
+  disallowing `aria-value*`.
+- Suite: 187 tests, 100% coverage on every dimension; `tsc --noEmit` + Vite
+  build green (Node 24 toolchain — see the Phase-0 container note).
+
 ## 15. References
 
 - Problem/strategy: `packages/fsl-ui/INTERNAL/` (PURPOSE, STRATEGIC_EVAL, BENCHMARK_EVAL,

--- a/docs/fsl-studio/package.json
+++ b/docs/fsl-studio/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ttoss/fsl-theme": "workspace:^",
     "@ttoss/fsl-ui": "workspace:^",
+    "lz-string": "^1.5.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
   },
@@ -29,11 +30,13 @@
     "@testing-library/user-event": "^14.6.1",
     "@ttoss/config": "workspace:^",
     "@ttoss/test-utils": "workspace:^",
+    "@types/jest-axe": "^3.5.9",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react-swc": "^4.3.1",
     "jest": "^30.4.2",
+    "jest-axe": "^10.0.0",
     "typescript": "~6.0.3",
     "vite": "^8.0.16"
   }

--- a/docs/fsl-studio/src/App.tsx
+++ b/docs/fsl-studio/src/App.tsx
@@ -2,7 +2,17 @@ import { getThemeStylesContent } from '@ttoss/fsl-theme/css';
 import { ThemeProvider } from '@ttoss/fsl-theme/react';
 import * as React from 'react';
 
+import { ComponentStoreProvider } from './studio/components/componentStore';
+import { Home } from './studio/Home';
+import { deleteDraft, loadDraft, newDraftId } from './studio/session/drafts';
+import {
+  bootFromHash,
+  type SessionBoot,
+  SessionProvider,
+} from './studio/session/sessionStore';
+import { SessionSync } from './studio/session/SessionSync';
 import { StudioShell } from './studio/StudioShell';
+import { presetBundle } from './studio/theme/presets';
 import { ThemeStoreProvider, useThemeStore } from './studio/theme/themeStore';
 
 /**
@@ -35,13 +45,101 @@ const ChromeThemedShell = () => {
 };
 
 /**
- * FSL Studio root. The theme store sits above the chrome so the chrome can
- * read whether to apply the edited theme to itself.
+ * One studio session: the domain stores seeded from the boot snapshot (URL
+ * fork or draft), the session layer above them, and the URL/draft sync.
+ * Keyed by draft id at the call site, so opening another draft remounts
+ * with fresh state.
  */
-export const App = () => {
+const StudioSession = ({
+  boot,
+  onGoHome,
+}: {
+  boot: SessionBoot;
+  onGoHome: () => void;
+}) => {
   return (
-    <ThemeStoreProvider>
-      <ChromeThemedShell />
+    <ThemeStoreProvider initial={boot.snapshot?.theme}>
+      <ComponentStoreProvider initial={boot.snapshot?.component}>
+        <SessionProvider
+          draftId={boot.draftId}
+          initialLens={boot.lens}
+          initialAltitude={boot.snapshot?.altitude}
+          onGoHome={onGoHome}
+        >
+          <SessionSync />
+          <ChromeThemedShell />
+        </SessionProvider>
+      </ComponentStoreProvider>
     </ThemeStoreProvider>
   );
+};
+
+/** The home screen wears the base theme (it has no session of its own). */
+const homeCss = getThemeStylesContent(presetBundle('base'));
+
+/**
+ * FSL Studio root (PRD §6.2, AD-10). Boot resolves from the URL hash: a
+ * valid `#s=` payload opens the studio as a fork of that state; otherwise
+ * the task-first home. Home actions start a fresh session on the chosen
+ * lens or continue an autosaved draft.
+ */
+export const App = () => {
+  const [boot, setBoot] = React.useState<SessionBoot>(() => {
+    return bootFromHash(window.location.hash);
+  });
+
+  const goHome = React.useCallback(() => {
+    window.history.replaceState(
+      null,
+      '',
+      window.location.pathname + window.location.search
+    );
+    setBoot({
+      screen: 'home',
+      snapshot: null,
+      lens: 'theme',
+      draftId: newDraftId(),
+    });
+  }, []);
+
+  if (boot.screen === 'home') {
+    return (
+      <ThemeProvider defaultMode="system">
+        <style>{homeCss}</style>
+        <Home
+          onStartTask={(lens) => {
+            setBoot({
+              screen: 'studio',
+              snapshot: null,
+              lens,
+              draftId: newDraftId(),
+            });
+          }}
+          onOpenDraft={(id) => {
+            const snapshot = loadDraft(id);
+            if (snapshot) {
+              setBoot({
+                screen: 'studio',
+                snapshot,
+                lens: snapshot.lens,
+                draftId: id,
+              });
+            }
+          }}
+          onDeleteDraft={(id) => {
+            deleteDraft(id);
+            // Re-boot home so the drafts list re-reads storage.
+            setBoot({
+              screen: 'home',
+              snapshot: null,
+              lens: 'theme',
+              draftId: newDraftId(),
+            });
+          }}
+        />
+      </ThemeProvider>
+    );
+  }
+
+  return <StudioSession key={boot.draftId} boot={boot} onGoHome={goHome} />;
 };

--- a/docs/fsl-studio/src/studio.css
+++ b/docs/fsl-studio/src/studio.css
@@ -538,3 +538,58 @@ body {
   gap: var(--tt-spacing-4, 1rem);
   margin-block-end: var(--tt-spacing-4, 1rem);
 }
+
+/* -- Token tree (semantic + core navigator, PRD F2.1/F2.2) --------------- */
+
+.token-row {
+  display: grid;
+  grid-template-columns: minmax(6rem, 1fr) minmax(0, 1.4fr) auto auto;
+  align-items: center;
+  gap: var(--tt-spacing-2, 0.5rem);
+  padding-block: 0.1rem;
+}
+
+.token-row-label {
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+  color: var(--tt-colors-informational-muted-text-default);
+}
+
+.token-row-input {
+  font: inherit;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  min-inline-size: 0;
+  padding-block: var(--tt-spacing-1, 0.25rem);
+  padding-inline: var(--tt-spacing-2, 0.5rem);
+  border: 1px solid var(--tt-colors-input-primary-border-default, #ccc);
+  border-radius: var(--tt-radii-control, 0.25rem);
+  background: var(--tt-colors-input-primary-background-default, transparent);
+  color: inherit;
+}
+
+.token-row-input[aria-invalid='true'] {
+  border-color: var(--tt-colors-input-negative-border-default, #b91c1c);
+}
+
+.token-broken-badge {
+  font-size: 0.75rem;
+  color: var(--tt-colors-feedback-negative-text-default, #b91c1c);
+}
+
+/* -- Peripheral ref-error counter (PRD §6.4-P2) --------------------------- */
+
+.studio-ref-errors {
+  font-size: 0.8125rem;
+  color: var(--tt-colors-feedback-negative-text-default, #b91c1c);
+  margin-inline-start: var(--tt-spacing-3, 0.75rem);
+}
+
+.theme-contrast-mode {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-block: var(--tt-spacing-2, 0.5rem) var(--tt-spacing-1, 0.25rem);
+  color: var(--tt-colors-informational-muted-text-default);
+}

--- a/docs/fsl-studio/src/studio.css
+++ b/docs/fsl-studio/src/studio.css
@@ -593,3 +593,246 @@ body {
   margin-block: var(--tt-spacing-2, 0.5rem) var(--tt-spacing-1, 0.25rem);
   color: var(--tt-colors-informational-muted-text-default);
 }
+
+/* -- Task-first home (PRD §6.2) ------------------------------------------- */
+
+.home {
+  min-block-size: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--tt-spacing-6, 1.5rem);
+  padding: var(--tt-spacing-8, 2rem);
+  background: var(--tt-colors-informational-primary-background-default, #fff);
+  color: var(--tt-colors-informational-primary-text-default, #111);
+}
+
+.home-brand {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.home-question {
+  font-size: 1.125rem;
+  margin: 0;
+  color: var(--tt-colors-informational-muted-text-default);
+}
+
+.home-tasks {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: var(--tt-spacing-4, 1rem);
+  inline-size: min(56rem, 100%);
+}
+
+.home-task {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tt-spacing-2, 0.5rem);
+  text-align: start;
+  padding: var(--tt-spacing-5, 1.25rem);
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  background: var(--tt-colors-informational-primary-background-default, #fff);
+  border: 1px solid var(--tt-colors-informational-primary-border-default, #ddd);
+  border-radius: var(--tt-radii-surface, 0.5rem);
+}
+
+.home-task:hover {
+  border-color: var(--tt-colors-action-accent-background-default, #0469e3);
+}
+
+.home-task-title {
+  font-weight: 600;
+}
+
+.home-task-description {
+  font-size: 0.875rem;
+  color: var(--tt-colors-informational-muted-text-default);
+}
+
+.home-drafts {
+  inline-size: min(56rem, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--tt-spacing-2, 0.5rem);
+}
+
+.home-drafts-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+  color: var(--tt-colors-informational-muted-text-default);
+}
+
+.home-drafts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--tt-spacing-1, 0.25rem);
+}
+
+.home-draft-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tt-spacing-2, 0.5rem);
+}
+
+.home-draft-open,
+.home-draft-delete {
+  font: inherit;
+  font-size: 0.875rem;
+  color: inherit;
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--tt-colors-informational-primary-border-default, #ddd);
+  border-radius: var(--tt-radii-control, 0.25rem);
+  padding-block: var(--tt-spacing-1, 0.25rem);
+  padding-inline: var(--tt-spacing-3, 0.75rem);
+}
+
+.home-draft-open {
+  flex: 1;
+  text-align: start;
+}
+
+/* -- Stage toolbar + grid altitude (PRD F1.4) ------------------------------ */
+
+.stage-toolbar {
+  display: flex;
+  justify-content: center;
+  padding-block-end: var(--tt-spacing-3, 0.75rem);
+}
+
+.stage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: var(--tt-spacing-4, 1rem);
+}
+
+.stage-grid-cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tt-spacing-3, 0.75rem);
+  padding: var(--tt-spacing-4, 1rem);
+  border: 1px solid var(--tt-colors-informational-muted-border-default, #e5e5e5);
+  border-radius: var(--tt-radii-surface, 0.5rem);
+  min-inline-size: 0;
+}
+
+.stage-grid-title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--tt-colors-informational-muted-text-default);
+}
+
+/* -- Command palette (PRD F1.5) -------------------------------------------- */
+
+.palette-open {
+  font: inherit;
+  font-size: 0.8125rem;
+  color: inherit;
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--tt-colors-informational-primary-border-default, #ddd);
+  border-radius: var(--tt-radii-control, 0.25rem);
+  padding-block: var(--tt-spacing-1, 0.25rem);
+  padding-inline: var(--tt-spacing-2, 0.5rem);
+  margin-inline-start: var(--tt-spacing-3, 0.75rem);
+}
+
+.palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--tt-zindex-overlay, 1000);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-block-start: 15vh;
+  background: var(--tt-colors-overlay-scrim, rgba(0, 0, 0, 0.4));
+}
+
+.palette {
+  inline-size: min(36rem, 92vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--tt-colors-informational-primary-background-default, #fff);
+  color: var(--tt-colors-informational-primary-text-default, #111);
+  border: 1px solid var(--tt-colors-informational-primary-border-default, #ddd);
+  border-radius: var(--tt-radii-surface, 0.5rem);
+  box-shadow: var(--tt-elevation-surface-overlay, 0 8px 16px rgba(0, 0, 0, 0.1));
+}
+
+.palette-input {
+  font: inherit;
+  padding: var(--tt-spacing-3, 0.75rem);
+  border: none;
+  border-block-end: 1px solid
+    var(--tt-colors-informational-muted-border-default, #e5e5e5);
+  border-start-start-radius: inherit;
+  border-start-end-radius: inherit;
+  background: transparent;
+  color: inherit;
+  outline: none;
+}
+
+.palette-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--tt-spacing-1, 0.25rem);
+  max-block-size: 40vh;
+  overflow-y: auto;
+}
+
+.palette-option {
+  padding-block: var(--tt-spacing-2, 0.5rem);
+  padding-inline: var(--tt-spacing-3, 0.75rem);
+  border-radius: var(--tt-radii-control, 0.25rem);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.palette-option[aria-selected='true'] {
+  background: var(--tt-colors-action-muted-background-hover, #f1f5f9);
+}
+
+.palette-empty {
+  padding: var(--tt-spacing-3, 0.75rem);
+  font-size: 0.875rem;
+  color: var(--tt-colors-informational-muted-text-default);
+}
+
+/* -- Reduced motion (PRD F1.5) ---------------------------------------------
+   fsl-theme's own CSS already carries reduced-motion token overrides; this
+   covers the Studio chrome's transitions. */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.studio-brand {
+  font: inherit;
+  font-weight: 700;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}

--- a/docs/fsl-studio/src/studio/Home.tsx
+++ b/docs/fsl-studio/src/studio/Home.tsx
@@ -1,0 +1,107 @@
+import { type Lens } from './lenses';
+import { listDrafts } from './session/drafts';
+
+/**
+ * Task-first home (PRD §6.2): a question, not a dashboard. Each task opens
+ * the studio with the right lens pre-loaded, never an empty screen. Drafts
+ * autosaved from previous sessions continue from here (PRD F1.3) — with the
+ * last-write-wins limitation stated in place, not in a modal.
+ */
+const TASKS: { lens: Lens; title: string; description: string }[] = [
+  {
+    lens: 'theme',
+    title: 'Create a theme',
+    description:
+      'Edit tokens, watch a page re-theme in light and dark, export DTCG, CSS, or code.',
+  },
+  {
+    lens: 'components',
+    title: 'Explore components',
+    description:
+      'The full catalog with only the prop combinations the FSL grammar allows.',
+  },
+  {
+    lens: 'generate',
+    title: 'Generate a composite',
+    description:
+      'AI-assisted composition with verified proposals — the lens ships in a later phase.',
+  },
+];
+
+export const Home = ({
+  onStartTask,
+  onOpenDraft,
+  onDeleteDraft,
+}: {
+  /** Open the studio on a lens with fresh defaults. */
+  onStartTask: (lens: Lens) => void;
+  /** Continue an autosaved draft (same draft id). */
+  onOpenDraft: (id: string) => void;
+  onDeleteDraft: (id: string) => void;
+}) => {
+  const drafts = listDrafts();
+
+  return (
+    <main className="home">
+      <h1 className="home-brand">FSL Studio</h1>
+      <p className="home-question">What do you want to do?</p>
+      <div className="home-tasks">
+        {TASKS.map((task) => {
+          return (
+            <button
+              key={task.lens}
+              type="button"
+              className="home-task"
+              onClick={() => {
+                return onStartTask(task.lens);
+              }}
+            >
+              <span className="home-task-title">{task.title}</span>
+              <span className="home-task-description">{task.description}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {drafts.length > 0 ? (
+        <section className="home-drafts" aria-label="Drafts">
+          <h2 className="home-drafts-title">Continue</h2>
+          <ul className="home-drafts-list">
+            {drafts.map((draft) => {
+              const edits = Object.keys(draft.snapshot.theme.overrides).length;
+              return (
+                <li key={draft.id} className="home-draft-row">
+                  <button
+                    type="button"
+                    className="home-draft-open"
+                    onClick={() => {
+                      return onOpenDraft(draft.id);
+                    }}
+                  >
+                    {draft.snapshot.theme.preset} · {edits} edit
+                    {edits === 1 ? '' : 's'} ·{' '}
+                    {new Date(draft.updatedAt).toLocaleString()}
+                  </button>
+                  <button
+                    type="button"
+                    className="home-draft-delete"
+                    aria-label={`Delete draft ${draft.id}`}
+                    onClick={() => {
+                      return onDeleteDraft(draft.id);
+                    }}
+                  >
+                    Delete
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          <p className="theme-hint">
+            Drafts autosave locally in this browser. The same draft open in two
+            tabs saves last-write-wins.
+          </p>
+        </section>
+      ) : null}
+    </main>
+  );
+};

--- a/docs/fsl-studio/src/studio/PageGrid.tsx
+++ b/docs/fsl-studio/src/studio/PageGrid.tsx
@@ -1,0 +1,25 @@
+import { EXAMPLE_PAGES } from './components/examplePages';
+
+/**
+ * The grid altitude (PRD F1.4): every example page rendered compact,
+ * side by side — the semantic-drift view. One theme edit re-themes all of
+ * them at once, which is exactly where drift becomes visible.
+ */
+export const PageGrid = () => {
+  return (
+    <div className="stage-grid">
+      {EXAMPLE_PAGES.map((page) => {
+        return (
+          <section
+            key={page.id}
+            className="stage-grid-cell"
+            aria-label={page.label}
+          >
+            <h3 className="stage-grid-title">{page.label}</h3>
+            {page.render()}
+          </section>
+        );
+      })}
+    </div>
+  );
+};

--- a/docs/fsl-studio/src/studio/Stage.tsx
+++ b/docs/fsl-studio/src/studio/Stage.tsx
@@ -17,8 +17,11 @@ import { useThemeStore } from './theme/themeStore';
  */
 export const Stage = ({
   renderSubject,
+  toolbar,
 }: {
   renderSubject: () => React.ReactNode;
+  /** Stage-level controls (the altitude switcher, PRD F1.4). */
+  toolbar?: React.ReactNode;
 }) => {
   const { liveBundle } = useThemeStore();
 
@@ -31,6 +34,7 @@ export const Stage = ({
   return (
     <section className="stage" aria-label="Stage">
       <style>{stageCss}</style>
+      {toolbar ? <div className="stage-toolbar">{toolbar}</div> : null}
       <div className="stage-panes">
         <div
           className="stage-pane"

--- a/docs/fsl-studio/src/studio/StudioShell.tsx
+++ b/docs/fsl-studio/src/studio/StudioShell.tsx
@@ -4,8 +4,13 @@ import * as React from 'react';
 import { ComponentInspector } from './components/ComponentInspector';
 import { ComponentNavigator } from './components/ComponentNavigator';
 import { ComponentStageContent } from './components/ComponentStageContent';
-import { ComponentStoreProvider } from './components/componentStore';
+import { useComponentStore } from './components/componentStore';
+import { EXAMPLE_PAGES, findPage } from './components/examplePages';
 import { type Lens, LENS_EMPTY_STATE, LENS_LABELS, LENSES } from './lenses';
+import { PageGrid } from './PageGrid';
+import { CommandPalette } from './session/CommandPalette';
+import { type Altitude, ALTITUDES } from './session/sessionState';
+import { useSession } from './session/sessionStore';
 import { Stage } from './Stage';
 import { StageSample } from './StageSample';
 import { ThemeInspector } from './theme/ThemeInspector';
@@ -29,69 +34,111 @@ const RefErrorsCounter = () => {
   );
 };
 
+const ALTITUDE_LABELS: Record<Altitude, string> = {
+  component: 'Component',
+  page: 'Page',
+  grid: 'Grid',
+};
+
 /**
- * The Studio shell: navigator / stage / inspector, with the lens switcher in
- * the header. Lenses swap the side panels and the stage subject; the stage
- * frame (the light/dark panes) never resets (PRD §6.2).
+ * The Studio shell: navigator / stage / inspector, with the lens switcher
+ * and command palette in the header and the altitude switcher on the stage.
+ * Lenses swap the side panels and the stage subject; the stage frame (the
+ * light/dark panes) and the altitude never reset on a lens switch
+ * (PRD §6.2, F1.4).
  */
 export const StudioShell = () => {
-  const [lens, setLens] = React.useState<Lens>('theme');
+  const { lens, altitude, setLens, setAltitude, goHome } = useSession();
+  const componentStore = useComponentStore();
+  const { selection } = componentStore;
 
   const renderSubject = React.useCallback(() => {
+    if (altitude === 'grid') {
+      return <PageGrid />;
+    }
+    if (altitude === 'page') {
+      // The selected example page, or the first one as the useful default —
+      // never an empty stage (PRD §6.2).
+      const pageId =
+        selection.kind === 'page' ? selection.id : EXAMPLE_PAGES[0].id;
+      return <>{findPage(pageId)?.render()}</>;
+    }
     if (lens === 'components') {
       return <ComponentStageContent />;
     }
     return <StageSample />;
-  }, [lens]);
+  }, [lens, altitude, selection]);
 
   return (
-    <ComponentStoreProvider>
-      <div className="studio">
-        <header className="studio-header">
-          <span className="studio-brand">FSL Studio</span>
-          <RefErrorsCounter />
-          <ToggleButtonGroup
-            aria-label="Lens"
-            selectionMode="single"
-            disallowEmptySelection
-            selectedKeys={[lens]}
-            onSelectionChange={(keys) => {
-              // Single selection + disallowEmptySelection: RAC guarantees
-              // exactly one key, and the only ids in the group are lenses.
-              setLens([...keys][0] as Lens);
-            }}
-          >
-            {LENSES.map((id) => {
-              return (
-                <ToggleButton key={id} id={id}>
-                  {LENS_LABELS[id]}
-                </ToggleButton>
-              );
-            })}
-          </ToggleButtonGroup>
-        </header>
-        <div className="studio-body">
-          <aside className="studio-navigator" aria-label="Navigator">
-            {lens === 'theme' ? <ThemeNavigator /> : null}
-            {lens === 'components' ? <ComponentNavigator /> : null}
-            {lens === 'generate' ? (
-              <p className="studio-empty-state">
-                {LENS_EMPTY_STATE.generate.navigator}
-              </p>
-            ) : null}
-          </aside>
-          <Stage renderSubject={renderSubject} />
-          <aside className="studio-inspector" aria-label="Inspector">
-            {lens === 'theme' ? <ThemeInspector /> : null}
-            {lens === 'components' ? <ComponentInspector /> : null}
-            {lens === 'generate' ? (
-              <p className="studio-empty-state">
-                {LENS_EMPTY_STATE.generate.inspector}
-              </p>
-            ) : null}
-          </aside>
-        </div>
+    <div className="studio">
+      <header className="studio-header">
+        <button type="button" className="studio-brand" onClick={goHome}>
+          FSL Studio
+        </button>
+        <RefErrorsCounter />
+        <ToggleButtonGroup
+          aria-label="Lens"
+          selectionMode="single"
+          disallowEmptySelection
+          selectedKeys={[lens]}
+          onSelectionChange={(keys) => {
+            // Single selection + disallowEmptySelection: RAC guarantees
+            // exactly one key, and the only ids in the group are lenses.
+            setLens([...keys][0] as Lens);
+          }}
+        >
+          {LENSES.map((id) => {
+            return (
+              <ToggleButton key={id} id={id}>
+                {LENS_LABELS[id]}
+              </ToggleButton>
+            );
+          })}
+        </ToggleButtonGroup>
+        <CommandPalette />
+      </header>
+      <div className="studio-body">
+        <aside className="studio-navigator" aria-label="Navigator">
+          {lens === 'theme' ? <ThemeNavigator /> : null}
+          {lens === 'components' ? <ComponentNavigator /> : null}
+          {lens === 'generate' ? (
+            <p className="studio-empty-state">
+              {LENS_EMPTY_STATE.generate.navigator}
+            </p>
+          ) : null}
+        </aside>
+        <Stage
+          renderSubject={renderSubject}
+          toolbar={
+            <ToggleButtonGroup
+              aria-label="Stage altitude"
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={[altitude]}
+              onSelectionChange={(keys) => {
+                setAltitude([...keys][0] as Altitude);
+              }}
+            >
+              {ALTITUDES.map((id) => {
+                return (
+                  <ToggleButton key={id} id={id}>
+                    {ALTITUDE_LABELS[id]}
+                  </ToggleButton>
+                );
+              })}
+            </ToggleButtonGroup>
+          }
+        />
+        <aside className="studio-inspector" aria-label="Inspector">
+          {lens === 'theme' ? <ThemeInspector /> : null}
+          {lens === 'components' ? <ComponentInspector /> : null}
+          {lens === 'generate' ? (
+            <p className="studio-empty-state">
+              {LENS_EMPTY_STATE.generate.inspector}
+            </p>
+          ) : null}
+        </aside>
       </div>
-    </ComponentStoreProvider>
+    </div>
   );
 };

--- a/docs/fsl-studio/src/studio/StudioShell.tsx
+++ b/docs/fsl-studio/src/studio/StudioShell.tsx
@@ -10,6 +10,24 @@ import { Stage } from './Stage';
 import { StageSample } from './StageSample';
 import { ThemeInspector } from './theme/ThemeInspector';
 import { ThemeNavigator } from './theme/ThemeNavigator';
+import { useThemeStore } from './theme/themeStore';
+
+/**
+ * Peripheral broken-ref counter (PRD §6.4-P2): validation is ambient — a
+ * discreet header signal, never a modal or toast. The per-token badges live
+ * on the offending rows in the navigator and the diff.
+ */
+const RefErrorsCounter = () => {
+  const { brokenRefs } = useThemeStore();
+  if (brokenRefs.length === 0) {
+    return null;
+  }
+  return (
+    <span className="studio-ref-errors">
+      ⚠ {brokenRefs.length} ref error{brokenRefs.length === 1 ? '' : 's'}
+    </span>
+  );
+};
 
 /**
  * The Studio shell: navigator / stage / inspector, with the lens switcher in
@@ -31,6 +49,7 @@ export const StudioShell = () => {
       <div className="studio">
         <header className="studio-header">
           <span className="studio-brand">FSL Studio</span>
+          <RefErrorsCounter />
           <ToggleButtonGroup
             aria-label="Lens"
             selectionMode="single"

--- a/docs/fsl-studio/src/studio/components/componentStore.tsx
+++ b/docs/fsl-studio/src/studio/components/componentStore.tsx
@@ -67,13 +67,16 @@ const ComponentStoreCtx = React.createContext<ComponentStore | null>(null);
 
 export const ComponentStoreProvider = ({
   children,
+  initial,
 }: {
   children: React.ReactNode;
+  /** Boot-time state (URL fork / draft restore, PRD F1.2/F1.3). */
+  initial?: Partial<ComponentReducerState>;
 }) => {
-  const [state, dispatch] = React.useReducer(
-    componentReducer,
-    initialComponentState
-  );
+  const [state, dispatch] = React.useReducer(componentReducer, {
+    ...initialComponentState,
+    ...initial,
+  });
 
   const value = React.useMemo<ComponentStore>(() => {
     return {

--- a/docs/fsl-studio/src/studio/components/examplePages.tsx
+++ b/docs/fsl-studio/src/studio/components/examplePages.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Checkbox,
   ConfirmationDialog,
+  createToastQueue,
   Meter,
   ProgressBar,
   Select,
@@ -16,6 +17,7 @@ import {
   TextFieldDescription,
   TextFieldError,
   TextFieldLabel,
+  ToastRegion,
   Wizard,
   WizardNavigation,
   WizardStep,
@@ -148,6 +150,51 @@ const DashboardPage = () => {
   );
 };
 
+const TOAST_EVALUATIONS = [
+  'primary',
+  'positive',
+  'caution',
+  'negative',
+] as const;
+
+const ToastsPage = () => {
+  // One queue per page instance: each stage pane keeps its own toasts, so
+  // the two color modes never share a notification stack. The region is
+  // viewport-fixed by design but inherits the pane's theme vars through the
+  // DOM, so its surfaces still follow the pane's mode.
+  const [queue] = React.useState(() => {
+    return createToastQueue();
+  });
+
+  return (
+    <div className="preview-col">
+      <div className="preview-row">
+        {TOAST_EVALUATIONS.map((evaluation) => {
+          return (
+            <Button
+              key={evaluation}
+              evaluation="muted"
+              onPress={() => {
+                queue.add(
+                  {
+                    title: `A ${evaluation} toast`,
+                    description: 'Queued from the example page.',
+                    evaluation,
+                  },
+                  { timeout: 5000 }
+                );
+              }}
+            >
+              Toast: {evaluation}
+            </Button>
+          );
+        })}
+      </div>
+      <ToastRegion queue={queue} />
+    </div>
+  );
+};
+
 export interface ExamplePage {
   id: string;
   label: string;
@@ -187,6 +234,15 @@ export const EXAMPLE_PAGES: readonly ExamplePage[] = [
     description: 'Feedback surfaces: meters, a progress bar, and tabs.',
     render: () => {
       return <DashboardPage />;
+    },
+  },
+  {
+    id: 'toasts',
+    label: 'Toasts',
+    description:
+      'Queued Feedback toasts across every legal evaluation — primary, positive, caution, negative.',
+    render: () => {
+      return <ToastsPage />;
     },
   },
 ];

--- a/docs/fsl-studio/src/studio/components/previews.tsx
+++ b/docs/fsl-studio/src/studio/components/previews.tsx
@@ -22,6 +22,7 @@ import {
   TagGroup,
   TextField,
   TextFieldControl,
+  TextFieldError,
   TextFieldLabel,
   ToggleButton,
   Toolbar,
@@ -225,12 +226,22 @@ export const PREVIEWS: Record<string, PreviewDef> = {
   },
 
   TextField: {
+    // The preview also shows the invalid runtime state (F3.2): validation is
+    // `isInvalid`, never a color prop — seeing it beside the default makes
+    // that contract visible. The copied snippet stays the minimal, valid one.
     render: () => {
       return (
-        <TextField>
-          <TextFieldLabel>Email</TextFieldLabel>
-          <TextFieldControl type="email" />
-        </TextField>
+        <div className="preview-col">
+          <TextField>
+            <TextFieldLabel>Email</TextFieldLabel>
+            <TextFieldControl type="email" />
+          </TextField>
+          <TextField isInvalid>
+            <TextFieldLabel>Email (invalid state)</TextFieldLabel>
+            <TextFieldControl type="email" />
+            <TextFieldError>Email is required.</TextFieldError>
+          </TextField>
+        </div>
       );
     },
     code: () => {

--- a/docs/fsl-studio/src/studio/session/CommandPalette.tsx
+++ b/docs/fsl-studio/src/studio/session/CommandPalette.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+
+import { useComponentStore } from '../components/componentStore';
+import { useThemeStore } from '../theme/themeStore';
+import { buildCommands, filterCommands } from './commands';
+import { useSession } from './sessionStore';
+
+/**
+ * ⌘K command palette (PRD F1.5, §6.5): tokens of work — lenses, altitudes,
+ * presets, components, pages — reachable from the keyboard. Opens on
+ * Cmd/Ctrl+K (or the header button), filters as you type, arrow keys +
+ * Enter execute, Escape closes. Combobox/listbox semantics with
+ * `aria-activedescendant` keep it screen-reader honest.
+ */
+export const CommandPalette = () => {
+  const session = useSession();
+  const theme = useThemeStore();
+  const component = useComponentStore();
+
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const [active, setActive] = React.useState(0);
+
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        setOpen((prev) => {
+          return !prev;
+        });
+        setQuery('');
+        setActive(0);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      return window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  const commands = React.useMemo(() => {
+    return buildCommands({ session, theme, component });
+  }, [session, theme, component]);
+
+  const results = React.useMemo(() => {
+    return filterCommands(commands, query);
+  }, [commands, query]);
+
+  const clampedActive = Math.min(active, Math.max(results.length - 1, 0));
+
+  const close = () => {
+    setOpen(false);
+    setQuery('');
+    setActive(0);
+  };
+
+  const runCommand = (index: number) => {
+    const command = results[index];
+    if (command) {
+      command.run();
+    }
+    close();
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="palette-open"
+        aria-label="Open command palette"
+        onClick={() => {
+          return setOpen(true);
+        }}
+      >
+        ⌘K
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="palette-overlay"
+      data-testid="palette-overlay"
+      // Backdrop: a pointer-only dismiss affordance. Keyboard users close
+      // with Escape (handled on the combobox input below).
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          close();
+        }
+      }}
+    >
+      <div
+        className="palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+      >
+        <input
+          // A user-invoked palette must receive focus to stay keyboard-operable.
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          autoFocus
+          type="text"
+          className="palette-input"
+          role="combobox"
+          aria-expanded="true"
+          aria-controls="palette-listbox"
+          aria-activedescendant={
+            results.length > 0 ? `palette-option-${clampedActive}` : undefined
+          }
+          aria-label="Search commands"
+          placeholder="Type a command…"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setActive(0);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowDown') {
+              event.preventDefault();
+              setActive(Math.min(clampedActive + 1, results.length - 1));
+            } else if (event.key === 'ArrowUp') {
+              event.preventDefault();
+              setActive(Math.max(clampedActive - 1, 0));
+            } else if (event.key === 'Enter') {
+              event.preventDefault();
+              runCommand(clampedActive);
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              close();
+            }
+          }}
+        />
+        <ul id="palette-listbox" role="listbox" className="palette-list">
+          {results.length === 0 ? (
+            <li className="palette-empty" role="presentation">
+              No matching command — try a component name, a preset, or a lens.
+            </li>
+          ) : (
+            results.map((command, index) => {
+              return (
+                // Keyboard interaction lives on the combobox input
+                // (aria-activedescendant pattern); the option's click is the
+                // pointer path of the same command.
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+                <li
+                  key={command.id}
+                  id={`palette-option-${index}`}
+                  role="option"
+                  aria-selected={index === clampedActive}
+                  className="palette-option"
+                  onClick={() => {
+                    return runCommand(index);
+                  }}
+                >
+                  {command.title}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/docs/fsl-studio/src/studio/session/SessionSync.tsx
+++ b/docs/fsl-studio/src/studio/session/SessionSync.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { useComponentStore } from '../components/componentStore';
+import { useThemeStore } from '../theme/themeStore';
+import { saveDraft } from './drafts';
+import { type SessionSnapshot, snapshotToHash } from './sessionState';
+import { useSession } from './sessionStore';
+
+/**
+ * URL + drafts synchronizer (PRD F1.2/F1.3, AD-10): projects the session
+ * onto the location hash (`history.replaceState` — steering, not history
+ * spam) and autosaves the draft, silently and debounced. The write is
+ * ambient; the live preview is the confirmation (PRD §6.4-P2).
+ */
+export const SYNC_DEBOUNCE_MS = 250;
+
+export const SessionSync = () => {
+  const session = useSession();
+  const theme = useThemeStore();
+  const component = useComponentStore();
+
+  const snapshot = React.useMemo<SessionSnapshot>(() => {
+    return {
+      v: 1,
+      lens: session.lens,
+      altitude: session.altitude,
+      theme: {
+        preset: theme.preset,
+        overrides: theme.overrides,
+        origins: theme.origins,
+      },
+      component: {
+        selection: component.selection,
+        evaluation: component.evaluation,
+        consequence: component.consequence,
+      },
+    };
+  }, [session, theme, component]);
+
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => {
+      window.history.replaceState(null, '', snapshotToHash(snapshot));
+      saveDraft(session.draftId, snapshot);
+    }, SYNC_DEBOUNCE_MS);
+    return () => {
+      return window.clearTimeout(timer);
+    };
+  }, [snapshot, session.draftId]);
+
+  return null;
+};

--- a/docs/fsl-studio/src/studio/session/commands.ts
+++ b/docs/fsl-studio/src/studio/session/commands.ts
@@ -1,0 +1,109 @@
+import { CATALOG } from '../components/catalog';
+import { type ComponentStore } from '../components/componentStore';
+import { EXAMPLE_PAGES } from '../components/examplePages';
+import { LENS_LABELS, LENSES } from '../lenses';
+import { PRESETS } from '../theme/presets';
+import { type ThemeStore } from '../theme/themeStore';
+import { ALTITUDES } from './sessionState';
+import { type SessionStore } from './sessionStore';
+
+/**
+ * The ⌘K command inventory (PRD F1.5, §6.5): lenses, stage altitudes,
+ * presets, every catalog component, the example pages, and session actions.
+ * Commands are derived from the same sources as the navigators — no second
+ * registry to drift.
+ */
+export interface Command {
+  id: string;
+  title: string;
+  run: () => void;
+}
+
+export const buildCommands = ({
+  session,
+  theme,
+  component,
+}: {
+  session: SessionStore;
+  theme: ThemeStore;
+  component: ComponentStore;
+}): Command[] => {
+  return [
+    ...LENSES.map((lens) => {
+      return {
+        id: `lens:${lens}`,
+        title: `Lens: ${LENS_LABELS[lens]}`,
+        run: () => {
+          return session.setLens(lens);
+        },
+      };
+    }),
+    ...ALTITUDES.map((altitude) => {
+      return {
+        id: `altitude:${altitude}`,
+        title: `Stage: ${altitude}`,
+        run: () => {
+          return session.setAltitude(altitude);
+        },
+      };
+    }),
+    ...PRESETS.map((preset) => {
+      return {
+        id: `preset:${preset.id}`,
+        title: `Preset: ${preset.label}`,
+        run: () => {
+          return theme.setPreset(preset.id);
+        },
+      };
+    }),
+    {
+      id: 'apply-to-studio',
+      title: theme.applyToStudio
+        ? 'Stop applying the theme to the Studio'
+        : 'Apply the theme to the Studio',
+      run: () => {
+        return theme.setApplyToStudio(!theme.applyToStudio);
+      },
+    },
+    {
+      id: 'home',
+      title: 'Go home',
+      run: () => {
+        return session.goHome();
+      },
+    },
+    ...CATALOG.map((entry) => {
+      return {
+        id: `component:${entry.key}`,
+        title: `Component: ${entry.meta.displayName}`,
+        run: () => {
+          component.selectComponent(entry.key);
+          session.setLens('components');
+        },
+      };
+    }),
+    ...EXAMPLE_PAGES.map((page) => {
+      return {
+        id: `page:${page.id}`,
+        title: `Page: ${page.label}`,
+        run: () => {
+          component.selectPage(page.id);
+          session.setLens('components');
+        },
+      };
+    }),
+  ];
+};
+
+export const filterCommands = (
+  commands: Command[],
+  query: string
+): Command[] => {
+  const q = query.trim().toLowerCase();
+  if (q === '') {
+    return commands;
+  }
+  return commands.filter((command) => {
+    return command.title.toLowerCase().includes(q);
+  });
+};

--- a/docs/fsl-studio/src/studio/session/drafts.ts
+++ b/docs/fsl-studio/src/studio/session/drafts.ts
@@ -1,0 +1,85 @@
+import { sanitizeSnapshot, type SessionSnapshot } from './sessionState';
+
+/**
+ * Drafts shelf (PRD F1.3, AD-10): silent autosave to localStorage keyed by
+ * draft id. Two tabs on the same draft = last-write-wins — an accepted v1
+ * limitation, documented in-app on the drafts list. Storage failures (quota,
+ * private mode) are swallowed: autosave is ambient, never an interruption
+ * (PRD §6.4-P2); stored garbage is sanitized on the way out.
+ */
+
+const STORAGE_KEY = 'fsl-studio.drafts.v1';
+
+export interface DraftRecord {
+  id: string;
+  updatedAt: number;
+  snapshot: SessionSnapshot;
+}
+
+type DraftIndex = Record<string, { updatedAt: number; snapshot: unknown }>;
+
+const readIndex = (): DraftIndex => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+      ? (parsed as DraftIndex)
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+const writeIndex = (index: DraftIndex): void => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(index));
+  } catch {
+    // Quota/private-mode failures: autosave silently degrades (PRD F1.3).
+  }
+};
+
+export const newDraftId = (): string => {
+  return `d-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+/** Last-write-wins upsert of a draft (PRD F1.3). */
+export const saveDraft = (id: string, snapshot: SessionSnapshot): void => {
+  const index = readIndex();
+  index[id] = { updatedAt: Date.now(), snapshot };
+  writeIndex(index);
+};
+
+export const loadDraft = (id: string): SessionSnapshot | null => {
+  const entry = readIndex()[id];
+  return entry ? sanitizeSnapshot(entry.snapshot) : null;
+};
+
+export const deleteDraft = (id: string): void => {
+  const index = readIndex();
+  delete index[id];
+  writeIndex(index);
+};
+
+/** All valid drafts, most recently updated first. */
+export const listDrafts = (): DraftRecord[] => {
+  const index = readIndex();
+  const records: DraftRecord[] = [];
+  for (const id of Object.keys(index)) {
+    const snapshot = sanitizeSnapshot(index[id].snapshot);
+    if (snapshot) {
+      records.push({
+        id,
+        updatedAt: Number(index[id].updatedAt) || 0,
+        snapshot,
+      });
+    }
+  }
+  return records.sort((a, b) => {
+    return b.updatedAt - a.updatedAt;
+  });
+};

--- a/docs/fsl-studio/src/studio/session/sessionState.ts
+++ b/docs/fsl-studio/src/studio/session/sessionState.ts
@@ -1,0 +1,169 @@
+import {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent,
+} from 'lz-string';
+
+import { CATALOG, findEntry } from '../components/catalog';
+import { type ComponentSelection } from '../components/componentStore';
+import { findPage } from '../components/examplePages';
+import { type Lens, LENSES } from '../lenses';
+import { type TokenOverrides } from '../theme/overrides';
+import { findPreset, type PresetId } from '../theme/presets';
+import { type Origin } from '../theme/themeStore';
+
+/**
+ * Session state and its URL projection (PRD F1.2, AD-10).
+ *
+ * The URL hash *is* the session: one `SessionSnapshot` serialized with
+ * lz-string. Opening a shared link forks the state (a copy under a new draft
+ * id); decoding is defensive because the payload is foreign input — anything
+ * that doesn't validate falls back to a safe default, and a payload that
+ * doesn't parse at all yields `null` (the app boots home instead of
+ * crashing). `applyToStudio` is deliberately local-only: a shared link must
+ * not re-skin the receiver's editor chrome (recorded in PRD §14).
+ */
+
+export const ALTITUDES = ['component', 'page', 'grid'] as const;
+
+/** Stage altitude (PRD F1.4): isolated component → example page → page grid. */
+export type Altitude = (typeof ALTITUDES)[number];
+
+export interface SessionSnapshot {
+  v: 1;
+  lens: Lens;
+  altitude: Altitude;
+  theme: {
+    preset: PresetId;
+    overrides: TokenOverrides;
+    origins: Record<string, Origin>;
+  };
+  component: {
+    selection: ComponentSelection;
+    evaluation?: string;
+    consequence?: string;
+  };
+}
+
+export const DEFAULT_SELECTION: ComponentSelection = {
+  kind: 'component',
+  key: CATALOG[0].key,
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const sanitizeOverrides = (value: unknown): TokenOverrides => {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const out: TokenOverrides = {};
+  for (const key of Object.keys(value)) {
+    if (typeof value[key] === 'string') {
+      out[key] = value[key];
+    }
+  }
+  return out;
+};
+
+const sanitizeOrigins = (
+  value: unknown,
+  overrides: TokenOverrides
+): Record<string, Origin> => {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const out: Record<string, Origin> = {};
+  for (const key of Object.keys(value)) {
+    const origin = value[key];
+    if ((origin === 'manual' || origin === 'ai') && key in overrides) {
+      out[key] = origin;
+    }
+  }
+  return out;
+};
+
+const sanitizeSelection = (value: unknown): ComponentSelection => {
+  if (isRecord(value)) {
+    if (
+      value.kind === 'component' &&
+      typeof value.key === 'string' &&
+      findEntry(value.key)
+    ) {
+      return { kind: 'component', key: value.key };
+    }
+    if (
+      value.kind === 'page' &&
+      typeof value.id === 'string' &&
+      findPage(value.id)
+    ) {
+      return { kind: 'page', id: value.id };
+    }
+  }
+  return DEFAULT_SELECTION;
+};
+
+const optionalString = (value: unknown): string | undefined => {
+  return typeof value === 'string' ? value : undefined;
+};
+
+/**
+ * Validate a parsed (foreign) payload into a safe snapshot, or `null` when
+ * it isn't a v1 session at all. Individual invalid fields degrade to
+ * defaults rather than rejecting the whole link.
+ */
+export const sanitizeSnapshot = (value: unknown): SessionSnapshot | null => {
+  if (!isRecord(value) || value.v !== 1) {
+    return null;
+  }
+
+  const themeIn = isRecord(value.theme) ? value.theme : {};
+  const componentIn = isRecord(value.component) ? value.component : {};
+  const overrides = sanitizeOverrides(themeIn.overrides);
+
+  return {
+    v: 1,
+    lens: LENSES.includes(value.lens as Lens) ? (value.lens as Lens) : 'theme',
+    altitude: ALTITUDES.includes(value.altitude as Altitude)
+      ? (value.altitude as Altitude)
+      : 'component',
+    theme: {
+      preset: findPreset(String(themeIn.preset))
+        ? (themeIn.preset as PresetId)
+        : 'base',
+      overrides,
+      origins: sanitizeOrigins(themeIn.origins, overrides),
+    },
+    component: {
+      selection: sanitizeSelection(componentIn.selection),
+      evaluation: optionalString(componentIn.evaluation),
+      consequence: optionalString(componentIn.consequence),
+    },
+  };
+};
+
+export const encodeSession = (snapshot: SessionSnapshot): string => {
+  return compressToEncodedURIComponent(JSON.stringify(snapshot));
+};
+
+export const decodeSession = (raw: string): SessionSnapshot | null => {
+  const json = decompressFromEncodedURIComponent(raw);
+  if (!json) {
+    return null;
+  }
+  try {
+    return sanitizeSnapshot(JSON.parse(json));
+  } catch {
+    return null;
+  }
+};
+
+/** The `#s=…` hash for a snapshot, and its parser. */
+export const snapshotToHash = (snapshot: SessionSnapshot): string => {
+  return `#s=${encodeSession(snapshot)}`;
+};
+
+export const snapshotFromHash = (hash: string): SessionSnapshot | null => {
+  const match = /^#s=(.+)$/.exec(hash);
+  return match ? decodeSession(match[1]) : null;
+};

--- a/docs/fsl-studio/src/studio/session/sessionStore.tsx
+++ b/docs/fsl-studio/src/studio/session/sessionStore.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+
+import { type Lens } from '../lenses';
+import { newDraftId } from './drafts';
+import {
+  type Altitude,
+  type SessionSnapshot,
+  snapshotFromHash,
+} from './sessionState';
+
+/**
+ * The session layer above the domain stores (PRD F1.2/F1.4): the active
+ * lens, the stage altitude, the draft identity, and the way back home.
+ * Lenses and altitude are projections of the one session — they live here so
+ * a lens switch never resets the stage frame and the URL/draft sync sees one
+ * consistent state.
+ */
+
+export type Screen = 'home' | 'studio';
+
+export interface SessionBoot {
+  screen: Screen;
+  /** Restored state (URL fork or draft); null = fresh defaults. */
+  snapshot: SessionSnapshot | null;
+  lens: Lens;
+  draftId: string;
+}
+
+/**
+ * Resolve the boot target from the URL hash (PRD AD-10): a valid `#s=` hash
+ * opens the studio as a **fork** — same state, new draft id; anything else
+ * lands on the task-first home.
+ */
+export const bootFromHash = (hash: string): SessionBoot => {
+  const snapshot = snapshotFromHash(hash);
+  if (snapshot) {
+    return {
+      screen: 'studio',
+      snapshot,
+      lens: snapshot.lens,
+      draftId: newDraftId(),
+    };
+  }
+  return {
+    screen: 'home',
+    snapshot: null,
+    lens: 'theme',
+    draftId: newDraftId(),
+  };
+};
+
+export interface SessionStore {
+  lens: Lens;
+  altitude: Altitude;
+  draftId: string;
+  setLens: (lens: Lens) => void;
+  setAltitude: (altitude: Altitude) => void;
+  goHome: () => void;
+}
+
+const SessionCtx = React.createContext<SessionStore | null>(null);
+
+export const SessionProvider = ({
+  children,
+  draftId,
+  initialLens,
+  initialAltitude = 'component',
+  onGoHome,
+}: {
+  children: React.ReactNode;
+  draftId: string;
+  initialLens: Lens;
+  initialAltitude?: Altitude;
+  onGoHome: () => void;
+}) => {
+  const [lens, setLens] = React.useState<Lens>(initialLens);
+  const [altitude, setAltitude] = React.useState<Altitude>(initialAltitude);
+
+  const value = React.useMemo<SessionStore>(() => {
+    return { lens, altitude, draftId, setLens, setAltitude, goHome: onGoHome };
+  }, [lens, altitude, draftId, onGoHome]);
+
+  return <SessionCtx.Provider value={value}>{children}</SessionCtx.Provider>;
+};
+
+export const useSession = (): SessionStore => {
+  const store = React.useContext(SessionCtx);
+  if (!store) {
+    throw new Error('useSession must be used within a SessionProvider');
+  }
+  return store;
+};

--- a/docs/fsl-studio/src/studio/theme/ExportPanel.tsx
+++ b/docs/fsl-studio/src/studio/theme/ExportPanel.tsx
@@ -29,13 +29,13 @@ export const ExportPanel = () => {
 
   const content = React.useMemo(() => {
     if (format === 'code') {
-      return generateThemeCode(store.preset, store.colors);
+      return generateThemeCode(store.preset, store.overrides);
     }
     if (format === 'dtcg') {
       return JSON.stringify(toDTCG(store.liveBundle.base), null, 2);
     }
     return getThemeStylesContent(store.liveBundle);
-  }, [format, store.preset, store.colors, store.liveBundle]);
+  }, [format, store.preset, store.overrides, store.liveBundle]);
 
   const copied = copiedContent === content;
 

--- a/docs/fsl-studio/src/studio/theme/ThemeInspector.tsx
+++ b/docs/fsl-studio/src/studio/theme/ThemeInspector.tsx
@@ -1,18 +1,55 @@
+import { Button, ConfirmationDialog } from '@ttoss/fsl-ui';
 import * as React from 'react';
 
 import { ExportPanel } from './ExportPanel';
-import { listColorLeaves } from './overrides';
+import { listTokenPaths } from './overrides';
+import { type ContrastResult } from './palette';
 import { useThemeStore } from './themeStore';
+
+const looksLikeColor = (value: string): boolean => {
+  return /^#[0-9a-fA-F]{3,8}$/.test(value);
+};
+
+const ContrastList = ({
+  mode,
+  results,
+}: {
+  mode: string;
+  results: ContrastResult[];
+}) => {
+  return (
+    <>
+      <h3 className="theme-contrast-mode">{mode}</h3>
+      <ul className="theme-contrast">
+        {results.map((result) => {
+          return (
+            <li key={result.label} className="theme-contrast-row">
+              <span className="theme-contrast-label">{result.label}</span>
+              <span
+                className={`theme-contrast-badge theme-contrast-${result.rating}`}
+              >
+                {result.rating === 'fail' ? 'Fail' : result.rating}{' '}
+                {result.ratio.toFixed(1)}:1
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+};
 
 /**
  * Theme lens inspector (PRD F2.3/F2.5/F2.6/F2.7): apply-to-Studio control,
- * the change diff with per-leaf revert, ambient contrast checks, and the
- * export peak.
+ * the change diff with per-leaf revert and ambient broken-ref badges, WCAG
+ * contrast for both modes, and the export peak. Exporting with broken refs
+ * goes through the one sanctioned escalation dialog (PRD §6.4-P2).
  */
 export const ThemeInspector = () => {
   const store = useThemeStore();
   const [showExport, setShowExport] = React.useState(false);
-  const leaves = listColorLeaves(store.colors);
+  const paths = listTokenPaths(store.overrides);
+  const hasBrokenRefs = store.brokenRefs.length > 0;
 
   return (
     <div className="theme-inspector">
@@ -43,37 +80,48 @@ export const ThemeInspector = () => {
 
       <section className="theme-section">
         <h2 className="theme-section-title">
-          Changes {leaves.length > 0 ? `(${leaves.length})` : ''}
+          Changes {paths.length > 0 ? `(${paths.length})` : ''}
         </h2>
-        {leaves.length === 0 ? (
+        {paths.length === 0 ? (
           <p className="theme-hint">
-            No changes yet. Edit a color to build a diff against the preset —
+            No changes yet. Edit a token to build a diff against the preset —
             this list is exactly what gets exported.
           </p>
         ) : (
           <>
             <ul className="theme-diff">
-              {leaves.map(({ hue, step }) => {
-                const value = store.colors[hue][step];
+              {paths.map((path) => {
+                const value = store.overrides[path];
+                const broken = store.brokenRefs.includes(path);
                 return (
-                  <li key={`${hue}.${step}`} className="theme-diff-row">
-                    <span
-                      className="theme-diff-swatch"
-                      style={{ backgroundColor: value }}
-                      aria-hidden
-                    />
+                  <li key={path} className="theme-diff-row">
+                    {looksLikeColor(value) ? (
+                      <span
+                        className="theme-diff-swatch"
+                        style={{ backgroundColor: value }}
+                        aria-hidden
+                      />
+                    ) : null}
                     <span className="theme-diff-path">
-                      {/* Phase 1 edits are all manual (✎). The ✦ AI-origin
-                          marker activates with the Generate lens (Phase 4);
-                          origin is already tracked in the store. */}
-                      ✎ {hue}.{step}
+                      {/* ✎ marks a manual edit; the ✦ AI-origin marker
+                          activates with the Generate lens (Phase 4). */}
+                      {store.origin(path) === 'ai' ? '✦' : '✎'} {path}
                     </span>
                     <span className="theme-diff-value">{value}</span>
+                    {broken ? (
+                      <span
+                        className="token-broken-badge"
+                        role="img"
+                        aria-label={`Broken reference at ${path}`}
+                      >
+                        ⚠
+                      </span>
+                    ) : null}
                     <button
                       type="button"
                       className="theme-revert"
                       onClick={() => {
-                        return store.revertColor(hue, step);
+                        return store.revertToken(path);
                       }}
                     >
                       Revert
@@ -97,36 +145,53 @@ export const ThemeInspector = () => {
 
       <section className="theme-section">
         <h2 className="theme-section-title">Contrast</h2>
-        <ul className="theme-contrast">
-          {store.contrast.map((result) => {
-            return (
-              <li key={result.label} className="theme-contrast-row">
-                <span className="theme-contrast-label">{result.label}</span>
-                <span
-                  className={`theme-contrast-badge theme-contrast-${result.rating}`}
-                >
-                  {result.rating === 'fail' ? 'Fail' : result.rating}{' '}
-                  {result.ratio.toFixed(1)}:1
-                </span>
-              </li>
-            );
-          })}
-        </ul>
+        {/* Every Studio preset carries a dark alternate (asserted in
+            presets.test), so both mode lists always render. */}
+        <ContrastList mode="Light" results={store.contrast.light} />
+        <ContrastList mode="Dark" results={store.contrast.dark} />
       </section>
 
       <section className="theme-section">
-        <button
-          type="button"
-          className="theme-export-toggle"
-          aria-expanded={showExport}
-          onClick={() => {
-            return setShowExport((prev) => {
-              return !prev;
-            });
-          }}
-        >
-          {showExport ? 'Hide export' : 'Export theme'}
-        </button>
+        {showExport ? (
+          <button
+            type="button"
+            className="theme-export-toggle"
+            aria-expanded
+            onClick={() => {
+              return setShowExport(false);
+            }}
+          >
+            Hide export
+          </button>
+        ) : hasBrokenRefs ? (
+          <ConfirmationDialog
+            trigger={<Button evaluation="muted">Export theme</Button>}
+            title="Broken token references"
+            confirmLabel="Export anyway"
+            cancelLabel="Go back"
+            consequence="committing"
+            onConfirm={() => {
+              return setShowExport(true);
+            }}
+          >
+            {store.brokenRefs.length === 1
+              ? 'One token resolves'
+              : `${store.brokenRefs.length} tokens resolve`}{' '}
+            to a broken reference — the exported theme will carry unresolved
+            values.
+          </ConfirmationDialog>
+        ) : (
+          <button
+            type="button"
+            className="theme-export-toggle"
+            aria-expanded={false}
+            onClick={() => {
+              return setShowExport(true);
+            }}
+          >
+            Export theme
+          </button>
+        )}
         {showExport ? <ExportPanel /> : null}
       </section>
     </div>

--- a/docs/fsl-studio/src/studio/theme/ThemeNavigator.tsx
+++ b/docs/fsl-studio/src/studio/theme/ThemeNavigator.tsx
@@ -1,5 +1,9 @@
-import { PRESETS } from './overrides';
+import { Disclosure, DisclosurePanel, DisclosureTrigger } from '@ttoss/fsl-ui';
+import * as React from 'react';
+
+import { PRESETS } from './presets';
 import { useThemeStore } from './themeStore';
+import { type TokenFamily, type TokenLeaf } from './tokenTree';
 
 /** A 6-digit hex is required by `<input type="color">`; fall back safely. */
 const forColorInput = (value: string): string => {
@@ -7,9 +11,196 @@ const forColorInput = (value: string): string => {
 };
 
 /**
- * Theme lens navigator (PRD F2.1): preset picker + editable core color
- * scales. Editing any step re-derives the theme and re-themes the stage (and
- * the chrome, when "apply to Studio" is on) within the same frame.
+ * One editable token leaf. The input holds the raw authored value — a
+ * literal or a `{ref}` string (editing a semantic leaf to another ref is the
+ * remap surface of PRD F2.2). A broken ref shows an ambient badge on the row,
+ * never a modal (PRD §6.4-P2).
+ */
+const TokenRow = ({ leaf, display }: { leaf: TokenLeaf; display: string }) => {
+  const store = useThemeStore();
+  const override = store.overrides[leaf.path];
+  const isOverridden = override != null;
+  const broken = store.brokenRefs.includes(leaf.path);
+
+  return (
+    <div className="token-row">
+      <label className="token-row-label" htmlFor={`token-${leaf.path}`}>
+        {display}
+      </label>
+      <input
+        id={`token-${leaf.path}`}
+        type="text"
+        className="token-row-input"
+        aria-label={leaf.path}
+        aria-invalid={broken || undefined}
+        value={override ?? leaf.raw}
+        onChange={(event) => {
+          return store.setToken(leaf.path, event.target.value);
+        }}
+      />
+      {broken ? (
+        <span
+          className="token-broken-badge"
+          role="img"
+          aria-label="Broken reference"
+        >
+          ⚠
+        </span>
+      ) : null}
+      {isOverridden ? (
+        <button
+          type="button"
+          className="theme-revert"
+          aria-label={`Revert ${leaf.path}`}
+          onClick={() => {
+            return store.revertToken(leaf.path);
+          }}
+        >
+          Revert
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+/** Leaves are only rendered while their disclosure is open (Miller/chunking). */
+const LazyDisclosure = ({
+  title,
+  count,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  count: number;
+  defaultOpen?: boolean;
+  children: () => React.ReactNode;
+}) => {
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <Disclosure isExpanded={open} onExpandedChange={setOpen}>
+      <DisclosureTrigger>
+        {title} · {count}
+      </DisclosureTrigger>
+      <DisclosurePanel>{open ? children() : null}</DisclosurePanel>
+    </Disclosure>
+  );
+};
+
+/** Display name of a leaf relative to its group prefix. */
+const displayName = (leaf: TokenLeaf, segmentsToDrop: number): string => {
+  return leaf.path.split('.').slice(segmentsToDrop).join('.');
+};
+
+const FamilySection = ({ family }: { family: TokenFamily }) => {
+  return (
+    <LazyDisclosure title={family.family} count={family.leafCount}>
+      {() => {
+        return family.groups.map((group) => {
+          if (group.label === '') {
+            return group.leaves.map((leaf) => {
+              return (
+                <TokenRow
+                  key={leaf.path}
+                  leaf={leaf}
+                  display={displayName(leaf, 2)}
+                />
+              );
+            });
+          }
+          return (
+            <LazyDisclosure
+              key={group.label}
+              title={group.label}
+              count={group.leaves.length}
+            >
+              {() => {
+                return group.leaves.map((leaf) => {
+                  return (
+                    <TokenRow
+                      key={leaf.path}
+                      leaf={leaf}
+                      display={displayName(leaf, 3)}
+                    />
+                  );
+                });
+              }}
+            </LazyDisclosure>
+          );
+        });
+      }}
+    </LazyDisclosure>
+  );
+};
+
+/** The core color scales keep the dedicated picker editor (the SC-1 wow). */
+const CoreColorScales = () => {
+  const store = useThemeStore();
+
+  return (
+    <>
+      {store.palette.map((scale) => {
+        return (
+          <fieldset key={scale.hue} className="theme-scale">
+            <legend className="theme-scale-legend">{scale.hue}</legend>
+            {scale.steps.map(({ step, base }) => {
+              const path = `core.colors.${scale.hue}.${step}`;
+              const overridden = store.overrides[path];
+              const value = overridden ?? base;
+              const isOverridden = overridden != null;
+              const inputId = `color-${scale.hue}-${step}`;
+              return (
+                <div key={step} className="theme-swatch-row">
+                  <label className="theme-swatch-label" htmlFor={inputId}>
+                    {step}
+                  </label>
+                  <input
+                    id={inputId}
+                    type="color"
+                    className="theme-swatch-input"
+                    aria-label={`${scale.hue} ${step} color`}
+                    value={forColorInput(value)}
+                    onChange={(event) => {
+                      return store.setToken(path, event.target.value);
+                    }}
+                  />
+                  <input
+                    type="text"
+                    className="theme-swatch-hex"
+                    aria-label={`${scale.hue} ${step} hex`}
+                    value={value}
+                    onChange={(event) => {
+                      return store.setToken(path, event.target.value);
+                    }}
+                  />
+                  {isOverridden ? (
+                    <button
+                      type="button"
+                      className="theme-revert"
+                      aria-label={`Revert ${scale.hue} ${step}`}
+                      onClick={() => {
+                        return store.revertToken(path);
+                      }}
+                    >
+                      Revert
+                    </button>
+                  ) : (
+                    <span className="theme-revert-placeholder" aria-hidden />
+                  )}
+                </div>
+              );
+            })}
+          </fieldset>
+        );
+      })}
+    </>
+  );
+};
+
+/**
+ * Theme lens navigator (PRD F2.1): preset picker, then the semantic layer
+ * grouped by family (remap editing per F2.2), then the core layer one level
+ * down on demand — color scales with pickers, every other family as raw
+ * value rows.
  */
 export const ThemeNavigator = () => {
   const store = useThemeStore();
@@ -40,71 +231,33 @@ export const ThemeNavigator = () => {
       </section>
 
       <section className="theme-section">
-        <h2 className="theme-section-title">Colors</h2>
+        <h2 className="theme-section-title">Semantic</h2>
         <p className="theme-hint">
-          Edit a core color scale and watch the stage re-theme. The brand scale
-          drives accents, links, focus rings, and selected states.
+          Meaning-bearing tokens, mostly references. Remap one to another{' '}
+          <code>{'{core.…}'}</code> ref and every consumer follows.
         </p>
-        {store.palette.map((scale) => {
-          return (
-            <fieldset key={scale.hue} className="theme-scale">
-              <legend className="theme-scale-legend">{scale.hue}</legend>
-              {scale.steps.map(({ step, base }) => {
-                const overridden = store.colors[scale.hue]?.[step];
-                const value = overridden ?? base;
-                const isOverridden = overridden != null;
-                const inputId = `color-${scale.hue}-${step}`;
-                return (
-                  <div key={step} className="theme-swatch-row">
-                    <label className="theme-swatch-label" htmlFor={inputId}>
-                      {step}
-                    </label>
-                    <input
-                      id={inputId}
-                      type="color"
-                      className="theme-swatch-input"
-                      aria-label={`${scale.hue} ${step} color`}
-                      value={forColorInput(value)}
-                      onChange={(event) => {
-                        return store.setColor(
-                          scale.hue,
-                          step,
-                          event.target.value
-                        );
-                      }}
-                    />
-                    <input
-                      type="text"
-                      className="theme-swatch-hex"
-                      aria-label={`${scale.hue} ${step} hex`}
-                      value={value}
-                      onChange={(event) => {
-                        return store.setColor(
-                          scale.hue,
-                          step,
-                          event.target.value
-                        );
-                      }}
-                    />
-                    {isOverridden ? (
-                      <button
-                        type="button"
-                        className="theme-revert"
-                        aria-label={`Revert ${scale.hue} ${step}`}
-                        onClick={() => {
-                          return store.revertColor(scale.hue, step);
-                        }}
-                      >
-                        Revert
-                      </button>
-                    ) : (
-                      <span className="theme-revert-placeholder" aria-hidden />
-                    )}
-                  </div>
-                );
-              })}
-            </fieldset>
-          );
+        {store.semanticTree.map((family) => {
+          return <FamilySection key={family.family} family={family} />;
+        })}
+      </section>
+
+      <section className="theme-section">
+        <h2 className="theme-section-title">Core</h2>
+        {/* Colors open by default: the brand scale is the SC-1 "wow" surface
+            and must stay reachable at a glance (recorded in PRD §14). */}
+        <LazyDisclosure
+          title="colors"
+          defaultOpen
+          count={store.palette.reduce((total, scale) => {
+            return total + scale.steps.length;
+          }, 0)}
+        >
+          {() => {
+            return <CoreColorScales />;
+          }}
+        </LazyDisclosure>
+        {store.coreTree.map((family) => {
+          return <FamilySection key={family.family} family={family} />;
         })}
       </section>
     </div>

--- a/docs/fsl-studio/src/studio/theme/overrides.ts
+++ b/docs/fsl-studio/src/studio/theme/overrides.ts
@@ -1,146 +1,150 @@
 import {
-  bruttal,
   createTheme,
   type DeepPartial,
   type ThemeBundle,
   type ThemeTokens,
 } from '@ttoss/fsl-theme';
 
+import { AUTHORED_PRESETS, presetBundle, type PresetId } from './presets';
+
 /**
  * Theme Lab editing model (PRD F2.2/F2.3).
  *
- * Phase-1 editable surface = **core color scales** (brand, neutral, and any
- * other hue the preset defines). Semantic color tokens are references, not
- * independently editable values, and core color edits are what produce the
- * cascade the "wow" depends on (brand.500 is referenced ~149× in the base
- * theme). Non-color families and semantic-ref remapping are deferred to a
- * later phase (recorded in PRD §14).
- *
- * The single source of truth is the override diff itself: a map of
- * `hue → step → hex`. That diff *is* the "changes vs preset" view (F2.3) and
- * *is* the `overrides` argument to `createTheme` for both live preview and
- * code export — one structure, no derived duplicate to keep in sync.
+ * The editable surface is any token leaf, addressed by its flat dotted path:
+ * core values (`core.colors.brand.500`, `core.radii.md`, …) and semantic
+ * remaps (`semantic.radii.control` → `{core.radii.none}`, …). The single
+ * source of truth is the override diff itself — a flat `path → value` map.
+ * That diff *is* the "changes vs preset" view (F2.3) and, unflattened, *is*
+ * the `overrides` argument to `createTheme` for both live preview and code
+ * export — one structure, no derived duplicate to keep in sync.
  */
-export type ColorOverrides = Record<string, Record<string, string>>;
+export type TokenOverrides = Record<string, string>;
 
-export type PresetId = 'base' | 'bruttal';
+export type { PresetId };
 
-export interface PresetSpec {
-  id: PresetId;
-  label: string;
-  description: string;
-}
-
-export const PRESETS: readonly PresetSpec[] = [
-  {
-    id: 'base',
-    label: 'Base',
-    description:
-      'The default FSL foundation — light base with a dark alternate.',
-  },
-  {
-    id: 'bruttal',
-    label: 'Bruttal',
-    description: 'The built-in high-contrast, expressive brand theme.',
-  },
-];
-
-/** The unedited bundle for a preset — also the "fallback" chrome theme. */
-export const presetBundle = (preset: PresetId): ThemeBundle => {
-  return preset === 'bruttal' ? bruttal : createTheme();
-};
-
-/**
- * Build the live bundle: the preset with the color overrides applied. `base`
- * extends the default foundation; `bruttal` extends the built-in bundle so it
- * inherits bruttal's alternate. The nested override object satisfies
- * `DeepPartial<ThemeTokens>` structurally but the color-scale type requires a
- * `500` step, which a partial diff intentionally omits — hence the cast.
- */
-export const buildBundle = (
-  preset: PresetId,
-  colors: ColorOverrides
-): ThemeBundle => {
-  const overrides = {
-    core: { colors },
-  } as DeepPartial<ThemeTokens>;
-
-  return preset === 'bruttal'
-    ? createTheme({ extends: bruttal, overrides })
-    : createTheme({ overrides });
-};
-
-/** Immutable set of one color leaf. */
-export const setColorLeaf = (
-  colors: ColorOverrides,
-  hue: string,
-  step: string,
+/** Immutable set of one token leaf. */
+export const setToken = (
+  overrides: TokenOverrides,
+  path: string,
   value: string
-): ColorOverrides => {
-  return {
-    ...colors,
-    [hue]: { ...colors[hue], [step]: value },
-  };
+): TokenOverrides => {
+  return { ...overrides, [path]: value };
 };
 
-/** Immutable removal of one color leaf, pruning an emptied hue. */
-export const removeColorLeaf = (
-  colors: ColorOverrides,
-  hue: string,
-  step: string
-): ColorOverrides => {
-  const hueEntry = colors[hue];
-  if (!hueEntry || !(step in hueEntry)) {
-    return colors;
+/** Immutable removal of one token leaf. */
+export const removeToken = (
+  overrides: TokenOverrides,
+  path: string
+): TokenOverrides => {
+  if (!(path in overrides)) {
+    return overrides;
   }
-
-  const nextHue = { ...hueEntry };
-  delete nextHue[step];
-
-  const next = { ...colors };
-  if (Object.keys(nextHue).length === 0) {
-    delete next[hue];
-  } else {
-    next[hue] = nextHue;
-  }
+  const next = { ...overrides };
+  delete next[path];
   return next;
 };
 
-export interface ColorLeaf {
-  hue: string;
-  step: string;
-}
-
-/** Flatten the override diff into a stable, sorted leaf list. */
-export const listColorLeaves = (colors: ColorOverrides): ColorLeaf[] => {
-  const leaves: ColorLeaf[] = [];
-  for (const hue of Object.keys(colors).sort()) {
-    for (const step of Object.keys(colors[hue]).sort()) {
-      leaves.push({ hue, step });
-    }
-  }
-  return leaves;
+/** The override diff as a stable, sorted path list. */
+export const listTokenPaths = (overrides: TokenOverrides): string[] => {
+  return Object.keys(overrides).sort();
 };
 
-export const hasOverrides = (colors: ColorOverrides): boolean => {
-  return Object.keys(colors).length > 0;
+export const hasOverrides = (overrides: TokenOverrides): boolean => {
+  return Object.keys(overrides).length > 0;
 };
 
 /**
- * Generate a runnable `createTheme(...)` snippet reproducing the edited theme
- * (PRD F2.7). The override diff serializes directly as the `overrides` object
- * literal — numeric step keys quote to valid TS object keys.
+ * Unflatten the diff's dotted paths into the nested object `createTheme`
+ * expects. A non-leaf collision (a path that is a prefix of another) keeps
+ * the deeper structure: sorted iteration puts the prefix first, so the deeper
+ * path's segment walk replaces the stray leaf — the UI only produces leaf
+ * paths, this only matters for defensively handling foreign URL payloads.
  */
-export const generateThemeCode = (
+export const nestOverrides = (
+  overrides: TokenOverrides
+): DeepPartial<ThemeTokens> => {
+  const root: Record<string, unknown> = {};
+
+  for (const path of listTokenPaths(overrides)) {
+    const segments = path.split('.');
+    let node = root;
+    for (const segment of segments.slice(0, -1)) {
+      const existing = node[segment];
+      if (typeof existing === 'object' && existing !== null) {
+        node = existing as Record<string, unknown>;
+      } else {
+        const child: Record<string, unknown> = {};
+        node[segment] = child;
+        node = child;
+      }
+    }
+    node[segments[segments.length - 1]] = overrides[path];
+  }
+
+  return root as DeepPartial<ThemeTokens>;
+};
+
+/**
+ * Minimal recursive merge for plain override objects (`b` wins on leaves).
+ * Used to inline an authored preset's overrides under the user diff for code
+ * export, and to resolve the dark alternate for contrast checks.
+ */
+export const mergeDeep = <T extends Record<string, unknown>>(
+  a: T,
+  b: Record<string, unknown>
+): T => {
+  const out: Record<string, unknown> = { ...a };
+  for (const key of Object.keys(b)) {
+    const prev = out[key];
+    const next = b[key];
+    out[key] =
+      typeof prev === 'object' &&
+      prev !== null &&
+      typeof next === 'object' &&
+      next !== null
+        ? mergeDeep(
+            prev as Record<string, unknown>,
+            next as Record<string, unknown>
+          )
+        : next;
+  }
+  return out as T;
+};
+
+/**
+ * Build the live bundle: the preset with the override diff applied on top.
+ * Extending the preset's bundle inherits its alternate (dark mode) too.
+ */
+export const buildBundle = (
   preset: PresetId,
-  colors: ColorOverrides
-): string => {
-  const overridesLiteral = JSON.stringify({ core: { colors } }, null, 2)
+  overrides: TokenOverrides
+): ThemeBundle => {
+  return createTheme({
+    extends: presetBundle(preset),
+    overrides: nestOverrides(overrides),
+  });
+};
+
+const serializeOverrides = (nested: object): string => {
+  return JSON.stringify(nested, null, 2)
     .split('\n')
     .map((line, index) => {
       return index === 0 ? line : `  ${line}`;
     })
     .join('\n');
+};
+
+/**
+ * Generate a runnable `createTheme(...)` snippet reproducing the edited theme
+ * (PRD F2.7). `base` embeds the diff alone; `bruttal` extends the published
+ * export; Studio-authored presets inline their own overrides under the diff
+ * (merged, diff wins) so the exported code runs anywhere without the Studio.
+ */
+export const generateThemeCode = (
+  preset: PresetId,
+  overrides: TokenOverrides
+): string => {
+  const nested = nestOverrides(overrides);
 
   if (preset === 'bruttal') {
     return [
@@ -148,17 +152,25 @@ export const generateThemeCode = (
       '',
       'export const theme = createTheme({',
       '  extends: bruttal,',
-      `  overrides: ${overridesLiteral},`,
+      `  overrides: ${serializeOverrides(nested)},`,
       '});',
       '',
     ].join('\n');
   }
 
+  const authored = AUTHORED_PRESETS[preset];
+  const merged = authored
+    ? mergeDeep(
+        authored.overrides as Record<string, unknown>,
+        nested as Record<string, unknown>
+      )
+    : nested;
+
   return [
     "import { createTheme } from '@ttoss/fsl-theme';",
     '',
     'export const theme = createTheme({',
-    `  overrides: ${overridesLiteral},`,
+    `  overrides: ${serializeOverrides(merged)},`,
     '});',
     '',
   ].join('\n');

--- a/docs/fsl-studio/src/studio/theme/palette.ts
+++ b/docs/fsl-studio/src/studio/theme/palette.ts
@@ -1,3 +1,8 @@
+import { type ThemeBundle } from '@ttoss/fsl-theme';
+import { toFlatTokens } from '@ttoss/fsl-theme/css';
+
+import { mergeDeep } from './overrides';
+
 /**
  * Palette helpers for the Theme Lab — WCAG contrast math and the curated
  * text/background pairs the Studio surfaces ambiently (PRD F2.6).
@@ -150,4 +155,37 @@ export const computeContrast = (
   }
 
   return results;
+};
+
+export interface ThemeContrast {
+  light: ContrastResult[];
+  /** Empty when the bundle opted out of an alternate mode. */
+  dark: ContrastResult[];
+}
+
+/**
+ * Contrast for both modes of a bundle (PRD F2.6, dark follow-up). The dark
+ * tokens are the base with the alternate's semantic remaps merged on top —
+ * the same projection `getThemeStylesContent` emits for the dark selector.
+ * `lightFlat` is the pre-resolved light map (shared with broken-ref
+ * detection, so each edit resolves the base once).
+ */
+export const computeThemeContrast = (
+  bundle: ThemeBundle,
+  lightFlat: Record<string, string | number>
+): ThemeContrast => {
+  const { alternate } = bundle;
+  return {
+    light: computeContrast(lightFlat),
+    dark: alternate
+      ? computeContrast(
+          toFlatTokens(
+            mergeDeep(
+              bundle.base as unknown as Record<string, unknown>,
+              alternate as unknown as Record<string, unknown>
+            ) as unknown as ThemeBundle['base']
+          )
+        )
+      : [],
+  };
 };

--- a/docs/fsl-studio/src/studio/theme/presets.ts
+++ b/docs/fsl-studio/src/studio/theme/presets.ts
@@ -1,0 +1,293 @@
+import {
+  bruttal,
+  createTheme,
+  type DeepPartial,
+  type ThemeBrief,
+  type ThemeBundle,
+  type ThemeTokens,
+} from '@ttoss/fsl-theme';
+
+/**
+ * Theme starting presets (PRD F2.4): the base foundation, the built-in
+ * `bruttal` bundle, and Studio-authored starting points inspired by the
+ * style-references library (`docs/website/docs/design/style-references`).
+ *
+ * The referenced style docs (minimalism, neobrutalism, glass, 90s) are still
+ * stubs, so these presets are deliberately conservative: a brand color scale
+ * plus a handful of semantic remaps that carry each style's clearest
+ * token-layer signature (radii, elevation, border weight) — never a parallel
+ * vocabulary, never recipe-layer effects (recorded in PRD §14). Each carries
+ * a `ThemeBrief` so the design intent ships with the bundle.
+ */
+export type PresetId =
+  | 'base'
+  | 'bruttal'
+  | 'minimalist'
+  | 'neobrutalism'
+  | 'glass'
+  | 'nineties';
+
+export interface PresetSpec {
+  id: PresetId;
+  label: string;
+  description: string;
+}
+
+export const PRESETS: readonly PresetSpec[] = [
+  {
+    id: 'base',
+    label: 'Base',
+    description:
+      'The default FSL foundation — light base with a dark alternate.',
+  },
+  {
+    id: 'bruttal',
+    label: 'Bruttal',
+    description: 'The built-in high-contrast, expressive brand theme.',
+  },
+  {
+    id: 'minimalist',
+    label: 'Minimalist',
+    description:
+      'Quiet slate brand, tight radii, flat cards — a starting point inspired by the minimalism style reference.',
+  },
+  {
+    id: 'neobrutalism',
+    label: 'Neobrutalism',
+    description:
+      'Vivid violet brand, sharp corners, thick borders, no shadows — a starting point inspired by the neobrutalism style reference.',
+  },
+  {
+    id: 'glass',
+    label: 'Glass',
+    description:
+      'Deep sky brand, generous radii, lifted surfaces — a starting point inspired by the glass style reference.',
+  },
+  {
+    id: 'nineties',
+    label: '90s',
+    description:
+      'Saturated primary blue, square corners, bold borders — a starting point inspired by the 90s style reference.',
+  },
+];
+
+interface AuthoredPreset {
+  overrides: DeepPartial<ThemeTokens>;
+  brief: ThemeBrief;
+}
+
+/**
+ * Studio-authored preset definitions. Brand `500` steps are chosen to keep
+ * ≥ 4.5:1 against white so filled accent surfaces stay WCAG AA (the same
+ * discipline `bruttal` documents for its own brand scale).
+ */
+export const AUTHORED_PRESETS: Partial<Record<PresetId, AuthoredPreset>> = {
+  minimalist: {
+    overrides: {
+      core: {
+        colors: {
+          brand: {
+            50: '#f8fafc',
+            100: '#f1f5f9',
+            200: '#e2e8f0',
+            300: '#cbd5e1',
+            400: '#94a3b8',
+            500: '#475569',
+            600: '#334155',
+            700: '#1e293b',
+            800: '#0f172a',
+            900: '#020617',
+          },
+        },
+      },
+      semantic: {
+        radii: {
+          control: '{core.radii.sm}',
+          surface: '{core.radii.sm}',
+        },
+        elevation: {
+          surface: {
+            raised: '{core.elevation.level.0}',
+          },
+        },
+      },
+    },
+    brief: {
+      name: 'minimalist',
+      purpose: 'quiet, content-first starting point',
+      primaryPosture: 'calm',
+      densityProfile: 'comfortable',
+      brandEnergy: 'quiet',
+      surfaceModel: 'flat',
+      accessibilityTarget: 'AA',
+    },
+  },
+
+  neobrutalism: {
+    overrides: {
+      core: {
+        colors: {
+          brand: {
+            50: '#f5f3ff',
+            100: '#ede9fe',
+            200: '#ddd6fe',
+            300: '#c4b5fd',
+            400: '#8b5cf6',
+            500: '#6d28d9',
+            600: '#5b21b6',
+            700: '#4c1d95',
+            800: '#3b0764',
+            900: '#2e1065',
+          },
+        },
+        border: {
+          width: {
+            default: '2px',
+            selected: '3px',
+            focused: '3px',
+          },
+        },
+      },
+      semantic: {
+        radii: {
+          control: '{core.radii.none}',
+          surface: '{core.radii.none}',
+        },
+        elevation: {
+          surface: {
+            flat: '{core.elevation.level.0}',
+            raised: '{core.elevation.level.0}',
+            overlay: '{core.elevation.level.0}',
+            blocking: '{core.elevation.level.0}',
+          },
+        },
+      },
+    },
+    brief: {
+      name: 'neobrutalism',
+      purpose: 'loud, raw, high-contrast starting point',
+      primaryPosture: 'expressive',
+      densityProfile: 'balanced',
+      brandEnergy: 'expressive',
+      surfaceModel: 'flat',
+      accessibilityTarget: 'AA',
+    },
+  },
+
+  glass: {
+    overrides: {
+      core: {
+        colors: {
+          brand: {
+            50: '#f0f9ff',
+            100: '#e0f2fe',
+            200: '#bae6fd',
+            300: '#7dd3fc',
+            400: '#38bdf8',
+            500: '#0369a1',
+            600: '#075985',
+            700: '#0c4a6e',
+            800: '#082f49',
+            900: '#05202f',
+          },
+        },
+      },
+      semantic: {
+        radii: {
+          control: '{core.radii.lg}',
+          surface: '{core.radii.xl}',
+        },
+        elevation: {
+          surface: {
+            raised: '{core.elevation.level.2}',
+            overlay: '{core.elevation.level.3}',
+          },
+        },
+      },
+    },
+    brief: {
+      name: 'glass',
+      purpose: 'soft, layered, airy starting point',
+      primaryPosture: 'premium',
+      densityProfile: 'comfortable',
+      brandEnergy: 'balanced',
+      surfaceModel: 'layered',
+      accessibilityTarget: 'AA',
+    },
+  },
+
+  nineties: {
+    overrides: {
+      core: {
+        colors: {
+          brand: {
+            50: '#ececff',
+            100: '#d6d6ff',
+            200: '#adadff',
+            300: '#8585ff',
+            400: '#4d4dff',
+            500: '#2424d6',
+            600: '#1d1db8',
+            700: '#17179a',
+            800: '#0f0f6b',
+            900: '#08083d',
+          },
+        },
+        border: {
+          width: {
+            default: '2px',
+          },
+        },
+      },
+      semantic: {
+        radii: {
+          control: '{core.radii.none}',
+          surface: '{core.radii.none}',
+        },
+        elevation: {
+          surface: {
+            flat: '{core.elevation.level.0}',
+            raised: '{core.elevation.level.0}',
+            overlay: '{core.elevation.level.0}',
+            blocking: '{core.elevation.level.0}',
+          },
+        },
+      },
+    },
+    brief: {
+      name: 'nineties',
+      purpose: 'retro primary-blue starting point',
+      primaryPosture: 'expressive',
+      densityProfile: 'compact',
+      brandEnergy: 'expressive',
+      surfaceModel: 'flat',
+      accessibilityTarget: 'AA',
+    },
+  },
+};
+
+const bundleCache = new Map<PresetId, ThemeBundle>();
+
+/** The unedited bundle for a preset — also the "fallback" chrome theme. */
+export const presetBundle = (preset: PresetId): ThemeBundle => {
+  const cached = bundleCache.get(preset);
+  if (cached) {
+    return cached;
+  }
+
+  const authored = AUTHORED_PRESETS[preset];
+  const bundle = authored
+    ? createTheme({ overrides: authored.overrides, brief: authored.brief })
+    : preset === 'bruttal'
+      ? bruttal
+      : createTheme();
+
+  bundleCache.set(preset, bundle);
+  return bundle;
+};
+
+export const findPreset = (id: string): PresetSpec | undefined => {
+  return PRESETS.find((preset) => {
+    return preset.id === id;
+  });
+};

--- a/docs/fsl-studio/src/studio/theme/themeStore.tsx
+++ b/docs/fsl-studio/src/studio/theme/themeStore.tsx
@@ -4,46 +4,47 @@ import * as React from 'react';
 
 import {
   buildBundle,
-  type ColorOverrides,
-  presetBundle,
-  type PresetId,
-  removeColorLeaf,
-  setColorLeaf,
+  removeToken,
+  setToken,
+  type TokenOverrides,
 } from './overrides';
-import { computeContrast, type ContrastResult } from './palette';
+import { computeThemeContrast, type ThemeContrast } from './palette';
+import { presetBundle, type PresetId } from './presets';
+import {
+  coreFamilies,
+  findBrokenRefs,
+  semanticFamilies,
+  type TokenFamily,
+} from './tokenTree';
 
 export type Origin = 'manual' | 'ai';
 
 /** A hue's editable scale, read from the active preset's core palette. */
 export interface PaletteScale {
   hue: string;
-  /** Ordered steps with their preset (unedited) hex value. */
+  /** Ordered steps with their preset (unedited) value. */
   steps: { step: string; base: string }[];
 }
 
 export interface ThemeReducerState {
   preset: PresetId;
-  colors: ColorOverrides;
+  overrides: TokenOverrides;
   origins: Record<string, Origin>;
   applyToStudio: boolean;
 }
 
 export type ThemeAction =
-  | { type: 'setColor'; hue: string; step: string; value: string }
-  | { type: 'revertColor'; hue: string; step: string }
+  | { type: 'setToken'; path: string; value: string }
+  | { type: 'revertToken'; path: string }
   | { type: 'resetAll' }
   | { type: 'setPreset'; preset: PresetId }
   | { type: 'setApplyToStudio'; value: boolean };
 
 export const initialThemeState: ThemeReducerState = {
   preset: 'base',
-  colors: {},
+  overrides: {},
   origins: {},
   applyToStudio: false,
-};
-
-const pathKey = (hue: string, step: string) => {
-  return `${hue}.${step}`;
 };
 
 export const themeReducer = (
@@ -51,36 +52,28 @@ export const themeReducer = (
   action: ThemeAction
 ): ThemeReducerState => {
   switch (action.type) {
-    case 'setColor': {
+    case 'setToken': {
       return {
         ...state,
-        colors: setColorLeaf(
-          state.colors,
-          action.hue,
-          action.step,
-          action.value
-        ),
-        origins: {
-          ...state.origins,
-          [pathKey(action.hue, action.step)]: 'manual',
-        },
+        overrides: setToken(state.overrides, action.path, action.value),
+        origins: { ...state.origins, [action.path]: 'manual' },
       };
     }
-    case 'revertColor': {
+    case 'revertToken': {
       const origins = { ...state.origins };
-      delete origins[pathKey(action.hue, action.step)];
+      delete origins[action.path];
       return {
         ...state,
-        colors: removeColorLeaf(state.colors, action.hue, action.step),
+        overrides: removeToken(state.overrides, action.path),
         origins,
       };
     }
     case 'resetAll': {
-      return { ...state, colors: {}, origins: {} };
+      return { ...state, overrides: {}, origins: {} };
     }
     case 'setPreset': {
       // Switching preset starts a fresh diff against that preset (PRD §14).
-      return { ...state, preset: action.preset, colors: {}, origins: {} };
+      return { ...state, preset: action.preset, overrides: {}, origins: {} };
     }
     case 'setApplyToStudio': {
       return { ...state, applyToStudio: action.value };
@@ -91,9 +84,11 @@ export const themeReducer = (
   }
 };
 
+export type { ThemeContrast };
+
 export interface ThemeStore {
   preset: PresetId;
-  colors: ColorOverrides;
+  overrides: TokenOverrides;
   applyToStudio: boolean;
   /** The edited bundle — drives the stage always, and the chrome when applied. */
   liveBundle: ThemeBundle;
@@ -101,11 +96,17 @@ export interface ThemeStore {
   fallbackBundle: ThemeBundle;
   /** Editable palette (hues + steps) read from the active preset. */
   palette: PaletteScale[];
-  /** Curated contrast results for the live theme (light mode). */
-  contrast: ContrastResult[];
-  origin: (hue: string, step: string) => Origin | undefined;
-  setColor: (hue: string, step: string, value: string) => void;
-  revertColor: (hue: string, step: string) => void;
+  /** Curated contrast results for the live theme, light and dark. */
+  contrast: ThemeContrast;
+  /** Flat paths whose resolved value still contains a broken `{ref}`. */
+  brokenRefs: string[];
+  /** Semantic families (raw leaves) of the active preset, for the navigator. */
+  semanticTree: TokenFamily[];
+  /** Core families (colors excluded) of the active preset. */
+  coreTree: TokenFamily[];
+  origin: (path: string) => Origin | undefined;
+  setToken: (path: string, value: string) => void;
+  revertToken: (path: string) => void;
   resetAll: () => void;
   setPreset: (preset: PresetId) => void;
   setApplyToStudio: (value: boolean) => void;
@@ -135,44 +136,69 @@ const buildPalette = (bundle: ThemeBundle): PaletteScale[] => {
 
 export const ThemeStoreProvider = ({
   children,
+  initial,
 }: {
   children: React.ReactNode;
+  /** Boot-time state (URL fork / draft restore, PRD F1.2/F1.3). */
+  initial?: Partial<ThemeReducerState>;
 }) => {
-  const [state, dispatch] = React.useReducer(themeReducer, initialThemeState);
+  const [state, dispatch] = React.useReducer(themeReducer, {
+    ...initialThemeState,
+    ...initial,
+  });
 
   const fallbackBundle = React.useMemo(() => {
     return presetBundle(state.preset);
   }, [state.preset]);
 
   const liveBundle = React.useMemo(() => {
-    return buildBundle(state.preset, state.colors);
-  }, [state.preset, state.colors]);
+    return buildBundle(state.preset, state.overrides);
+  }, [state.preset, state.overrides]);
 
   const palette = React.useMemo(() => {
     return buildPalette(fallbackBundle);
   }, [fallbackBundle]);
 
-  const contrast = React.useMemo(() => {
-    return computeContrast(toFlatTokens(liveBundle.base));
+  const semanticTree = React.useMemo(() => {
+    return semanticFamilies(fallbackBundle);
+  }, [fallbackBundle]);
+
+  const coreTree = React.useMemo(() => {
+    return coreFamilies(fallbackBundle);
+  }, [fallbackBundle]);
+
+  const lightFlat = React.useMemo(() => {
+    return toFlatTokens(liveBundle.base);
   }, [liveBundle]);
+
+  const contrast = React.useMemo<ThemeContrast>(() => {
+    return computeThemeContrast(liveBundle, lightFlat);
+  }, [liveBundle, lightFlat]);
+
+  const brokenRefs = React.useMemo(() => {
+    return findBrokenRefs(lightFlat);
+  }, [lightFlat]);
 
   const value = React.useMemo<ThemeStore>(() => {
     return {
       preset: state.preset,
-      colors: state.colors,
+      overrides: state.overrides,
       applyToStudio: state.applyToStudio,
       liveBundle,
       fallbackBundle,
       palette,
       contrast,
-      origin: (hue, step) => {
-        return state.origins[pathKey(hue, step)];
+      brokenRefs,
+      semanticTree,
+      coreTree,
+      origin: (path) => {
+        return state.origins[path];
       },
-      setColor: (hue, step, colorValue) => {
-        return dispatch({ type: 'setColor', hue, step, value: colorValue });
+      setToken: (path, tokenValue) => {
+        return dispatch({ type: 'setToken', path, value: tokenValue });
       },
-      revertColor: (hue, step) => {
-        return dispatch({ type: 'revertColor', hue, step });
+      revertToken: (path) => {
+        return dispatch({ type: 'revertToken', path });
       },
       resetAll: () => {
         return dispatch({ type: 'resetAll' });
@@ -184,7 +210,16 @@ export const ThemeStoreProvider = ({
         return dispatch({ type: 'setApplyToStudio', value: v });
       },
     };
-  }, [state, liveBundle, fallbackBundle, palette, contrast]);
+  }, [
+    state,
+    liveBundle,
+    fallbackBundle,
+    palette,
+    contrast,
+    brokenRefs,
+    semanticTree,
+    coreTree,
+  ]);
 
   return (
     <ThemeStoreCtx.Provider value={value}>{children}</ThemeStoreCtx.Provider>

--- a/docs/fsl-studio/src/studio/theme/themeStore.tsx
+++ b/docs/fsl-studio/src/studio/theme/themeStore.tsx
@@ -89,6 +89,8 @@ export type { ThemeContrast };
 export interface ThemeStore {
   preset: PresetId;
   overrides: TokenOverrides;
+  /** Per-path edit origin map (✎ manual / ✦ AI) — serialized with the session. */
+  origins: Record<string, Origin>;
   applyToStudio: boolean;
   /** The edited bundle — drives the stage always, and the chrome when applied. */
   liveBundle: ThemeBundle;
@@ -183,6 +185,7 @@ export const ThemeStoreProvider = ({
     return {
       preset: state.preset,
       overrides: state.overrides,
+      origins: state.origins,
       applyToStudio: state.applyToStudio,
       liveBundle,
       fallbackBundle,

--- a/docs/fsl-studio/src/studio/theme/tokenTree.ts
+++ b/docs/fsl-studio/src/studio/theme/tokenTree.ts
@@ -1,0 +1,155 @@
+import { type ThemeBundle } from '@ttoss/fsl-theme';
+import { type FlatTokenMap } from '@ttoss/fsl-theme/css';
+
+/**
+ * Token-tree projection for the Theme Lab navigator (PRD F2.1).
+ *
+ * The navigator opens at the **semantic** layer grouped by family; `core` is
+ * one level down, on demand (progressive disclosure — never ~500 leaves at
+ * once). This module derives that tree from a theme bundle: families in the
+ * PRD's canonical order, semantic colors further grouped by ux context, and
+ * every leaf carrying its **raw** value (`{ref}` strings included) — the raw
+ * value is what a remap edits (PRD F2.2).
+ */
+
+export interface TokenLeaf {
+  /** Flat dotted path, e.g. `semantic.radii.control`. */
+  path: string;
+  /** Raw authored value — a `{ref}` string or a literal. */
+  raw: string;
+}
+
+export interface TokenGroup {
+  /** Sub-group label (ux context for semantic colors), '' for a flat family. */
+  label: string;
+  leaves: TokenLeaf[];
+}
+
+export interface TokenFamily {
+  family: string;
+  groups: TokenGroup[];
+  leafCount: number;
+}
+
+/** Flatten a nested token object into raw leaves, sorted by path. */
+export const flattenLeaves = (
+  node: Record<string, unknown>,
+  prefix: string
+): TokenLeaf[] => {
+  const leaves: TokenLeaf[] = [];
+  for (const key of Object.keys(node).sort()) {
+    const value = node[key];
+    const path = `${prefix}.${key}`;
+    if (typeof value === 'object' && value !== null) {
+      leaves.push(...flattenLeaves(value as Record<string, unknown>, path));
+    } else if (value !== undefined) {
+      leaves.push({ path, raw: String(value) });
+    }
+  }
+  return leaves;
+};
+
+/** Canonical semantic family order (PRD F2.1). */
+export const SEMANTIC_FAMILIES = [
+  'colors',
+  'text',
+  'spacing',
+  'sizing',
+  'radii',
+  'border',
+  'focus',
+  'elevation',
+  'opacity',
+  'overlay',
+  'motion',
+  'zIndex',
+] as const;
+
+const groupByFirstSegment = (
+  leaves: TokenLeaf[],
+  prefixLength: number
+): TokenGroup[] => {
+  const byLabel = new Map<string, TokenLeaf[]>();
+  for (const leaf of leaves) {
+    const label = leaf.path.split('.')[prefixLength];
+    const bucket = byLabel.get(label);
+    if (bucket) {
+      bucket.push(leaf);
+    } else {
+      byLabel.set(label, [leaf]);
+    }
+  }
+  return [...byLabel.entries()].map(([label, groupLeaves]) => {
+    return { label, leaves: groupLeaves };
+  });
+};
+
+const toFamily = (
+  family: string,
+  node: Record<string, unknown>,
+  layer: 'semantic' | 'core'
+): TokenFamily => {
+  const leaves = flattenLeaves(node, `${layer}.${family}`);
+  // Colors are by far the largest family — group them one level deeper
+  // (ux context for semantic, hue for core) so no group dumps hundreds of
+  // leaves at once (Miller/chunking, PRD §6.5).
+  const groups =
+    family === 'colors'
+      ? groupByFirstSegment(leaves, 2)
+      : [{ label: '', leaves }];
+  return { family, groups, leafCount: leaves.length };
+};
+
+/**
+ * The semantic layer of a bundle as ordered families. The `dataviz` extension
+ * is not part of the F2.1 family list and is omitted.
+ */
+export const semanticFamilies = (bundle: ThemeBundle): TokenFamily[] => {
+  const semantic = bundle.base.semantic as unknown as Record<string, unknown>;
+  return SEMANTIC_FAMILIES.filter((family) => {
+    return typeof semantic[family] === 'object' && semantic[family] !== null;
+  }).map((family) => {
+    return toFamily(
+      family,
+      semantic[family] as Record<string, unknown>,
+      'semantic'
+    );
+  });
+};
+
+/**
+ * The core layer as families, colors excluded — core color scales get the
+ * dedicated picker editor (the SC-1 "wow" surface), not generic rows.
+ */
+export const coreFamilies = (bundle: ThemeBundle): TokenFamily[] => {
+  const core = bundle.base.core as unknown as Record<string, unknown>;
+  return Object.keys(core)
+    .sort()
+    .filter((family) => {
+      return (
+        family !== 'colors' &&
+        family !== 'dataviz' &&
+        typeof core[family] === 'object' &&
+        core[family] !== null
+      );
+    })
+    .map((family) => {
+      return toFamily(family, core[family] as Record<string, unknown>, 'core');
+    });
+};
+
+/**
+ * Broken references in a **resolved** flat map (PRD F2.2 live validation).
+ * `toFlatTokens` leaves unresolvable refs (missing target or circular) as
+ * `{path}` in the output, so any surviving brace expression marks a broken
+ * token — the same mechanical check `validateRefs` performs, but readable as
+ * data instead of console output (recorded in PRD §14).
+ */
+export const findBrokenRefs = (flat: FlatTokenMap): string[] => {
+  return Object.keys(flat)
+    .filter((key) => {
+      const value = flat[key];
+      return typeof value === 'string' && /\{[^}]+\}/.test(value);
+    })
+    .sort();
+};

--- a/docs/fsl-studio/tests/unit/setupTests.tsx
+++ b/docs/fsl-studio/tests/unit/setupTests.tsx
@@ -7,6 +7,13 @@
  */
 import '@ttoss/test-utils/react';
 
+// The session layer projects state onto the URL hash and localStorage
+// drafts (PRD F1.2/F1.3); both persist across tests in a file, so reset.
+beforeEach(() => {
+  window.localStorage.clear();
+  window.history.replaceState(null, '', '/');
+});
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query: string) => {

--- a/docs/fsl-studio/tests/unit/tests/App.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/App.test.tsx
@@ -1,9 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'src/App';
+import { Stage } from 'src/studio/Stage';
+import { ThemeStoreProvider } from 'src/studio/theme/themeStore';
+
+/** Boot into the studio (Theme lens) through the task-first home. */
+const renderStudio = () => {
+  const utils = render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Create a theme/ }));
+  return utils;
+};
 
 test('renders the shell with brand, lens switcher, and side panels', () => {
-  render(<App />);
+  renderStudio();
 
   expect(screen.getByText('FSL Studio')).toBeInTheDocument();
 
@@ -22,7 +31,7 @@ test('renders the shell with brand, lens switcher, and side panels', () => {
 });
 
 test('stage renders fsl-ui components in light and dark panes', () => {
-  render(<App />);
+  renderStudio();
 
   const light = screen.getByTestId('stage-pane-light');
   const dark = screen.getByTestId('stage-pane-dark');
@@ -43,7 +52,7 @@ test('stage renders fsl-ui components in light and dark panes', () => {
 
 test('switching lens swaps the panels and the stage subject, keeping the frame', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderStudio();
 
   const navigator = screen.getByRole('complementary', { name: 'Navigator' });
   const themeCopy = navigator.textContent;
@@ -60,7 +69,7 @@ test('switching lens swaps the panels and the stage subject, keeping the frame',
 
 test('lens selection cannot be emptied (one lens is always active)', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderStudio();
 
   const themeLens = screen.getByRole('radio', { name: 'Theme' });
   expect(themeLens).toHaveAttribute('aria-checked', 'true');
@@ -71,11 +80,25 @@ test('lens selection cannot be emptied (one lens is always active)', async () =>
 });
 
 test('stage theme CSS is emitted element-scoped for the panes', () => {
-  const { container } = render(<App />);
+  const { container } = renderStudio();
 
   const stageStyle = container.querySelector('.stage style');
   expect(stageStyle?.textContent).toContain(
     '[data-tt-theme="fsl-studio-stage"]'
   );
   expect(stageStyle?.textContent).toContain('[data-tt-mode="dark"]');
+});
+
+test('the stage renders without a toolbar (optional prop)', () => {
+  const { container } = render(
+    <ThemeStoreProvider>
+      <Stage
+        renderSubject={() => {
+          return <span>subject</span>;
+        }}
+      />
+    </ThemeStoreProvider>
+  );
+  expect(container.querySelector('.stage-toolbar')).toBeNull();
+  expect(screen.getAllByText('subject')).toHaveLength(2);
 });

--- a/docs/fsl-studio/tests/unit/tests/Axe.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/Axe.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { App } from 'src/App';
+
+expect.extend(toHaveNoViolations);
+
+/**
+ * Axe-clean CI gate (PRD F1 AC / §8). Two rules are excluded, each for a
+ * documented reason:
+ *
+ * - `color-contrast`: jsdom performs no layout or painting, so axe cannot
+ *   compute it; contrast is instead checked as data by the Theme Lab's own
+ *   WCAG math (palette.test.ts) and by fsl-ui upstream.
+ * - `aria-allowed-attr`: React Aria's Meter renders the standard fallback
+ *   `role="meter progressbar"`, which axe misreads as disallowing the
+ *   aria-value* attributes. Upstream RAC pattern, not a Studio defect —
+ *   reported per PRD §2 (recorded in §14).
+ */
+const runAxe = (container: Element) => {
+  return axe(container, {
+    rules: {
+      'color-contrast': { enabled: false },
+      'aria-allowed-attr': { enabled: false },
+    },
+  });
+};
+
+jest.setTimeout(30000);
+
+test('home is axe clean', async () => {
+  const { container } = render(<App />);
+  expect(await runAxe(container)).toHaveNoViolations();
+});
+
+test('the theme lens is axe clean', async () => {
+  const { container } = render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Create a theme/ }));
+  expect(await runAxe(container)).toHaveNoViolations();
+});
+
+test('the components lens is axe clean', async () => {
+  const { container } = render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Explore components/ }));
+  expect(await runAxe(container)).toHaveNoViolations();
+});
+
+test('the open command palette is axe clean', async () => {
+  const { container } = render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Create a theme/ }));
+  fireEvent.click(screen.getByRole('button', { name: 'Open command palette' }));
+  expect(await runAxe(container)).toHaveNoViolations();
+});

--- a/docs/fsl-studio/tests/unit/tests/CommandPalette.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/CommandPalette.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'src/App';
+
+const startThemeTask = () => {
+  render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Create a theme/ }));
+};
+
+const openPalette = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(
+    screen.getByRole('button', { name: 'Open command palette' })
+  );
+  return screen.getByRole('combobox', { name: 'Search commands' });
+};
+
+test('⌘K toggles the palette; Escape closes it', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'k', metaKey: true });
+  expect(
+    screen.getByRole('dialog', { name: 'Command palette' })
+  ).toBeInTheDocument();
+
+  // ⌘K again closes (toggle).
+  fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+  fireEvent.keyDown(window, { key: 'k', metaKey: true });
+  await user.keyboard('{Escape}');
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('filtering + Enter runs a command (lens switch)', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  const input = await openPalette(user);
+  await user.type(input, 'lens: components');
+  await user.keyboard('{Enter}');
+
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: 'Components' })).toHaveAttribute(
+    'aria-checked',
+    'true'
+  );
+});
+
+test('arrow keys move the active option; clamped at both ends', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  const input = await openPalette(user);
+  await user.type(input, 'lens:');
+  // Three lens commands; walk down past the end and back up past the start.
+  await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}');
+  expect(input).toHaveAttribute('aria-activedescendant', 'palette-option-2');
+  await user.keyboard('{ArrowUp}{ArrowUp}{ArrowUp}{ArrowUp}');
+  expect(input).toHaveAttribute('aria-activedescendant', 'palette-option-0');
+});
+
+test('clicking an option runs it; a component command switches lens too', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  await openPalette(user);
+  await user.click(screen.getByRole('option', { name: 'Component: Button' }));
+
+  expect(screen.getByRole('radio', { name: 'Components' })).toHaveAttribute(
+    'aria-checked',
+    'true'
+  );
+  // The Button preview is on stage in both panes.
+  expect(screen.getAllByRole('button', { name: 'Save changes' })).toHaveLength(
+    2
+  );
+});
+
+test('page and preset commands are available', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  // Preset first, while the Theme lens (with the preset picker) is visible.
+  let input = await openPalette(user);
+  await user.type(input, 'preset: bruttal');
+  await user.keyboard('{Enter}');
+  expect(screen.getByRole('button', { name: 'Bruttal' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+
+  // The page command also switches to the Components lens.
+  input = await openPalette(user);
+  await user.type(input, 'page: wizard');
+  await user.keyboard('{Enter}');
+  expect(screen.getAllByText(/tell us about your project/)).toHaveLength(2);
+});
+
+test('an altitude command moves the stage', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  const input = await openPalette(user);
+  await user.type(input, 'stage: grid');
+  await user.keyboard('{Enter}');
+  expect(screen.getByRole('radio', { name: 'Grid' })).toHaveAttribute(
+    'aria-checked',
+    'true'
+  );
+});
+
+test('the apply-to-Studio command toggles and re-titles', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  let input = await openPalette(user);
+  await user.type(input, 'apply the theme');
+  await user.keyboard('{Enter}');
+  expect(
+    screen.getByRole('checkbox', { name: /Apply this theme to the Studio/ })
+  ).toBeChecked();
+
+  input = await openPalette(user);
+  await user.type(input, 'stop applying');
+  await user.keyboard('{Enter}');
+  expect(
+    screen.getByRole('checkbox', { name: /Apply this theme to the Studio/ })
+  ).not.toBeChecked();
+});
+
+test('the go-home command leaves the studio', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  const input = await openPalette(user);
+  await user.type(input, 'go home');
+  await user.keyboard('{Enter}');
+  expect(screen.getByText('What do you want to do?')).toBeInTheDocument();
+});
+
+test('no match shows the teaching empty state; Enter is a no-op', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  const input = await openPalette(user);
+  await user.type(input, 'zzz-nothing');
+  expect(screen.getByText(/No matching command/)).toBeInTheDocument();
+  expect(input).not.toHaveAttribute('aria-activedescendant');
+  await user.keyboard('{Enter}');
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('clicking the backdrop closes; clicking inside does not', async () => {
+  const user = userEvent.setup();
+  startThemeTask();
+
+  const input = await openPalette(user);
+  await user.click(input);
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+  await user.click(screen.getByTestId('palette-overlay'));
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});

--- a/docs/fsl-studio/tests/unit/tests/ComponentLab.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/ComponentLab.test.tsx
@@ -13,7 +13,7 @@ import {
 const openComponentsLens = async () => {
   const user = userEvent.setup();
   render(<App />);
-  await user.click(screen.getByRole('radio', { name: 'Components' }));
+  await user.click(screen.getByRole('button', { name: /Explore components/ }));
   return user;
 };
 
@@ -114,7 +114,9 @@ test('selecting an example page renders it on the stage', async () => {
 test('the Generate lens shows its placeholder panels', async () => {
   const user = userEvent.setup();
   render(<App />);
-  await user.click(screen.getByRole('radio', { name: 'Generate' }));
+  await user.click(
+    screen.getByRole('button', { name: /Generate a composite/ })
+  );
 
   expect(
     within(navigator()).getByText(/session compositions will live here/)

--- a/docs/fsl-studio/tests/unit/tests/ThemeLab.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/ThemeLab.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { App } from 'src/App';
+import { ThemeInspector } from 'src/studio/theme/ThemeInspector';
+import { ThemeStoreProvider } from 'src/studio/theme/themeStore';
 
 const stageStyle = (container: HTMLElement): string => {
   return container.querySelector('.stage style')?.textContent ?? '';
@@ -112,11 +114,14 @@ test('apply-to-Studio toggle exposes the safe-fallback control', async () => {
   expect(toggle).not.toBeChecked();
 });
 
-test('contrast section surfaces curated pairs ambiently', () => {
+test('contrast section surfaces curated pairs for light and dark', () => {
   render(<App />);
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
-  expect(within(inspector).getByText('Accent action')).toBeInTheDocument();
-  expect(within(inspector).getByText('Surface')).toBeInTheDocument();
+  // Each curated pair is checked in both modes (F2.6 dark follow-up done).
+  expect(within(inspector).getByText('Light')).toBeInTheDocument();
+  expect(within(inspector).getByText('Dark')).toBeInTheDocument();
+  expect(within(inspector).getAllByText('Accent action')).toHaveLength(2);
+  expect(within(inspector).getAllByText('Surface')).toHaveLength(2);
 });
 
 test('export peak ships all three formats', async () => {
@@ -201,6 +206,181 @@ describe('export copy', () => {
       await screen.findByRole('button', { name: 'Copy' })
     ).toBeInTheDocument();
   });
+});
+
+describe('semantic layer navigator (F2.1/F2.2)', () => {
+  test('semantic families disclose leaves; a remap re-derives the theme', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<App />);
+
+    // Semantic radii family: 3 leaves (control, surface, round).
+    await user.click(screen.getByRole('button', { name: 'radii · 3' }));
+    const control = screen.getByLabelText('semantic.radii.control');
+    expect(control).toHaveValue('{core.radii.md}');
+
+    fireEvent.change(control, { target: { value: '{core.radii.none}' } });
+
+    // The remap flows into the stage CSS same-frame (radius collapses to 0).
+    expect(stageStyle(container)).toContain('0px');
+    const inspector = screen.getByRole('complementary', { name: 'Inspector' });
+    expect(within(inspector).getByText('Changes (1)')).toBeInTheDocument();
+    expect(
+      within(inspector).getByText(/semantic\.radii\.control/)
+    ).toBeInTheDocument();
+  });
+
+  test('semantic colors group by ux context before leaves render', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Two "colors" disclosures exist (semantic family, core scales); the
+    // semantic one comes first in DOM order.
+    const [semanticColors] = screen.getAllByRole('button', {
+      name: /^colors · \d+$/,
+    });
+    await user.click(semanticColors);
+    // Contexts appear as sub-disclosures; leaves are not rendered yet.
+    expect(
+      screen.getByRole('button', { name: /^action · \d+$/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(
+        'semantic.colors.action.accent.background.default'
+      )
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^action · \d+$/ }));
+    expect(
+      screen.getByLabelText('semantic.colors.action.accent.background.default')
+    ).toBeInTheDocument();
+  });
+
+  test('a token row reverts its own override', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'radii · 3' }));
+    const control = screen.getByLabelText('semantic.radii.control');
+    fireEvent.change(control, { target: { value: '{core.radii.none}' } });
+
+    await user.click(
+      screen.getByRole('button', { name: 'Revert semantic.radii.control' })
+    );
+    expect(screen.getByLabelText('semantic.radii.control')).toHaveValue(
+      '{core.radii.md}'
+    );
+  });
+
+  test('core families expose raw values one level down', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Core radii: 6 leaves (none, sm, md, lg, xl, full).
+    await user.click(screen.getByRole('button', { name: 'radii · 6' }));
+    const md = screen.getByLabelText('core.radii.md');
+    expect(md).toHaveValue('8px');
+
+    fireEvent.change(md, { target: { value: '10px' } });
+    const inspector = screen.getByRole('complementary', { name: 'Inspector' });
+    expect(within(inspector).getByText(/core\.radii\.md/)).toBeInTheDocument();
+  });
+});
+
+describe('broken refs: ambient validation + sanctioned escalation (F2.2)', () => {
+  const breakOneRef = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole('button', { name: 'radii · 3' }));
+    fireEvent.change(screen.getByLabelText('semantic.radii.control'), {
+      target: { value: '{core.radii.nope}' },
+    });
+  };
+
+  test('a broken remap surfaces ambiently: row badge + peripheral counter', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await breakOneRef(user);
+
+    // Badge on the offending navigator row…
+    expect(
+      screen.getByRole('img', { name: 'Broken reference' })
+    ).toBeInTheDocument();
+    // …and on its diff row…
+    expect(
+      screen.getByRole('img', {
+        name: 'Broken reference at semantic.radii.control',
+      })
+    ).toBeInTheDocument();
+    // …and the peripheral header counter. Never a modal, never a toast.
+    expect(screen.getByText('⚠ 1 ref error')).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+    // Two broken tokens pluralize the counter.
+    fireEvent.change(screen.getByLabelText('semantic.radii.surface'), {
+      target: { value: '{core.radii.nada}' },
+    });
+    expect(screen.getByText('⚠ 2 ref errors')).toBeInTheDocument();
+  });
+
+  test('exporting with broken refs goes through the escalation dialog', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await breakOneRef(user);
+    const inspector = screen.getByRole('complementary', { name: 'Inspector' });
+
+    await user.click(
+      within(inspector).getByRole('button', { name: 'Export theme' })
+    );
+    // The one sanctioned escalation (PRD §6.4-P2): a dialog, not a toast.
+    expect(screen.getByText('Broken token references')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Export anyway' }));
+    expect(screen.getByTestId('export-content')).toBeInTheDocument();
+  });
+
+  test('the escalation dialog pluralizes for multiple broken refs', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await breakOneRef(user);
+    fireEvent.change(screen.getByLabelText('semantic.radii.surface'), {
+      target: { value: '{core.radii.nada}' },
+    });
+    const inspector = screen.getByRole('complementary', { name: 'Inspector' });
+
+    await user.click(
+      within(inspector).getByRole('button', { name: 'Export theme' })
+    );
+    expect(screen.getByText(/2 tokens resolve/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Go back' }));
+  });
+
+  test('the escalation dialog can be declined', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await breakOneRef(user);
+    const inspector = screen.getByRole('complementary', { name: 'Inspector' });
+
+    await user.click(
+      within(inspector).getByRole('button', { name: 'Export theme' })
+    );
+    await user.click(screen.getByRole('button', { name: 'Go back' }));
+    expect(screen.queryByTestId('export-content')).not.toBeInTheDocument();
+  });
+});
+
+test('an AI-origin diff entry shows the ✦ marker', () => {
+  // Nothing in Phases 0–2 produces an AI edit; the marker activates with the
+  // Generate lens (Phase 4). The store already tracks origin, so render the
+  // inspector against a forked initial state carrying one.
+  render(
+    <ThemeStoreProvider
+      initial={{
+        overrides: { 'core.radii.md': '10px' },
+        origins: { 'core.radii.md': 'ai' },
+      }}
+    >
+      <ThemeInspector />
+    </ThemeStoreProvider>
+  );
+  expect(screen.getByText(/✦ core\.radii\.md/)).toBeInTheDocument();
 });
 
 test('editing via the native color input updates the theme', () => {

--- a/docs/fsl-studio/tests/unit/tests/ThemeLab.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/ThemeLab.test.tsx
@@ -8,8 +8,15 @@ const stageStyle = (container: HTMLElement): string => {
   return container.querySelector('.stage style')?.textContent ?? '';
 };
 
+/** Boot into the Theme lens through the task-first home (PRD §6.2). */
+const renderThemeLab = () => {
+  const utils = render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Create a theme/ }));
+  return utils;
+};
+
 test('editing the brand scale cascades to the stage (the wow)', () => {
-  const { container } = render(<App />);
+  const { container } = renderThemeLab();
 
   // Accent surfaces resolve to the brand color; before editing, the distinctive
   // value is absent from the stage CSS.
@@ -25,7 +32,7 @@ test('editing the brand scale cascades to the stage (the wow)', () => {
 
 test('a color edit shows in the change diff and reverts individually', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderThemeLab();
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
   expect(within(inspector).getByText(/No changes yet/)).toBeInTheDocument();
@@ -44,7 +51,7 @@ test('a color edit shows in the change diff and reverts individually', async () 
 
 test('reset all clears the diff', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderThemeLab();
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
   fireEvent.change(screen.getByLabelText('brand 500 hex'), {
@@ -63,7 +70,7 @@ test('reset all clears the diff', async () => {
 
 test('reverting via the diff row also works', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderThemeLab();
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
   fireEvent.change(screen.getByLabelText('brand 500 hex'), {
@@ -83,7 +90,7 @@ test('reverting via the diff row also works', async () => {
 
 test('switching preset starts a fresh diff', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderThemeLab();
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
   fireEvent.change(screen.getByLabelText('brand 500 hex'), {
@@ -97,7 +104,7 @@ test('switching preset starts a fresh diff', async () => {
 
 test('apply-to-Studio toggle exposes the safe-fallback control', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderThemeLab();
 
   const toggle = screen.getByRole('checkbox', {
     name: /Apply this theme to the Studio/,
@@ -115,7 +122,7 @@ test('apply-to-Studio toggle exposes the safe-fallback control', async () => {
 });
 
 test('contrast section surfaces curated pairs for light and dark', () => {
-  render(<App />);
+  renderThemeLab();
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
   // Each curated pair is checked in both modes (F2.6 dark follow-up done).
   expect(within(inspector).getByText('Light')).toBeInTheDocument();
@@ -126,7 +133,7 @@ test('contrast section surfaces curated pairs for light and dark', () => {
 
 test('export peak ships all three formats', async () => {
   const user = userEvent.setup();
-  render(<App />);
+  renderThemeLab();
   const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
   await user.click(
@@ -166,7 +173,7 @@ describe('export copy', () => {
   });
 
   const openExport = () => {
-    render(<App />);
+    renderThemeLab();
     const inspector = screen.getByRole('complementary', { name: 'Inspector' });
     fireEvent.click(
       within(inspector).getByRole('button', { name: 'Export theme' })
@@ -211,7 +218,7 @@ describe('export copy', () => {
 describe('semantic layer navigator (F2.1/F2.2)', () => {
   test('semantic families disclose leaves; a remap re-derives the theme', async () => {
     const user = userEvent.setup();
-    const { container } = render(<App />);
+    const { container } = renderThemeLab();
 
     // Semantic radii family: 3 leaves (control, surface, round).
     await user.click(screen.getByRole('button', { name: 'radii · 3' }));
@@ -231,7 +238,7 @@ describe('semantic layer navigator (F2.1/F2.2)', () => {
 
   test('semantic colors group by ux context before leaves render', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
 
     // Two "colors" disclosures exist (semantic family, core scales); the
     // semantic one comes first in DOM order.
@@ -257,7 +264,7 @@ describe('semantic layer navigator (F2.1/F2.2)', () => {
 
   test('a token row reverts its own override', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
 
     await user.click(screen.getByRole('button', { name: 'radii · 3' }));
     const control = screen.getByLabelText('semantic.radii.control');
@@ -273,7 +280,7 @@ describe('semantic layer navigator (F2.1/F2.2)', () => {
 
   test('core families expose raw values one level down', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
 
     // Core radii: 6 leaves (none, sm, md, lg, xl, full).
     await user.click(screen.getByRole('button', { name: 'radii · 6' }));
@@ -296,7 +303,7 @@ describe('broken refs: ambient validation + sanctioned escalation (F2.2)', () =>
 
   test('a broken remap surfaces ambiently: row badge + peripheral counter', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
     await breakOneRef(user);
 
     // Badge on the offending navigator row…
@@ -322,7 +329,7 @@ describe('broken refs: ambient validation + sanctioned escalation (F2.2)', () =>
 
   test('exporting with broken refs goes through the escalation dialog', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
     await breakOneRef(user);
     const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
@@ -338,7 +345,7 @@ describe('broken refs: ambient validation + sanctioned escalation (F2.2)', () =>
 
   test('the escalation dialog pluralizes for multiple broken refs', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
     await breakOneRef(user);
     fireEvent.change(screen.getByLabelText('semantic.radii.surface'), {
       target: { value: '{core.radii.nada}' },
@@ -354,7 +361,7 @@ describe('broken refs: ambient validation + sanctioned escalation (F2.2)', () =>
 
   test('the escalation dialog can be declined', async () => {
     const user = userEvent.setup();
-    render(<App />);
+    renderThemeLab();
     await breakOneRef(user);
     const inspector = screen.getByRole('complementary', { name: 'Inspector' });
 
@@ -384,14 +391,14 @@ test('an AI-origin diff entry shows the ✦ marker', () => {
 });
 
 test('editing via the native color input updates the theme', () => {
-  render(<App />);
+  renderThemeLab();
   const colorInput = screen.getByLabelText('brand 500 color');
   fireEvent.change(colorInput, { target: { value: '#abcdef' } });
   expect(screen.getByLabelText('brand 500 hex')).toHaveValue('#abcdef');
 });
 
 test('a non-6-digit hex override falls back safely in the color input', () => {
-  render(<App />);
+  renderThemeLab();
   fireEvent.change(screen.getByLabelText('brand 500 hex'), {
     target: { value: '#fff' },
   });

--- a/docs/fsl-studio/tests/unit/tests/drafts.test.ts
+++ b/docs/fsl-studio/tests/unit/tests/drafts.test.ts
@@ -1,0 +1,89 @@
+import {
+  deleteDraft,
+  listDrafts,
+  loadDraft,
+  newDraftId,
+  saveDraft,
+} from 'src/studio/session/drafts';
+import {
+  sanitizeSnapshot,
+  type SessionSnapshot,
+} from 'src/studio/session/sessionState';
+
+const STORAGE_KEY = 'fsl-studio.drafts.v1';
+
+const snapshot = (preset: string): SessionSnapshot => {
+  // Route through the sanitizer so the fixture always matches the schema.
+  const result = sanitizeSnapshot({ v: 1, theme: { preset } });
+  if (!result) {
+    throw new Error('fixture must sanitize');
+  }
+  return result;
+};
+
+test('save → list → load → delete round-trip, most recent first', () => {
+  jest
+    .spyOn(Date, 'now')
+    .mockReturnValueOnce(1000) // saveDraft a
+    .mockReturnValueOnce(2000); // saveDraft b
+  saveDraft('a', snapshot('base'));
+  saveDraft('b', snapshot('bruttal'));
+  jest.restoreAllMocks();
+
+  const drafts = listDrafts();
+  expect(
+    drafts.map((draft) => {
+      return draft.id;
+    })
+  ).toEqual(['b', 'a']);
+  expect(loadDraft('a')?.theme.preset).toBe('base');
+
+  deleteDraft('a');
+  expect(loadDraft('a')).toBeNull();
+  expect(listDrafts()).toHaveLength(1);
+});
+
+test('loadDraft of an unknown id is null', () => {
+  expect(loadDraft('missing')).toBeNull();
+});
+
+test('garbage in storage degrades to an empty shelf', () => {
+  window.localStorage.setItem(STORAGE_KEY, 'not json');
+  expect(listDrafts()).toEqual([]);
+
+  window.localStorage.setItem(STORAGE_KEY, '[1,2]');
+  expect(listDrafts()).toEqual([]);
+});
+
+test('invalid stored snapshots are skipped; bad timestamps degrade to 0', () => {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      ok: { updatedAt: 'soon', snapshot: { v: 1 } },
+      bad: { updatedAt: 2, snapshot: { v: 99 } },
+    })
+  );
+  const drafts = listDrafts();
+  expect(drafts).toHaveLength(1);
+  expect(drafts[0].id).toBe('ok');
+  expect(drafts[0].updatedAt).toBe(0);
+});
+
+test('storage write failures are swallowed (autosave stays ambient)', () => {
+  const spy = jest
+    .spyOn(Storage.prototype, 'setItem')
+    .mockImplementation(() => {
+      throw new Error('quota');
+    });
+  expect(() => {
+    return saveDraft('a', snapshot('base'));
+  }).not.toThrow();
+  spy.mockRestore();
+});
+
+test('newDraftId produces unique, storable ids', () => {
+  const a = newDraftId();
+  const b = newDraftId();
+  expect(a).toMatch(/^d-/);
+  expect(a).not.toBe(b);
+});

--- a/docs/fsl-studio/tests/unit/tests/examplePages.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/examplePages.test.tsx
@@ -98,3 +98,29 @@ describe('example pages', () => {
     expect(screen.queryByText('Delete account?')).not.toBeInTheDocument();
   });
 });
+
+test('toasts page queues a toast per evaluation and dismisses', async () => {
+  const user = userEvent.setup();
+  const page = findPage('toasts');
+  render(wrap(<>{page?.render()}</>));
+
+  await user.click(screen.getByRole('button', { name: 'Toast: positive' }));
+  const region = screen.getByRole('region', { name: /notification/i });
+  expect(within(region).getByText('A positive toast')).toBeInTheDocument();
+  expect(
+    within(region).getByText('Queued from the example page.')
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Toast: negative' }));
+  expect(within(region).getByText('A negative toast')).toBeInTheDocument();
+
+  // Dismissing removes exactly that toast from the queue.
+  const positiveRoot = within(region)
+    .getByText('A positive toast')
+    .closest('[data-scope="toast"][data-part="root"]');
+  await user.click(within(positiveRoot as HTMLElement).getByRole('button'));
+  expect(
+    within(region).queryByText('A positive toast')
+  ).not.toBeInTheDocument();
+  expect(within(region).getByText('A negative toast')).toBeInTheDocument();
+});

--- a/docs/fsl-studio/tests/unit/tests/overrides.test.ts
+++ b/docs/fsl-studio/tests/unit/tests/overrides.test.ts
@@ -2,62 +2,86 @@ import {
   buildBundle,
   generateThemeCode,
   hasOverrides,
-  listColorLeaves,
-  presetBundle,
-  removeColorLeaf,
-  setColorLeaf,
+  listTokenPaths,
+  mergeDeep,
+  nestOverrides,
+  removeToken,
+  setToken,
 } from 'src/studio/theme/overrides';
 
-describe('color leaf mutation', () => {
-  test('setColorLeaf adds a leaf immutably', () => {
+describe('token leaf mutation', () => {
+  test('setToken adds a leaf immutably', () => {
     const a = {};
-    const b = setColorLeaf(a, 'brand', '500', '#ff0000');
+    const b = setToken(a, 'core.colors.brand.500', '#ff0000');
     expect(a).toEqual({});
-    expect(b).toEqual({ brand: { 500: '#ff0000' } });
+    expect(b).toEqual({ 'core.colors.brand.500': '#ff0000' });
   });
 
-  test('setColorLeaf merges into an existing hue', () => {
-    const a = { brand: { 500: '#ff0000' } };
-    const b = setColorLeaf(a, 'brand', '600', '#cc0000');
-    expect(b).toEqual({ brand: { 500: '#ff0000', 600: '#cc0000' } });
+  test('removeToken removes a leaf and is a no-op for an absent one', () => {
+    const a = { 'core.colors.brand.500': '#ff0000' };
+    expect(removeToken(a, 'core.colors.brand.500')).toEqual({});
+    expect(removeToken(a, 'core.colors.brand.900')).toBe(a);
   });
 
-  test('removeColorLeaf prunes an emptied hue', () => {
-    const a = { brand: { 500: '#ff0000' } };
-    expect(removeColorLeaf(a, 'brand', '500')).toEqual({});
-  });
-
-  test('removeColorLeaf keeps sibling steps', () => {
-    const a = { brand: { 500: '#ff0000', 600: '#cc0000' } };
-    expect(removeColorLeaf(a, 'brand', '500')).toEqual({
-      brand: { 600: '#cc0000' },
-    });
-  });
-
-  test('removeColorLeaf is a no-op for an absent leaf', () => {
-    const a = { brand: { 500: '#ff0000' } };
-    expect(removeColorLeaf(a, 'neutral', '0')).toBe(a);
-    expect(removeColorLeaf(a, 'brand', '900')).toBe(a);
-  });
-
-  test('listColorLeaves returns a sorted flat list', () => {
-    const a = { neutral: { 900: '#000', 0: '#fff' }, brand: { 500: '#f00' } };
-    expect(listColorLeaves(a)).toEqual([
-      { hue: 'brand', step: '500' },
-      { hue: 'neutral', step: '0' },
-      { hue: 'neutral', step: '900' },
+  test('listTokenPaths returns a sorted list', () => {
+    const a = {
+      'semantic.radii.control': '{core.radii.none}',
+      'core.colors.brand.500': '#f00',
+    };
+    expect(listTokenPaths(a)).toEqual([
+      'core.colors.brand.500',
+      'semantic.radii.control',
     ]);
   });
 
   test('hasOverrides reflects presence', () => {
     expect(hasOverrides({})).toBe(false);
-    expect(hasOverrides({ brand: { 500: '#f00' } })).toBe(true);
+    expect(hasOverrides({ 'core.colors.brand.500': '#f00' })).toBe(true);
+  });
+});
+
+describe('nestOverrides', () => {
+  test('unflattens dotted paths into nested objects', () => {
+    expect(
+      nestOverrides({
+        'core.colors.brand.500': '#ff0000',
+        'core.colors.brand.600': '#cc0000',
+        'semantic.radii.control': '{core.radii.none}',
+      })
+    ).toEqual({
+      core: { colors: { brand: { 500: '#ff0000', 600: '#cc0000' } } },
+      semantic: { radii: { control: '{core.radii.none}' } },
+    });
+  });
+
+  test('keeps deeper structure on a prefix collision (foreign payloads)', () => {
+    // 'core.colors' (a non-leaf path) collides with a deeper leaf; the deeper
+    // structure wins regardless of insertion order.
+    expect(
+      nestOverrides({
+        'core.colors': 'garbage',
+        'core.colors.brand.500': '#ff0000',
+      })
+    ).toEqual({ core: { colors: { brand: { 500: '#ff0000' } } } });
+  });
+});
+
+describe('mergeDeep', () => {
+  test('merges nested objects with b winning on leaves', () => {
+    expect(
+      mergeDeep({ a: { x: 1, y: 2 }, keep: 'me' }, { a: { y: 3 }, extra: true })
+    ).toEqual({ a: { x: 1, y: 3 }, keep: 'me', extra: true });
+  });
+
+  test('replaces a non-object with an object and vice versa', () => {
+    expect(mergeDeep({ a: 1 }, { a: { b: 2 } })).toEqual({ a: { b: 2 } });
+    expect(mergeDeep({ a: { b: 2 } }, { a: 1 })).toEqual({ a: 1 });
   });
 });
 
 describe('buildBundle', () => {
   test('base preset applies overrides to core colors', () => {
-    const bundle = buildBundle('base', { brand: { 500: '#ff0000' } });
+    const bundle = buildBundle('base', { 'core.colors.brand.500': '#ff0000' });
     expect(bundle.base.core.colors.brand[500]).toBe('#ff0000');
     // A dark alternate is present for the base preset.
     expect(bundle.alternate).toBeDefined();
@@ -65,20 +89,22 @@ describe('buildBundle', () => {
 
   test('bruttal preset extends the built-in bundle', () => {
     const bundle = buildBundle('bruttal', {});
-    expect(bundle.base.core.colors.brand).toBeDefined();
+    expect(bundle.base.core.colors.brand[500]).toBe('#6D5D4F');
   });
-});
 
-describe('presetBundle', () => {
-  test('returns distinct bundles per preset', () => {
-    expect(presetBundle('base').base.core.colors.brand[500]).toBeDefined();
-    expect(presetBundle('bruttal').base.core.colors.brand[500]).toBeDefined();
+  test('semantic remap overrides land in the built theme', () => {
+    const bundle = buildBundle('base', {
+      'semantic.radii.control': '{core.radii.none}',
+    });
+    expect(bundle.base.semantic.radii.control).toBe('{core.radii.none}');
   });
 });
 
 describe('generateThemeCode', () => {
   test('base preset snippet has no extends and embeds the diff', () => {
-    const code = generateThemeCode('base', { brand: { 500: '#ff0000' } });
+    const code = generateThemeCode('base', {
+      'core.colors.brand.500': '#ff0000',
+    });
     expect(code).toContain("import { createTheme } from '@ttoss/fsl-theme'");
     expect(code).not.toContain('extends');
     expect(code).toContain('"brand"');
@@ -87,10 +113,26 @@ describe('generateThemeCode', () => {
   });
 
   test('bruttal preset snippet imports and extends bruttal', () => {
-    const code = generateThemeCode('bruttal', { brand: { 500: '#ff0000' } });
+    const code = generateThemeCode('bruttal', {
+      'core.colors.brand.500': '#ff0000',
+    });
     expect(code).toContain(
       "import { bruttal, createTheme } from '@ttoss/fsl-theme'"
     );
     expect(code).toContain('extends: bruttal');
+  });
+
+  test('authored preset snippet inlines its overrides, diff winning', () => {
+    const code = generateThemeCode('neobrutalism', {
+      'core.colors.brand.500': '#ff0000',
+    });
+    // Runnable anywhere: no Studio-only imports, preset payload inlined.
+    expect(code).toContain("import { createTheme } from '@ttoss/fsl-theme'");
+    expect(code).not.toContain('extends');
+    // Preset signature carried over…
+    expect(code).toContain('{core.radii.none}');
+    // …and the user's diff wins on the collided leaf.
+    expect(code).toContain('"#ff0000"');
+    expect(code).not.toContain('#6d28d9');
   });
 });

--- a/docs/fsl-studio/tests/unit/tests/palette.test.ts
+++ b/docs/fsl-studio/tests/unit/tests/palette.test.ts
@@ -1,5 +1,8 @@
+import { createTheme } from '@ttoss/fsl-theme';
+import { toFlatTokens } from '@ttoss/fsl-theme/css';
 import {
   computeContrast,
+  computeThemeContrast,
   contrastRatio,
   parseHex,
   rateContrast,
@@ -94,5 +97,29 @@ describe('computeContrast', () => {
       'semantic.colors.action.accent.background.default': 'blue',
     };
     expect(computeContrast(resolved)).toHaveLength(0);
+  });
+});
+
+describe('computeThemeContrast', () => {
+  test('computes both modes when the bundle has an alternate', () => {
+    const bundle = createTheme();
+    const lightFlat = toFlatTokens(bundle.base);
+    const { light, dark } = computeThemeContrast(bundle, lightFlat);
+    expect(light.length).toBeGreaterThan(0);
+    expect(dark.length).toBeGreaterThan(0);
+    // Dark surfaces resolve to different values than light ones.
+    const surfaceLight = light.find((result) => {
+      return result.label === 'Surface';
+    });
+    const surfaceDark = dark.find((result) => {
+      return result.label === 'Surface';
+    });
+    expect(surfaceLight?.background).not.toBe(surfaceDark?.background);
+  });
+
+  test('a single-mode bundle yields no dark results', () => {
+    const bundle = createTheme({ alternate: null });
+    const lightFlat = toFlatTokens(bundle.base);
+    expect(computeThemeContrast(bundle, lightFlat).dark).toEqual([]);
   });
 });

--- a/docs/fsl-studio/tests/unit/tests/presets.test.ts
+++ b/docs/fsl-studio/tests/unit/tests/presets.test.ts
@@ -1,0 +1,71 @@
+import { toFlatTokens } from '@ttoss/fsl-theme/css';
+import { contrastRatio } from 'src/studio/theme/palette';
+import {
+  AUTHORED_PRESETS,
+  findPreset,
+  presetBundle,
+  PRESETS,
+} from 'src/studio/theme/presets';
+
+describe('preset catalog', () => {
+  test('ships base, bruttal, and the style-reference starting points', () => {
+    const ids = PRESETS.map((preset) => {
+      return preset.id;
+    });
+    expect(ids).toEqual([
+      'base',
+      'bruttal',
+      'minimalist',
+      'neobrutalism',
+      'glass',
+      'nineties',
+    ]);
+  });
+
+  test('findPreset resolves known ids and rejects unknown ones', () => {
+    expect(findPreset('glass')?.label).toBe('Glass');
+    expect(findPreset('vaporwave')).toBeUndefined();
+  });
+});
+
+describe('preset bundles', () => {
+  test.each(
+    PRESETS.map((preset) => {
+      return [preset.id] as const;
+    })
+  )('%s builds, resolves cleanly, and keeps a dark alternate', (id) => {
+    const bundle = presetBundle(id);
+    // strict: throws on any unresolved ref — authored remaps must be valid.
+    expect(() => {
+      return toFlatTokens(bundle.base, { strict: true });
+    }).not.toThrow();
+    expect(bundle.alternate).toBeDefined();
+  });
+
+  test('bundles are cached per preset', () => {
+    expect(presetBundle('minimalist')).toBe(presetBundle('minimalist'));
+  });
+
+  test('authored presets carry their brand scale and brief', () => {
+    const neo = presetBundle('neobrutalism');
+    expect(neo.base.core.colors.brand[500]).toBe('#6d28d9');
+    expect(neo.meta?.name).toBe('neobrutalism');
+    expect(neo.base.semantic.radii.control).toBe('{core.radii.none}');
+  });
+
+  test.each(Object.keys(AUTHORED_PRESETS))(
+    '%s brand.500 keeps ≥ 4.5:1 on white (AA filled surfaces)',
+    (id) => {
+      const authored = AUTHORED_PRESETS[id as keyof typeof AUTHORED_PRESETS];
+      const brand = (
+        authored?.overrides.core?.colors as Record<
+          string,
+          Record<string, string>
+        >
+      ).brand;
+      const ratio = contrastRatio(brand[500], '#ffffff');
+      expect(ratio).not.toBeNull();
+      expect(ratio as number).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+});

--- a/docs/fsl-studio/tests/unit/tests/session.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/session.test.tsx
@@ -1,0 +1,211 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from 'src/App';
+import { listDrafts } from 'src/studio/session/drafts';
+import { snapshotFromHash } from 'src/studio/session/sessionState';
+import { bootFromHash, useSession } from 'src/studio/session/sessionStore';
+
+const startThemeTask = () => {
+  const utils = render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: /Create a theme/ }));
+  return utils;
+};
+
+describe('bootFromHash', () => {
+  test('a valid #s= hash boots the studio as a fork', () => {
+    startThemeTask();
+    fireEvent.change(screen.getByLabelText('brand 500 hex'), {
+      target: { value: '#abcdef' },
+    });
+    return waitFor(() => {
+      const boot = bootFromHash(window.location.hash);
+      expect(boot.screen).toBe('studio');
+      expect(boot.snapshot?.theme.overrides['core.colors.brand.500']).toBe(
+        '#abcdef'
+      );
+      // Fork semantics (AD-10): a fresh draft id every time.
+      expect(boot.draftId).not.toBe(bootFromHash(window.location.hash).draftId);
+    });
+  });
+
+  test('no hash boots home', () => {
+    const boot = bootFromHash('');
+    expect(boot.screen).toBe('home');
+    expect(boot.snapshot).toBeNull();
+  });
+});
+
+describe('URL is the state (F1.2 AC)', () => {
+  test('an edit lands in the hash; a fresh boot from it restores the state', async () => {
+    const first = startThemeTask();
+    fireEvent.change(screen.getByLabelText('brand 500 hex'), {
+      target: { value: '#abcdef' },
+    });
+
+    await waitFor(() => {
+      const snapshot = snapshotFromHash(window.location.hash);
+      expect(snapshot?.theme.overrides['core.colors.brand.500']).toBe(
+        '#abcdef'
+      );
+    });
+    first.unmount();
+
+    // A "fresh browser" with the same deep link: state reproduced in full.
+    render(<App />);
+    expect(screen.getByLabelText('brand 500 hex')).toHaveValue('#abcdef');
+    expect(
+      screen.getByRole('complementary', { name: 'Inspector' })
+    ).toHaveTextContent('Changes (1)');
+  });
+
+  test('drafts autosave silently while editing (F1.3)', async () => {
+    startThemeTask();
+    fireEvent.change(screen.getByLabelText('brand 500 hex'), {
+      target: { value: '#abcdef' },
+    });
+    await waitFor(() => {
+      const drafts = listDrafts();
+      expect(drafts).toHaveLength(1);
+      expect(drafts[0].snapshot.theme.overrides['core.colors.brand.500']).toBe(
+        '#abcdef'
+      );
+    });
+    // Ambient: no toast, no dialog announced the save.
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('stage altitudes (F1.4)', () => {
+  test('page altitude shows an example page; grid shows the drift view', async () => {
+    const user = userEvent.setup();
+    startThemeTask();
+
+    // Component altitude (default): the sample gallery.
+    expect(screen.getAllByRole('button', { name: 'Save' })).toHaveLength(2);
+
+    await user.click(screen.getByRole('radio', { name: 'Page' }));
+    // First example page (form) in both panes.
+    expect(screen.getAllByLabelText('Email')).toHaveLength(2);
+
+    await user.click(screen.getByRole('radio', { name: 'Grid' }));
+    // All four example pages, per pane.
+    expect(screen.getAllByRole('region', { name: 'Wizard' })).toHaveLength(2);
+    expect(
+      screen.getAllByRole('region', { name: 'Form + validation' })
+    ).toHaveLength(2);
+  });
+
+  test('altitude persists across lens switches (frame never resets)', async () => {
+    const user = userEvent.setup();
+    startThemeTask();
+
+    await user.click(screen.getByRole('radio', { name: 'Grid' }));
+    await user.click(screen.getByRole('radio', { name: 'Components' }));
+
+    expect(screen.getByRole('radio', { name: 'Grid' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getAllByRole('region', { name: 'Wizard' })).toHaveLength(2);
+  });
+
+  test('page altitude follows a selected example page', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(
+      screen.getByRole('button', { name: /Explore components/ })
+    );
+    // "Wizard" names both the catalog composite and the example page; the
+    // example-pages group renders after the catalog groups.
+    const wizardButtons = screen.getAllByRole('button', { name: 'Wizard' });
+    await user.click(wizardButtons[wizardButtons.length - 1]);
+    await user.click(screen.getByRole('radio', { name: 'Page' }));
+    expect(screen.getAllByText(/tell us about your project/)).toHaveLength(2);
+  });
+});
+
+describe('home ↔ studio (PRD §6.2, F1.3)', () => {
+  test('the brand button returns home and clears the hash', async () => {
+    const user = userEvent.setup();
+    startThemeTask();
+
+    await user.click(screen.getByRole('button', { name: 'FSL Studio' }));
+    expect(screen.getByText('What do you want to do?')).toBeInTheDocument();
+    expect(window.location.hash).toBe('');
+  });
+
+  test('a draft continues from home under the same id (last-write-wins noted)', async () => {
+    const user = userEvent.setup();
+    startThemeTask();
+    fireEvent.change(screen.getByLabelText('brand 500 hex'), {
+      target: { value: '#abcdef' },
+    });
+    await waitFor(() => {
+      expect(listDrafts()).toHaveLength(1);
+    });
+    const [draft] = listDrafts();
+
+    await user.click(screen.getByRole('button', { name: 'FSL Studio' }));
+    expect(screen.getByText(/last-write-wins/)).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: new RegExp(`^base · 1 edit ·`) })
+    );
+    expect(screen.getByLabelText('brand 500 hex')).toHaveValue('#abcdef');
+
+    // Same draft id — continue, not fork.
+    await waitFor(() => {
+      expect(listDrafts()).toHaveLength(1);
+    });
+    expect(listDrafts()[0].id).toBe(draft.id);
+  });
+
+  test('deleting a draft removes it from the shelf', async () => {
+    const user = userEvent.setup();
+    startThemeTask();
+    await waitFor(() => {
+      expect(listDrafts()).toHaveLength(1);
+    });
+    const [draft] = listDrafts();
+
+    await user.click(screen.getByRole('button', { name: 'FSL Studio' }));
+    await user.click(
+      screen.getByRole('button', { name: `Delete draft ${draft.id}` })
+    );
+    expect(listDrafts()).toHaveLength(0);
+    expect(screen.queryByText(/last-write-wins/)).not.toBeInTheDocument();
+  });
+
+  test('opening a corrupted draft is a no-op (home stays)', async () => {
+    const user = userEvent.setup();
+    startThemeTask();
+    await waitFor(() => {
+      expect(listDrafts()).toHaveLength(1);
+    });
+    const [draft] = listDrafts();
+    await user.click(screen.getByRole('button', { name: 'FSL Studio' }));
+
+    // Corrupt the stored snapshot behind the listed draft.
+    window.localStorage.setItem(
+      'fsl-studio.drafts.v1',
+      JSON.stringify({ [draft.id]: { updatedAt: 1, snapshot: { v: 99 } } })
+    );
+    // The list re-reads on render; the row is already on screen from before
+    // corruption — clicking it must not crash into a broken studio.
+    const open = screen.getByRole('button', { name: /^base · 0 edits ·/ });
+    await user.click(open);
+    expect(screen.getByText('What do you want to do?')).toBeInTheDocument();
+  });
+});
+
+test('useSession outside a provider throws', () => {
+  const Consumer = () => {
+    useSession();
+    return null;
+  };
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  expect(() => {
+    return render(<Consumer />);
+  }).toThrow('useSession must be used within a SessionProvider');
+  spy.mockRestore();
+});

--- a/docs/fsl-studio/tests/unit/tests/sessionState.test.ts
+++ b/docs/fsl-studio/tests/unit/tests/sessionState.test.ts
@@ -1,0 +1,145 @@
+import { CATALOG } from 'src/studio/components/catalog';
+import {
+  decodeSession,
+  DEFAULT_SELECTION,
+  encodeSession,
+  sanitizeSnapshot,
+  type SessionSnapshot,
+  snapshotFromHash,
+  snapshotToHash,
+} from 'src/studio/session/sessionState';
+
+const snapshot: SessionSnapshot = {
+  v: 1,
+  lens: 'components',
+  altitude: 'page',
+  theme: {
+    preset: 'bruttal',
+    overrides: {
+      'core.colors.brand.500': '#abcdef',
+      'semantic.radii.control': '{core.radii.none}',
+    },
+    origins: {
+      'core.colors.brand.500': 'manual',
+      'semantic.radii.control': 'ai',
+    },
+  },
+  component: {
+    selection: { kind: 'page', id: 'form' },
+    evaluation: 'accent',
+    consequence: 'destructive',
+  },
+};
+
+test('URL round-trip reproduces the full session state (F1 AC)', () => {
+  const encoded = encodeSession(snapshot);
+  // URL-safe payload (lz-string EncodedURIComponent alphabet).
+  expect(encoded).toMatch(/^[A-Za-z0-9+$\-_.!*'(),]+$/);
+  expect(decodeSession(encoded)).toEqual(snapshot);
+  // And through the hash form used in the location bar.
+  expect(snapshotFromHash(snapshotToHash(snapshot))).toEqual(snapshot);
+});
+
+test('hash without the session marker parses to null', () => {
+  expect(snapshotFromHash('')).toBeNull();
+  expect(snapshotFromHash('#other=1')).toBeNull();
+});
+
+describe('decodeSession on foreign payloads', () => {
+  test('garbage that does not decompress yields null', () => {
+    expect(decodeSession('%%%not-lz%%%')).toBeNull();
+  });
+
+  test('decompressible non-JSON yields null', () => {
+    // Compress a plain string that is not valid JSON.
+    const { compressToEncodedURIComponent } = jest.requireActual('lz-string');
+    expect(decodeSession(compressToEncodedURIComponent('not json'))).toBeNull();
+  });
+});
+
+describe('sanitizeSnapshot', () => {
+  test('rejects non-objects and unknown versions', () => {
+    expect(sanitizeSnapshot(null)).toBeNull();
+    expect(sanitizeSnapshot('x')).toBeNull();
+    expect(sanitizeSnapshot({ v: 2 })).toBeNull();
+    expect(sanitizeSnapshot([1])).toBeNull();
+  });
+
+  test('a bare v1 payload degrades every field to safe defaults', () => {
+    expect(sanitizeSnapshot({ v: 1 })).toEqual({
+      v: 1,
+      lens: 'theme',
+      altitude: 'component',
+      theme: { preset: 'base', overrides: {}, origins: {} },
+      component: { selection: DEFAULT_SELECTION },
+    });
+  });
+
+  test('invalid fields fall back individually', () => {
+    const result = sanitizeSnapshot({
+      v: 1,
+      lens: 'nope',
+      altitude: 'orbit',
+      theme: {
+        preset: 'vaporwave',
+        overrides: { good: '#fff', bad: 42 },
+        origins: { good: 'manual', bad: 'manual', good2: 'alien' },
+      },
+      component: {
+        selection: { kind: 'component', key: '__missing__' },
+        evaluation: 7,
+        consequence: null,
+      },
+    });
+    expect(result?.lens).toBe('theme');
+    expect(result?.altitude).toBe('component');
+    expect(result?.theme.preset).toBe('base');
+    // Non-string override values are dropped…
+    expect(result?.theme.overrides).toEqual({ good: '#fff' });
+    // …and origins keep only valid values for surviving overrides.
+    expect(result?.theme.origins).toEqual({ good: 'manual' });
+    // Unknown component key falls back to the first catalog entry.
+    expect(result?.component.selection).toEqual({
+      kind: 'component',
+      key: CATALOG[0].key,
+    });
+    expect(result?.component.evaluation).toBeUndefined();
+    expect(result?.component.consequence).toBeUndefined();
+  });
+
+  test('valid page and component selections survive', () => {
+    expect(
+      sanitizeSnapshot({
+        v: 1,
+        component: { selection: { kind: 'page', id: 'wizard' } },
+      })?.component.selection
+    ).toEqual({ kind: 'page', id: 'wizard' });
+
+    expect(
+      sanitizeSnapshot({
+        v: 1,
+        component: { selection: { kind: 'component', key: 'buttonMeta' } },
+      })?.component.selection
+    ).toEqual({ kind: 'component', key: 'buttonMeta' });
+  });
+
+  test('an unknown page id falls back to the default selection', () => {
+    expect(
+      sanitizeSnapshot({
+        v: 1,
+        component: { selection: { kind: 'page', id: 'nope' } },
+      })?.component.selection
+    ).toEqual(DEFAULT_SELECTION);
+  });
+
+  test('non-object overrides/origins/selection degrade safely', () => {
+    const result = sanitizeSnapshot({
+      v: 1,
+      theme: { overrides: [1, 2], origins: 'x' },
+      component: { selection: 'x' },
+    });
+    expect(result?.theme.overrides).toEqual({});
+    expect(result?.theme.origins).toEqual({});
+    expect(result?.component.selection).toEqual(DEFAULT_SELECTION);
+  });
+});

--- a/docs/fsl-studio/tests/unit/tests/themeStore.test.tsx
+++ b/docs/fsl-studio/tests/unit/tests/themeStore.test.tsx
@@ -8,51 +8,48 @@ import {
   useThemeStore,
 } from 'src/studio/theme/themeStore';
 
+const BRAND = 'core.colors.brand.500';
+
 describe('themeReducer', () => {
-  test('setColor adds an override and tags origin manual', () => {
+  test('setToken adds an override and tags origin manual', () => {
     const next = themeReducer(initialThemeState, {
-      type: 'setColor',
-      hue: 'brand',
-      step: '500',
+      type: 'setToken',
+      path: BRAND,
       value: '#ff0000',
     });
-    expect(next.colors).toEqual({ brand: { 500: '#ff0000' } });
-    expect(next.origins['brand.500']).toBe('manual');
+    expect(next.overrides).toEqual({ [BRAND]: '#ff0000' });
+    expect(next.origins[BRAND]).toBe('manual');
   });
 
-  test('revertColor removes the override and its origin', () => {
+  test('revertToken removes the override and its origin', () => {
     const edited = themeReducer(initialThemeState, {
-      type: 'setColor',
-      hue: 'brand',
-      step: '500',
+      type: 'setToken',
+      path: BRAND,
       value: '#ff0000',
     });
     const reverted = themeReducer(edited, {
-      type: 'revertColor',
-      hue: 'brand',
-      step: '500',
+      type: 'revertToken',
+      path: BRAND,
     });
-    expect(reverted.colors).toEqual({});
-    expect(reverted.origins['brand.500']).toBeUndefined();
+    expect(reverted.overrides).toEqual({});
+    expect(reverted.origins[BRAND]).toBeUndefined();
   });
 
   test('resetAll clears all overrides and origins', () => {
     const edited = themeReducer(initialThemeState, {
-      type: 'setColor',
-      hue: 'brand',
-      step: '500',
+      type: 'setToken',
+      path: BRAND,
       value: '#ff0000',
     });
     const reset = themeReducer(edited, { type: 'resetAll' });
-    expect(reset.colors).toEqual({});
+    expect(reset.overrides).toEqual({});
     expect(reset.origins).toEqual({});
   });
 
   test('setPreset switches preset and starts a fresh diff', () => {
     const edited = themeReducer(initialThemeState, {
-      type: 'setColor',
-      hue: 'brand',
-      step: '500',
+      type: 'setToken',
+      path: BRAND,
       value: '#ff0000',
     });
     const switched = themeReducer(edited, {
@@ -60,7 +57,7 @@ describe('themeReducer', () => {
       preset: 'bruttal',
     });
     expect(switched.preset).toBe('bruttal');
-    expect(switched.colors).toEqual({});
+    expect(switched.overrides).toEqual({});
     expect(switched.origins).toEqual({});
   });
 
@@ -100,14 +97,12 @@ describe('useThemeStore', () => {
           <button
             type="button"
             onClick={() => {
-              return store.setColor('brand', '500', '#123456');
+              return store.setToken(BRAND, '#123456');
             }}
           >
             edit
           </button>
-          <span data-testid="origin">
-            {String(store.origin('brand', '500'))}
-          </span>
+          <span data-testid="origin">{String(store.origin(BRAND))}</span>
         </div>
       );
     };
@@ -121,5 +116,70 @@ describe('useThemeStore', () => {
     expect(screen.getByTestId('origin').textContent).toBe('undefined');
     await user.click(screen.getByRole('button', { name: 'edit' }));
     expect(screen.getByTestId('origin').textContent).toBe('manual');
+  });
+
+  test('accepts boot-time initial state (URL fork / draft restore)', () => {
+    const Probe = () => {
+      const store = useThemeStore();
+      return (
+        <div>
+          <span data-testid="preset">{store.preset}</span>
+          <span data-testid="value">{store.overrides[BRAND]}</span>
+        </div>
+      );
+    };
+
+    render(
+      <ThemeStoreProvider
+        initial={{ preset: 'minimalist', overrides: { [BRAND]: '#abcdef' } }}
+      >
+        <Probe />
+      </ThemeStoreProvider>
+    );
+
+    expect(screen.getByTestId('preset').textContent).toBe('minimalist');
+    expect(screen.getByTestId('value').textContent).toBe('#abcdef');
+  });
+
+  test('exposes broken refs and dark contrast for the live bundle', async () => {
+    const user = userEvent.setup();
+    const Probe = () => {
+      const store = useThemeStore();
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => {
+              return store.setToken(
+                'semantic.radii.control',
+                '{core.radii.nope}'
+              );
+            }}
+          >
+            break
+          </button>
+          <span data-testid="broken">{store.brokenRefs.join(',')}</span>
+          <span data-testid="dark-count">{store.contrast.dark.length}</span>
+        </div>
+      );
+    };
+
+    render(
+      <ThemeStoreProvider>
+        <Probe />
+      </ThemeStoreProvider>
+    );
+
+    // The base theme resolves cleanly, and a dark alternate yields dark rows.
+    expect(screen.getByTestId('broken').textContent).toBe('');
+    expect(
+      Number(screen.getByTestId('dark-count').textContent)
+    ).toBeGreaterThan(0);
+
+    // A remap to a nonexistent core ref surfaces as a broken token.
+    await user.click(screen.getByRole('button', { name: 'break' }));
+    expect(screen.getByTestId('broken').textContent).toContain(
+      'semantic.radii.control'
+    );
   });
 });

--- a/docs/fsl-studio/tests/unit/tests/tokenTree.test.ts
+++ b/docs/fsl-studio/tests/unit/tests/tokenTree.test.ts
@@ -1,0 +1,116 @@
+import { createTheme } from '@ttoss/fsl-theme';
+import { toFlatTokens } from '@ttoss/fsl-theme/css';
+import {
+  coreFamilies,
+  findBrokenRefs,
+  flattenLeaves,
+  SEMANTIC_FAMILIES,
+  semanticFamilies,
+} from 'src/studio/theme/tokenTree';
+
+const bundle = createTheme();
+
+describe('flattenLeaves', () => {
+  test('flattens nested objects into sorted raw leaves', () => {
+    expect(
+      flattenLeaves({ b: { y: '2px', x: 1 }, a: '{core.radii.sm}' }, 'root')
+    ).toEqual([
+      { path: 'root.a', raw: '{core.radii.sm}' },
+      { path: 'root.b.x', raw: '1' },
+      { path: 'root.b.y', raw: '2px' },
+    ]);
+  });
+
+  test('skips undefined values', () => {
+    expect(flattenLeaves({ a: undefined, b: 'x' }, 'root')).toEqual([
+      { path: 'root.b', raw: 'x' },
+    ]);
+  });
+});
+
+describe('semanticFamilies', () => {
+  const families = semanticFamilies(bundle);
+
+  test('returns families in the canonical PRD F2.1 order', () => {
+    const names = families.map((family) => {
+      return family.family;
+    });
+    // Every returned family is in the canonical list, in order.
+    const canonical = SEMANTIC_FAMILIES.filter((name) => {
+      return names.includes(name);
+    });
+    expect(names).toEqual(canonical);
+    expect(names).toContain('colors');
+    expect(names).toContain('radii');
+    expect(names).not.toContain('dataviz');
+  });
+
+  test('groups semantic colors by ux context', () => {
+    const colors = families.find((family) => {
+      return family.family === 'colors';
+    });
+    const labels = colors?.groups.map((group) => {
+      return group.label;
+    });
+    expect(labels).toEqual(
+      expect.arrayContaining(['action', 'input', 'navigation', 'feedback'])
+    );
+    // Grouped leaf counts add up to the family count.
+    const total = colors?.groups.reduce((sum, group) => {
+      return sum + group.leaves.length;
+    }, 0);
+    expect(total).toBe(colors?.leafCount);
+  });
+
+  test('non-color families are one flat group with raw refs', () => {
+    const radii = families.find((family) => {
+      return family.family === 'radii';
+    });
+    expect(radii?.groups).toHaveLength(1);
+    expect(radii?.groups[0].label).toBe('');
+    const control = radii?.groups[0].leaves.find((leaf) => {
+      return leaf.path === 'semantic.radii.control';
+    });
+    expect(control?.raw).toMatch(/^\{core\.radii\./);
+  });
+});
+
+describe('coreFamilies', () => {
+  const families = coreFamilies(bundle);
+
+  test('excludes colors (picker-editor surface) and dataviz', () => {
+    const names = families.map((family) => {
+      return family.family;
+    });
+    expect(names).not.toContain('colors');
+    expect(names).not.toContain('dataviz');
+    expect(names).toEqual(expect.arrayContaining(['radii', 'spacing']));
+  });
+
+  test('exposes raw core values', () => {
+    const radii = families.find((family) => {
+      return family.family === 'radii';
+    });
+    const md = radii?.groups[0].leaves.find((leaf) => {
+      return leaf.path === 'core.radii.md';
+    });
+    expect(md?.raw).toBe('8px');
+  });
+});
+
+describe('findBrokenRefs', () => {
+  test('the base theme resolves without broken refs', () => {
+    expect(findBrokenRefs(toFlatTokens(bundle.base))).toEqual([]);
+  });
+
+  test('detects unresolved refs left in the flat map', () => {
+    expect(
+      findBrokenRefs({
+        good: '#fff',
+        numeric: 1,
+        broken: '{core.colors.nope.500}',
+        compound: 'clamp({core.spacing.missing}, 1px, 2px)',
+      })
+    ).toEqual(['broken', 'compound']);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@ttoss/fsl-ui':
         specifier: workspace:^
         version: link:../../packages/fsl-ui
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -215,6 +218,9 @@ importers:
       '@ttoss/test-utils':
         specifier: workspace:^
         version: link:../../packages/test-utils
+      '@types/jest-axe':
+        specifier: ^3.5.9
+        version: 3.5.9
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.4
@@ -230,6 +236,9 @@ importers:
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      jest-axe:
+        specifier: ^10.0.0
+        version: 10.0.0
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -758,7 +767,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -24035,7 +24044,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -24046,7 +24055,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -24054,11 +24063,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -24067,13 +24076,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -24081,7 +24090,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@ts-morph/common@0.29.0':
@@ -34459,7 +34468,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
Completes Phases 0–2 of the FSL Studio roadmap by shipping all F1 (session/URL state) and F2 (Theme Lab) features deferred by earlier phases.

## Summary

This PR implements the full Theme Lab editing surface and session persistence layer:

- **Flat token override model** replaces Phase-1 `ColorOverrides`; the diff now covers any core leaf and semantic remaps (e.g., `semantic.radii.control` → `{core.radii.none}`)
- **Token tree navigator** (PRD F2.1) groups semantic tokens by family and UX context; core tokens are progressive-disclosure on demand
- **Editable token rows** (PRD F2.2) support both literal values and `{ref}` strings for semantic remapping; broken refs show ambient badges, never modals
- **Theme presets** expand from 2 (base, bruttal) to 6, adding style-reference starting points (minimalist, neobrutalism, glass, 90s)
- **Session state projection** (PRD F1.2) encodes the full studio state in the URL hash; opening a shared link forks the state (new draft id)
- **Draft autosave** (PRD F1.3) silently persists to localStorage; drafts list on home shows previous sessions
- **Task-first home** (PRD §6.2) replaces the empty studio with a question ("What do you want to do?") and task buttons
- **Command palette** (PRD F1.5, §6.5) opens on ⌘K with keyboard navigation; commands derive from the same sources as navigators
- **Stage altitude switcher** (PRD F1.4) cycles component → page → grid; the frame never resets on lens switch
- **Ambient validation** (PRD §6.4-P2) surfaces broken refs as discreet header counters and per-token badges; no modals
- **WCAG contrast checks** (PRD F2.6) compute both light and dark mode; results display in the inspector
- **Export with validation** (PRD §6.4-P2) gates code export on broken refs via one sanctioned dialog

## Key Changes

**New files:**
- `src/studio/theme/presets.ts` — preset catalog with authored overrides and design briefs
- `src/studio/theme/tokenTree.ts` — token-tree projection for navigator grouping
- `src/studio/session/sessionState.ts` — session snapshot schema and URL codec (lz-string)
- `src/studio/session/sessionStore.tsx` — session layer (lens, altitude, draft id, boot logic)
- `src/studio/session/drafts.ts` — localStorage autosave with sanitization
- `src/studio/session/commands.ts` — command palette inventory
- `src/studio/session/CommandPalette.tsx` — ⌘K UI with combobox semantics
- `src/studio/session/SessionSync.tsx` — URL/draft synchronizer
- `src/studio/Home.tsx` — task-first home with drafts list
- `src/studio/PageGrid.tsx` — grid altitude renderer
- Tests for all new modules

**Modified files:**
- `src/studio/theme/overrides.ts` — flat `path → value` model; `setToken`/`removeToken` replace color-specific mutations
- `src/studio/theme/themeStore.tsx` — reducer actions updated; `brokenRefs` tracking; contrast computation
- `src/studio/theme/ThemeNavigator.tsx` — token tree UI with lazy disclosure; semantic families grouped by UX context
- `src/studio/theme/ThemeInspector.tsx` — contrast results display; export dialog on broken refs
- `src/studio/theme/palette.ts` — `computeThemeContrast` for both modes
- `src/studio/StudioShell.tsx` — altitude switcher in toolbar; ref-error counter in header
- `src/studio/Stage.tsx` — toolbar prop for altitude controls
- `src/App.tsx` — session boot logic; home/studio screen routing; draft lifecycle
- `src/studio

https://claude.ai/code/session_014KUcLgqsKzU6UCtpPneC8s