### PR TITLE
feat(http-server-mcp-openapi): generate MCP tools from OpenAPI specs

### DIFF
--- a/packages/http-server-mcp-openapi/README.md
+++ b/packages/http-server-mcp-openapi/README.md
@@ -1,0 +1,143 @@
+# @ttoss/http-server-mcp-openapi
+
+Generate [Model Context Protocol (MCP)](https://modelcontextprotocol.io) tools
+from an [OpenAPI](https://www.openapis.org/) specification and register them on
+a [@ttoss/http-server-mcp](https://ttoss.dev/docs/modules/packages/http-server-mcp)
+server.
+
+Point it at your existing OpenAPI document and every operation becomes an MCP
+tool whose handler resolves the incoming arguments into an HTTP request against
+your REST API. The OpenAPI spec stays the single source of truth for both your
+REST surface and your MCP tool surface.
+
+## Installation
+
+```bash
+pnpm add @ttoss/http-server-mcp-openapi @ttoss/http-server-mcp
+```
+
+## Quick Start
+
+```typescript
+import { App, bodyParser } from '@ttoss/http-server';
+import { createMcpRouter, McpServer } from '@ttoss/http-server-mcp';
+import { registerOpenApiTools } from '@ttoss/http-server-mcp-openapi';
+
+import openApiDocument from './openapi.json' with { type: 'json' };
+
+const server = new McpServer({ name: 'my-api', version: '1.0.0' });
+
+registerOpenApiTools({
+  server,
+  spec: openApiDocument,
+  // You own how the request is executed — base URL, auth, fetch impl.
+  callApi: async ({ method, url, body }) => {
+    const res = await fetch(`https://api.example.com${url}`, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return res.json();
+  },
+});
+
+const app = new App();
+app.use(bodyParser());
+app.use(createMcpRouter(server).routes());
+app.listen(3000);
+```
+
+## How Operations Map to Tools
+
+Each OpenAPI operation with an `operationId` and a supported HTTP method
+(`GET`, `POST`, `PUT`, `PATCH`, `DELETE`) becomes one tool:
+
+| OpenAPI                   | MCP tool                                     |
+| ------------------------- | -------------------------------------------- |
+| `operationId: listAgents` | tool name `list-agents` (kebab-case)         |
+| path/query/body params    | a single camelCase `inputSchema` object      |
+| `$ref`, `oneOf`, `anyOf`  | dereferenced and merged into a flat schema   |
+| snake_case body fields    | camelCase tool inputs, mapped back on call   |
+| operation `description`   | tool description (quotes/newlines sanitised) |
+
+Path params are always required strings. Query and body params carry their
+declared type and `required` flag. Array params keep their `items` schema.
+
+Tool arguments are **camelCase** (`agentId`, `projectId`); the generated
+request path, query string, and body use the original **snake_case** names.
+
+## `registerOpenApiTools`
+
+| Field      | Description                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `server`   | The `McpServer` to register tools on.                                                                         |
+| `spec`     | One OpenAPI document, or an array of them (tools are flattened).                                              |
+| `callApi`  | Runs the resolved `{ method, url, body, tool }` request and returns the raw data.                             |
+| `toText?`  | Serialises the raw data into the tool's text payload. Defaults to pretty JSON; strings pass through verbatim. |
+| `options?` | See [Options](#options).                                                                                      |
+
+Returns the list of `ToolDefinition`s that were registered.
+
+## `openApiToToolDefinitions`
+
+Use the lower-level function when you want the tool definitions without
+registering them — to inspect, filter, or wire handlers yourself:
+
+```typescript
+import { openApiToToolDefinitions } from '@ttoss/http-server-mcp-openapi';
+
+const tools = openApiToToolDefinitions({ spec: openApiDocument });
+
+for (const tool of tools) {
+  // tool.name, tool.method, tool.inputSchema, tool.extensions, ...
+  const url = tool.path(args) + (tool.query ? tool.query(args) : '');
+  const body = tool.body?.(args);
+}
+```
+
+Each `ToolDefinition` exposes `name`, `description`, `inputSchema`, `method`,
+`pathTemplate`, `operationId`, the `path`/`query`/`body` builders,
+`acceptedBodyFields`, and `extensions`.
+
+## Options
+
+```typescript
+registerOpenApiTools({
+  server,
+  spec,
+  callApi,
+  options: {
+    excludeExtension: 'x-mcp-exclude', // operations flagged truthy are skipped
+    serverManagedExtension: 'x-mcp-server-managed', // body fields hidden from the input schema
+  },
+});
+```
+
+- **`excludeExtension`** (default `x-mcp-exclude`) — an operation with this
+  extension set truthy is omitted from the tool surface.
+- **`serverManagedExtension`** (default `x-mcp-server-managed`) — a request-body
+  property with this extension set truthy is hidden from the tool's
+  `inputSchema` (the caller can't set it) but still appears in
+  `acceptedBodyFields`.
+
+### Reading custom extensions
+
+Every `x-` prefixed extension on an operation is forwarded verbatim on
+`tool.extensions`, so you can attach and read your own metadata without this
+package needing to know about it:
+
+```typescript
+const tools = openApiToToolDefinitions({ spec: openApiDocument });
+const iamAction = tools[0].extensions['x-iam-action'];
+```
+
+## Related Packages
+
+- [@ttoss/http-server-mcp](https://ttoss.dev/docs/modules/packages/http-server-mcp) - MCP server integration for @ttoss/http-server
+- [@ttoss/http-server](https://ttoss.dev/docs/modules/packages/http-server) - HTTP server foundation
+- [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/sdk) - MCP SDK
+
+## Resources
+
+- [MCP Documentation](https://modelcontextprotocol.io)
+- [OpenAPI Specification](https://spec.openapis.org/oas/latest.html)

--- a/packages/http-server-mcp-openapi/jest.config.ts
+++ b/packages/http-server-mcp-openapi/jest.config.ts
@@ -1,0 +1,3 @@
+import { jestRootConfig } from '@ttoss/config';
+
+export default jestRootConfig();

--- a/packages/http-server-mcp-openapi/package.json
+++ b/packages/http-server-mcp-openapi/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@ttoss/http-server-mcp-openapi",
+  "version": "0.0.0",
+  "description": "Generate Model Context Protocol (MCP) tools from an OpenAPI specification for @ttoss/http-server-mcp",
+  "keywords": [
+    "ai",
+    "koa",
+    "llm",
+    "mcp",
+    "model-context-protocol",
+    "openapi",
+    "rest",
+    "server"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ttoss/ttoss.git",
+    "directory": "packages/http-server-mcp-openapi"
+  },
+  "license": "MIT",
+  "author": "ttoss",
+  "contributors": [
+    "Pedro Arantes <pedro@arantespp.com> (https://arantespp.com)"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "jest --projects tests/unit"
+  },
+  "dependencies": {
+    "@ttoss/http-server-mcp": "workspace:^"
+  },
+  "devDependencies": {
+    "@ttoss/config": "workspace:^",
+    "@ttoss/http-server": "workspace:^",
+    "jest": "^30.4.2",
+    "supertest": "^7.2.2",
+    "tsdown": "^0.22.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "types": "./dist/index.d.mts"
+      }
+    },
+    "provenance": true
+  }
+}

--- a/packages/http-server-mcp-openapi/src/index.ts
+++ b/packages/http-server-mcp-openapi/src/index.ts
@@ -1,0 +1,36 @@
+export {
+  registerOpenApiTools,
+  type RegisterOpenApiToolsArgs,
+  type ResolvedRequest,
+} from './registerOpenApiTools';
+export {
+  buildBodyFn,
+  buildPathFn,
+  buildQueryFn,
+  dereferenceSchema,
+  resolveParameter,
+  resolveSchema,
+} from './schema';
+export {
+  buildInputSchema,
+  extractAcceptedBodyFields,
+  extractBodyProps,
+  extractPathParams,
+  extractQueryParams,
+  getJsonSchemaType,
+  openApiToToolDefinitions,
+  operationIdToToolName,
+  processOperation,
+  processPath,
+  snakeToCamel,
+} from './toolDefinitions';
+export {
+  DEFAULT_EXCLUDE_EXTENSION,
+  DEFAULT_SERVER_MANAGED_EXTENSION,
+  type JsonSchemaProperty,
+  type OpenApiSpec,
+  type OpenApiToToolsOptions,
+  type OperationSpec,
+  type RequestBodySpec,
+  type ToolDefinition,
+} from './types';

--- a/packages/http-server-mcp-openapi/src/registerOpenApiTools.ts
+++ b/packages/http-server-mcp-openapi/src/registerOpenApiTools.ts
@@ -1,0 +1,103 @@
+import { type McpServer, registerToolFromSchema } from '@ttoss/http-server-mcp';
+
+import { openApiToToolDefinitions } from './toolDefinitions';
+import type {
+  OpenApiSpec,
+  OpenApiToToolsOptions,
+  ToolDefinition,
+} from './types';
+
+/** The resolved HTTP request a tool call maps to, before transport concerns. */
+export interface ResolvedRequest {
+  /** Uppercase HTTP method. */
+  method: string;
+  /** Request path including the query string, e.g. `/agents/agt_1?limit=10`. */
+  url: string;
+  /** snake_case request body, or `undefined` when the operation has none. */
+  body?: Record<string, unknown>;
+  /** The tool definition the call resolved to (for auth/metadata lookups). */
+  tool: ToolDefinition;
+}
+
+export interface RegisterOpenApiToolsArgs {
+  /** The MCP server the generated tools are registered on. */
+  server: McpServer;
+  /** One or more OpenAPI documents to derive tools from. */
+  spec: OpenApiSpec | OpenApiSpec[];
+  /** Tuning options forwarded to {@link openApiToToolDefinitions}. */
+  options?: OpenApiToToolsOptions;
+  /**
+   * Performs the HTTP request for a resolved tool call and returns the raw
+   * response data. This package builds the method/url/body; the caller owns
+   * how the request is executed — base URL, auth headers, fetch impl, etc.
+   */
+  callApi: (request: ResolvedRequest) => Promise<unknown> | unknown;
+  /**
+   * Serialises the raw API data into the MCP tool's text payload.
+   * @default (data) => JSON.stringify(data, null, 2)
+   */
+  toText?: (data: unknown) => string;
+}
+
+const defaultToText = (data: unknown): string => {
+  return typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+};
+
+/**
+ * Derives MCP tools from OpenAPI document(s) and registers each on the given
+ * MCP server. Every tool's handler resolves the incoming camelCase args into a
+ * concrete HTTP request and delegates execution to `callApi`.
+ *
+ * @returns The list of {@link ToolDefinition} that were registered.
+ *
+ * @example
+ * ```typescript
+ * import { McpServer } from '@ttoss/http-server-mcp';
+ * import { registerOpenApiTools } from '@ttoss/http-server-mcp-openapi';
+ *
+ * const server = new McpServer({ name: 'my-api', version: '1.0.0' });
+ *
+ * registerOpenApiTools({
+ *   server,
+ *   spec: myOpenApiDocument,
+ *   callApi: async ({ method, url, body }) => {
+ *     const res = await fetch(`https://api.example.com${url}`, {
+ *       method,
+ *       headers: { 'Content-Type': 'application/json' },
+ *       body: body ? JSON.stringify(body) : undefined,
+ *     });
+ *     return res.json();
+ *   },
+ * });
+ * ```
+ */
+export const registerOpenApiTools = (
+  args: RegisterOpenApiToolsArgs
+): ToolDefinition[] => {
+  const toText = args.toText ?? defaultToText;
+  const tools = openApiToToolDefinitions({
+    spec: args.spec,
+    options: args.options,
+  });
+
+  for (const tool of tools) {
+    registerToolFromSchema(args.server, {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      handler: async (handlerArgs: Record<string, unknown>) => {
+        const url =
+          tool.path(handlerArgs) + (tool.query ? tool.query(handlerArgs) : '');
+        const data = await args.callApi({
+          method: tool.method,
+          url,
+          body: tool.body ? tool.body(handlerArgs) : undefined,
+          tool,
+        });
+        return { content: [{ type: 'text' as const, text: toText(data) }] };
+      },
+    });
+  }
+
+  return tools;
+};

--- a/packages/http-server-mcp-openapi/src/schema.ts
+++ b/packages/http-server-mcp-openapi/src/schema.ts
@@ -1,0 +1,232 @@
+import type { OpenApiSpec } from './types';
+
+type ResolvedSchema = {
+  type?: string;
+  required?: string[];
+  properties?: Record<string, unknown>;
+  oneOf?: Array<Record<string, unknown>>;
+  anyOf?: Array<Record<string, unknown>>;
+};
+
+const getAlternativeSchemas = (
+  schema: Record<string, unknown>
+): Array<Record<string, unknown>> | undefined => {
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
+    return schema.oneOf as Array<Record<string, unknown>>;
+  }
+
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+    return schema.anyOf as Array<Record<string, unknown>>;
+  }
+
+  return undefined;
+};
+
+const mergeResolvedSchemas = (
+  resolvedAlternatives: ResolvedSchema[]
+): ResolvedSchema => {
+  const mergedProperties = Object.assign(
+    {},
+    ...resolvedAlternatives.map((candidate) => {
+      return candidate.properties ?? {};
+    })
+  );
+
+  const requiredIntersection = resolvedAlternatives.reduce<
+    string[] | undefined
+  >((current, candidate) => {
+    const required = candidate.required ?? [];
+
+    if (current === undefined) {
+      return [...required];
+    }
+
+    return current.filter((field) => {
+      return required.includes(field);
+    });
+  }, undefined);
+
+  return {
+    type: 'object',
+    properties:
+      Object.keys(mergedProperties).length > 0 ? mergedProperties : undefined,
+    required:
+      requiredIntersection && requiredIntersection.length > 0
+        ? requiredIntersection
+        : undefined,
+  };
+};
+
+const dereferenceValue = (args: {
+  value: unknown;
+  spec: OpenApiSpec;
+  seenRefs: Set<string>;
+}): unknown => {
+  const { value, spec, seenRefs } = args;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      return dereferenceValue({ value: item, spec, seenRefs });
+    });
+  }
+
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+
+    if (typeof obj.$ref === 'string') {
+      const refName = obj.$ref.replace('#/components/schemas/', '');
+      // Guard against circular $refs: if already resolving this ref, stop
+      // recursing and return an empty schema rather than looping forever.
+      if (seenRefs.has(refName)) return {};
+      const resolved = spec.components?.schemas?.[refName];
+      return dereferenceValue({
+        value: resolved,
+        spec,
+        seenRefs: new Set(seenRefs).add(refName),
+      });
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, entryValue] of Object.entries(obj)) {
+      result[key] = dereferenceValue({ value: entryValue, spec, seenRefs });
+    }
+    return result;
+  }
+
+  return value;
+};
+
+/**
+ * Recursively inlines every `$ref` in a schema (including refs nested inside
+ * `properties`, `items`, `oneOf`, `anyOf`, etc.), producing a self-contained
+ * schema safe to hand to an MCP client or LLM provider as a tool definition —
+ * provider tool schemas have no `components` section to resolve refs against.
+ */
+export const dereferenceSchema = (
+  schema: Record<string, unknown> | undefined,
+  spec: OpenApiSpec
+): Record<string, unknown> | undefined => {
+  if (!schema) return schema;
+  return dereferenceValue({
+    value: schema,
+    spec,
+    seenRefs: new Set(),
+  }) as Record<string, unknown>;
+};
+
+/**
+ * Resolves a schema down to a single object shape: follows a top-level `$ref`
+ * and merges `oneOf` / `anyOf` alternatives (union of properties, intersection
+ * of `required`) so the caller sees one flat property set.
+ */
+export const resolveSchema = (
+  schema: Record<string, unknown> | undefined,
+  spec: OpenApiSpec
+): ResolvedSchema => {
+  if (!schema) return {};
+  if (typeof schema.$ref === 'string') {
+    const refName = schema.$ref.replace('#/components/schemas/', '');
+    const resolved = spec.components?.schemas?.[refName];
+    return resolveSchema(resolved as Record<string, unknown> | undefined, spec);
+  }
+
+  const alternatives = getAlternativeSchemas(schema);
+
+  if (alternatives) {
+    return mergeResolvedSchemas(
+      alternatives.map((candidate) => {
+        return resolveSchema(candidate, spec);
+      })
+    );
+  }
+
+  return schema;
+};
+
+/** Follows a parameter `$ref` into `components.parameters`, if present. */
+export const resolveParameter = (
+  param: Record<string, unknown> | undefined,
+  spec: OpenApiSpec
+): {
+  name?: string;
+  in?: string;
+  required?: boolean;
+  description?: string;
+  schema?: {
+    type?: string;
+    items?: { type?: string };
+  };
+} => {
+  if (!param) return {};
+  if (typeof param.$ref === 'string') {
+    const refName = param.$ref.replace('#/components/parameters/', '');
+    const resolved = spec.components?.parameters?.[refName];
+    return resolved || {};
+  }
+  return param;
+};
+
+/** Builds a function that substitutes path params into the path template. */
+export const buildPathFn = (
+  pathTemplate: string,
+  pathParams: Array<{ name: string; camelName: string }>
+): ((args: Record<string, unknown>) => string) => {
+  return (args: Record<string, unknown>) => {
+    let result = pathTemplate;
+    for (const { name, camelName } of pathParams) {
+      const value = args[camelName];
+      if (value !== undefined) {
+        result = result.replace(`{${name}}`, encodeURIComponent(String(value)));
+      }
+    }
+    return result;
+  };
+};
+
+/**
+ * Builds a function that serialises query params into a query string
+ * (including the leading `?`). Returns `undefined` when the op has no query
+ * params. Array values are appended once per element.
+ */
+export const buildQueryFn = (
+  queryParams: Array<{ name: string; camelName: string }>
+): ((args: Record<string, unknown>) => string) | undefined => {
+  if (queryParams.length === 0) return undefined;
+
+  return (args: Record<string, unknown>) => {
+    const search = new URLSearchParams();
+    for (const { name, camelName } of queryParams) {
+      const value = args[camelName];
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          search.append(name, String(item));
+        }
+      } else {
+        search.append(name, String(value));
+      }
+    }
+    const qs = search.toString();
+    return qs ? `?${qs}` : '';
+  };
+};
+
+/**
+ * Builds a function that maps camelCase args back to a snake_case request
+ * body, skipping `undefined` args. Returns `undefined` when the op has no body.
+ */
+export const buildBodyFn = (
+  bodyProps: Array<{ snakeName: string; camelName: string }>
+): ((args: Record<string, unknown>) => Record<string, unknown>) | undefined => {
+  if (bodyProps.length === 0) return undefined;
+
+  return (args: Record<string, unknown>) => {
+    const body: Record<string, unknown> = {};
+    for (const { snakeName, camelName } of bodyProps) {
+      if (args[camelName] !== undefined) {
+        body[snakeName] = args[camelName];
+      }
+    }
+    return body;
+  };
+};

--- a/packages/http-server-mcp-openapi/src/toolDefinitions.ts
+++ b/packages/http-server-mcp-openapi/src/toolDefinitions.ts
@@ -1,0 +1,377 @@
+import type { JsonObjectSchema } from '@ttoss/http-server-mcp';
+
+import {
+  buildBodyFn,
+  buildPathFn,
+  buildQueryFn,
+  dereferenceSchema,
+  resolveParameter,
+  resolveSchema,
+} from './schema';
+import {
+  DEFAULT_EXCLUDE_EXTENSION,
+  DEFAULT_SERVER_MANAGED_EXTENSION,
+  type JsonSchemaProperty,
+  type OpenApiSpec,
+  type OpenApiToToolsOptions,
+  type OperationSpec,
+  type RequestBodySpec,
+  type ToolDefinition,
+} from './types';
+
+/**
+ * Folds `_` and `-` separators into camelCase. OpenAPI operation and parameter
+ * names may be snake_case (`agent_id`) or kebab-case (`list-tools`), and MCP
+ * tool inputs are camelCase by convention, so both are folded here.
+ */
+export const snakeToCamel = (str: string): string => {
+  return str.replace(/[_-]([a-z])/g, (_, letter) => {
+    return letter.toUpperCase();
+  });
+};
+
+/** Converts a camelCase `operationId` to a kebab-case tool name. */
+export const operationIdToToolName = (operationId: string): string => {
+  return operationId
+    .replace(/([A-Z])/g, '-$1')
+    .toLowerCase()
+    .replace(/^-/, '');
+};
+
+export const getJsonSchemaType = (
+  schemaType: string | undefined
+): JsonSchemaProperty['type'] => {
+  if (schemaType === 'integer' || schemaType === 'number') return 'number';
+  if (schemaType === 'boolean') return 'boolean';
+  if (schemaType === 'array') return 'array';
+  if (schemaType === 'object') return 'object';
+  return 'string';
+};
+
+const sanitizeDescription = (description: string | undefined): string => {
+  return (description || '').replace(/'/g, "\\'").replace(/\n/g, ' ').trim();
+};
+
+export const buildInputSchema = (
+  pathParams: Array<{ name: string; camelName: string }>,
+  queryParams: Array<{
+    name: string;
+    camelName: string;
+    description: string;
+    required: boolean;
+    type: string;
+  }>,
+  bodyProps: Array<{
+    snakeName: string;
+    camelName: string;
+    description: string;
+    required: boolean;
+    type: string;
+    items?: unknown;
+  }>
+): JsonObjectSchema => {
+  const allParams = [...pathParams, ...queryParams, ...bodyProps];
+
+  if (allParams.length === 0) {
+    return {
+      type: 'object',
+    };
+  }
+
+  const requiredFields = [
+    ...pathParams.map((p) => {
+      return p.camelName;
+    }),
+    ...queryParams
+      .filter((p) => {
+        return p.required;
+      })
+      .map((p) => {
+        return p.camelName;
+      }),
+    ...bodyProps
+      .filter((p) => {
+        return p.required;
+      })
+      .map((p) => {
+        return p.camelName;
+      }),
+  ];
+
+  const properties: Record<string, JsonSchemaProperty> = {};
+  for (const param of allParams) {
+    if ('type' in param) {
+      const jsonType = getJsonSchemaType(param.type);
+      const description = sanitizeDescription(param.description);
+      if (param.type === 'array') {
+        const itemsSchema =
+          'items' in param && param.items
+            ? param.items
+            : { type: 'string' as const };
+        properties[param.camelName] = {
+          type: 'array',
+          items: itemsSchema,
+          description,
+        };
+      } else {
+        properties[param.camelName] = {
+          type: jsonType,
+          description,
+        };
+      }
+    } else {
+      // path param
+      properties[param.camelName] = {
+        type: 'string',
+        description: '',
+      };
+    }
+  }
+
+  return {
+    type: 'object',
+    properties,
+    required: requiredFields.length > 0 ? requiredFields : undefined,
+  };
+};
+
+export const extractPathParams = (args: {
+  parameters?: Array<{ name?: string; in?: string; [key: string]: unknown }>;
+  spec: OpenApiSpec;
+}): Array<{ name: string; camelName: string }> => {
+  return (args.parameters || [])
+    .map((p) => {
+      return resolveParameter(p, args.spec);
+    })
+    .filter((p) => {
+      return p.in === 'path';
+    })
+    .map((p) => {
+      return {
+        name: p.name || '',
+        camelName: snakeToCamel(p.name || ''),
+      };
+    });
+};
+
+export const extractQueryParams = (args: {
+  parameters?: Array<{ name?: string; in?: string; [key: string]: unknown }>;
+  spec: OpenApiSpec;
+}): Array<{
+  name: string;
+  camelName: string;
+  description: string;
+  required: boolean;
+  type: string;
+}> => {
+  return (args.parameters || [])
+    .map((p) => {
+      return resolveParameter(p, args.spec);
+    })
+    .filter((p) => {
+      return p.in === 'query';
+    })
+    .map((p) => {
+      return {
+        name: p.name || '',
+        camelName: snakeToCamel(p.name || ''),
+        description: p.description || '',
+        required: p.required || false,
+        type: p.schema?.type || 'string',
+      };
+    });
+};
+
+const resolveBodySchema = (args: {
+  requestBody?: RequestBodySpec;
+  spec: OpenApiSpec;
+}) => {
+  const rawBodySchema = args.requestBody?.content?.['application/json']?.schema;
+  const dereferencedBodySchema = dereferenceSchema(rawBodySchema, args.spec);
+  return resolveSchema(dereferencedBodySchema, args.spec);
+};
+
+/**
+ * snake_case names of every top-level property an operation's request schema
+ * declares, including server-managed ones.
+ */
+export const extractAcceptedBodyFields = (args: {
+  requestBody?: RequestBodySpec;
+  spec: OpenApiSpec;
+}): string[] => {
+  const bodySchema = resolveBodySchema(args);
+  return Object.keys(bodySchema?.properties ?? {});
+};
+
+export const extractBodyProps = (args: {
+  requestBody?: RequestBodySpec;
+  spec: OpenApiSpec;
+  serverManagedExtension: string;
+}): Array<{
+  snakeName: string;
+  camelName: string;
+  description: string;
+  required: boolean;
+  type: string;
+  items?: unknown;
+}> => {
+  const bodySchema = resolveBodySchema(args);
+  if (!bodySchema?.properties) return [];
+  const entries = Object.entries(bodySchema.properties).filter(
+    ([, value]: [string, unknown]) => {
+      const val = value as Record<string, unknown>;
+      return !val[args.serverManagedExtension];
+    }
+  );
+  return entries.map(([key, value]: [string, unknown]) => {
+    const val = value as {
+      description?: unknown;
+      type?: unknown;
+      items?: unknown;
+    };
+    return {
+      snakeName: key,
+      camelName: snakeToCamel(key),
+      description: typeof val.description === 'string' ? val.description : '',
+      required: (bodySchema.required || []).includes(key),
+      type: typeof val.type === 'string' ? val.type : 'string',
+      items: val.items,
+    };
+  });
+};
+
+/** Collects every `x-` prefixed extension declared on the operation. */
+const extractExtensions = (
+  operation: OperationSpec
+): Record<string, unknown> => {
+  const extensions: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(operation)) {
+    if (key.startsWith('x-')) {
+      extensions[key] = value;
+    }
+  }
+  return extensions;
+};
+
+export const processOperation = (args: {
+  pathTemplate: string;
+  method: string;
+  operation: OperationSpec;
+  spec: OpenApiSpec;
+  options: Required<OpenApiToToolsOptions>;
+}): ToolDefinition | null => {
+  const httpMethod = args.method.toUpperCase();
+  if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(httpMethod)) {
+    return null;
+  }
+
+  if (!args.operation.operationId) return null;
+
+  if (args.operation[args.options.excludeExtension]) {
+    return null;
+  }
+
+  const toolName = operationIdToToolName(args.operation.operationId);
+
+  const pathParams = extractPathParams({
+    parameters: args.operation.parameters || [],
+    spec: args.spec,
+  });
+
+  const queryParams = extractQueryParams({
+    parameters: args.operation.parameters || [],
+    spec: args.spec,
+  });
+
+  const bodyProps = extractBodyProps({
+    requestBody: args.operation.requestBody,
+    spec: args.spec,
+    serverManagedExtension: args.options.serverManagedExtension,
+  });
+
+  const inputSchema = buildInputSchema(pathParams, queryParams, bodyProps);
+
+  const acceptedBodyFields = extractAcceptedBodyFields({
+    requestBody: args.operation.requestBody,
+    spec: args.spec,
+  });
+
+  return {
+    name: toolName,
+    description: sanitizeDescription(args.operation.description),
+    inputSchema,
+    method: httpMethod,
+    pathTemplate: args.pathTemplate,
+    operationId: args.operation.operationId,
+    path: buildPathFn(args.pathTemplate, pathParams),
+    query: buildQueryFn(queryParams),
+    body: buildBodyFn(bodyProps),
+    acceptedBodyFields,
+    extensions: extractExtensions(args.operation),
+  };
+};
+
+export const processPath = (args: {
+  pathTemplate: string;
+  pathItem: Record<string, OperationSpec>;
+  spec: OpenApiSpec;
+  options: Required<OpenApiToToolsOptions>;
+}): ToolDefinition[] => {
+  const tools: ToolDefinition[] = [];
+  for (const [method, operation] of Object.entries(args.pathItem)) {
+    const tool = processOperation({
+      pathTemplate: args.pathTemplate,
+      method,
+      operation,
+      spec: args.spec,
+      options: args.options,
+    });
+    if (tool) {
+      tools.push(tool);
+    }
+  }
+  return tools;
+};
+
+/**
+ * Translates one or more OpenAPI documents into REST-backed MCP tool
+ * definitions. Each translatable operation (has an `operationId`, a supported
+ * HTTP method, and is not excluded) becomes one {@link ToolDefinition}.
+ *
+ * @example
+ * ```typescript
+ * import { openApiToToolDefinitions } from '@ttoss/http-server-mcp-openapi';
+ *
+ * const tools = openApiToToolDefinitions({ spec: myOpenApiDocument });
+ * ```
+ */
+export const openApiToToolDefinitions = (args: {
+  spec: OpenApiSpec | OpenApiSpec[];
+  options?: OpenApiToToolsOptions;
+}): ToolDefinition[] => {
+  const options: Required<OpenApiToToolsOptions> = {
+    excludeExtension:
+      args.options?.excludeExtension ?? DEFAULT_EXCLUDE_EXTENSION,
+    serverManagedExtension:
+      args.options?.serverManagedExtension ?? DEFAULT_SERVER_MANAGED_EXTENSION,
+  };
+
+  const specs = Array.isArray(args.spec) ? args.spec : [args.spec];
+  const tools: ToolDefinition[] = [];
+
+  for (const spec of specs) {
+    const paths = spec.paths || {};
+    for (const [pathTemplate, pathItem] of Object.entries(paths)) {
+      tools.push(
+        ...processPath({
+          pathTemplate,
+          pathItem: pathItem as Record<string, OperationSpec>,
+          spec,
+          options,
+        })
+      );
+    }
+  }
+
+  return tools;
+};

--- a/packages/http-server-mcp-openapi/src/types.ts
+++ b/packages/http-server-mcp-openapi/src/types.ts
@@ -1,0 +1,122 @@
+import type { JsonObjectSchema } from '@ttoss/http-server-mcp';
+
+/**
+ * A single JSON Schema property descriptor as emitted for a tool's
+ * `inputSchema`. Only the subset of JSON Schema the generator produces is
+ * modelled here; the value is forwarded verbatim over the MCP wire protocol.
+ */
+export interface JsonSchemaProperty {
+  type:
+    | 'string'
+    | 'number'
+    | 'boolean'
+    | 'array'
+    | 'integer'
+    | 'object'
+    | 'null';
+  description?: string;
+  items?: unknown;
+}
+
+/**
+ * A REST-backed MCP tool derived from a single OpenAPI operation.
+ *
+ * The `path` / `query` / `body` builders turn the camelCase arguments an MCP
+ * client sends into the pieces of an HTTP request against the original REST
+ * API. They intentionally hold no transport concerns (base URL, auth); the
+ * caller wires those in when it performs the request.
+ */
+export interface ToolDefinition {
+  /** kebab-case tool name derived from the operation's `operationId`. */
+  name: string;
+  /** Sanitised operation description (quotes escaped, newlines flattened). */
+  description: string;
+  /** Plain JSON Schema describing the tool's camelCase input object. */
+  inputSchema: JsonObjectSchema;
+  /** Uppercase HTTP method (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`). */
+  method: string;
+  /** The raw OpenAPI path template, e.g. `/agents/{agent_id}`. */
+  pathTemplate: string;
+  /** The operation's `operationId`. */
+  operationId: string;
+  /** Builds the request path, substituting path params from the args. */
+  path: (args: Record<string, unknown>) => string;
+  /** Builds the query string (including leading `?`), or `undefined` if none. */
+  query?: (args: Record<string, unknown>) => string;
+  /** Builds the snake_case request body, or `undefined` if the op has no body. */
+  body?: (args: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * snake_case names of every top-level request-body property the operation's
+   * schema declares, including server-managed ones hidden from `inputSchema`.
+   */
+  acceptedBodyFields: string[];
+  /**
+   * Every `x-` prefixed extension declared on the operation, forwarded
+   * verbatim. Lets consumers read custom metadata (e.g. `x-iam-action`)
+   * without this package needing to know about it.
+   */
+  extensions: Record<string, unknown>;
+}
+
+/** Minimal shape of an OpenAPI document consumed by the generator. */
+export interface OpenApiSpec {
+  paths?: Record<string, Record<string, unknown>>;
+  components?: {
+    schemas?: Record<string, unknown>;
+    parameters?: Record<string, unknown>;
+  };
+}
+
+export type RequestBodySpec = {
+  required?: boolean;
+  content?: {
+    'application/json'?: {
+      schema?: {
+        type?: string;
+        required?: string[];
+        properties?: Record<string, unknown>;
+        oneOf?: Array<Record<string, unknown>>;
+        anyOf?: Array<Record<string, unknown>>;
+        $ref?: string;
+      };
+    };
+  };
+};
+
+export interface OperationSpec {
+  operationId?: string;
+  description?: string;
+  parameters?: Array<{
+    name?: string;
+    in?: string;
+    required?: boolean;
+    description?: string;
+    schema?: {
+      type?: string;
+      items?: { type?: string };
+    };
+    $ref?: string;
+  }>;
+  requestBody?: RequestBodySpec;
+  [extension: string]: unknown;
+}
+
+/** Options that tune how operations and body properties are translated. */
+export interface OpenApiToToolsOptions {
+  /**
+   * Operation-level extension flag that, when truthy, excludes the operation
+   * from the generated tool surface.
+   * @default 'x-mcp-exclude'
+   */
+  excludeExtension?: string;
+  /**
+   * Body-property extension flag that, when truthy, hides the property from the
+   * generated `inputSchema` while keeping it in `acceptedBodyFields` (for
+   * server-managed fields the API sets itself).
+   * @default 'x-mcp-server-managed'
+   */
+  serverManagedExtension?: string;
+}
+
+export const DEFAULT_EXCLUDE_EXTENSION = 'x-mcp-exclude';
+export const DEFAULT_SERVER_MANAGED_EXTENSION = 'x-mcp-server-managed';

--- a/packages/http-server-mcp-openapi/tests/tsconfig.json
+++ b/packages/http-server-mcp-openapi/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@ttoss/config/tsconfig.test.json",
+  "compilerOptions": {
+    "paths": {
+      "src/*": ["../src/*"],
+      "tests/*": ["./*"]
+    }
+  }
+}

--- a/packages/http-server-mcp-openapi/tests/unit/babel.config.cjs
+++ b/packages/http-server-mcp-openapi/tests/unit/babel.config.cjs
@@ -1,0 +1,5 @@
+const { babelConfig } = require('@ttoss/config');
+
+const config = babelConfig({});
+
+module.exports = config;

--- a/packages/http-server-mcp-openapi/tests/unit/fixtures/openApiSpec.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/fixtures/openApiSpec.ts
@@ -1,0 +1,163 @@
+import type { OpenApiSpec } from 'src/index';
+
+/**
+ * A realistic OpenAPI document exercising every branch of the generator:
+ * path/query/body params, `$ref`s (schema and parameter), `oneOf`/`anyOf`,
+ * array items, server-managed fields, circular refs, and excluded operations.
+ */
+export const testSpec: OpenApiSpec = {
+  paths: {
+    '/agents': {
+      get: {
+        operationId: 'listAgents',
+        description: "List all agents.\nSupports filters.'quoted'",
+        parameters: [
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            description: 'Max results',
+            schema: { type: 'integer' },
+          },
+          {
+            name: 'tags',
+            in: 'query',
+            required: true,
+            description: 'Filter by tags',
+            schema: { type: 'array', items: { type: 'string' } },
+          },
+          { $ref: '#/components/parameters/ProjectId' },
+        ],
+      },
+      post: {
+        operationId: 'createAgent',
+        description: 'Create an agent',
+        'x-iam-action': 'agents:CreateAgent',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/CreateAgentBody' },
+            },
+          },
+        },
+      },
+    },
+    '/agents/{agent_id}': {
+      get: {
+        operationId: 'getAgent',
+        description: 'Get an agent by ID',
+        parameters: [
+          {
+            name: 'agent_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+      },
+      delete: {
+        operationId: 'deleteAgent',
+        description: 'Delete an agent',
+        parameters: [
+          {
+            name: 'agent_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+      },
+      // Unsupported HTTP method — must be skipped.
+      head: {
+        operationId: 'headAgent',
+        description: 'ignored',
+      },
+    },
+    '/internal': {
+      // Excluded from the MCP surface via the exclude extension.
+      get: {
+        operationId: 'internalOp',
+        description: 'internal',
+        'x-mcp-exclude': true,
+      },
+      // No operationId — must be skipped.
+      post: {
+        description: 'anonymous',
+      },
+    },
+    '/actors': {
+      post: {
+        operationId: 'createActor',
+        description: 'Create an actor (agent xor chat)',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  { $ref: '#/components/schemas/AgentActor' },
+                  { $ref: '#/components/schemas/ChatActor' },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    parameters: {
+      ProjectId: {
+        name: 'project_id',
+        in: 'query',
+        required: true,
+        description: 'Project scope',
+        schema: { type: 'string' },
+      },
+    },
+    schemas: {
+      CreateAgentBody: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string', description: 'Agent name' },
+          model_config: { $ref: '#/components/schemas/ModelConfig' },
+          skill_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Attached skills',
+          },
+          id: {
+            type: 'string',
+            description: 'Server-assigned id',
+            'x-mcp-server-managed': true,
+          },
+        },
+      },
+      ModelConfig: {
+        type: 'object',
+        properties: {
+          temperature: { type: 'number' },
+          // Circular ref back to CreateAgentBody to exercise the guard.
+          parent: { $ref: '#/components/schemas/CreateAgentBody' },
+        },
+      },
+      AgentActor: {
+        type: 'object',
+        required: ['agent_id', 'name'],
+        properties: {
+          name: { type: 'string' },
+          agent_id: { type: 'string' },
+        },
+      },
+      ChatActor: {
+        type: 'object',
+        required: ['chat_id', 'name'],
+        properties: {
+          name: { type: 'string' },
+          chat_id: { type: 'string' },
+        },
+      },
+    },
+  },
+};

--- a/packages/http-server-mcp-openapi/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/jest.config.ts
@@ -1,0 +1,13 @@
+import { jestUnitConfig } from '@ttoss/config';
+
+export default {
+  ...jestUnitConfig(),
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+};

--- a/packages/http-server-mcp-openapi/tests/unit/tests/helpers.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/helpers.test.ts
@@ -1,0 +1,307 @@
+import {
+  buildInputSchema,
+  buildPathFn,
+  buildQueryFn,
+  dereferenceSchema,
+  extractPathParams,
+  extractQueryParams,
+  getJsonSchemaType,
+  openApiToToolDefinitions,
+  operationIdToToolName,
+  resolveParameter,
+  resolveSchema,
+  snakeToCamel,
+} from 'src/index';
+
+describe('extract helpers with no parameters', () => {
+  test('return empty arrays when parameters are omitted', () => {
+    expect(extractPathParams({ spec: {} })).toEqual([]);
+    expect(extractQueryParams({ spec: {} })).toEqual([]);
+  });
+});
+
+describe('snakeToCamel', () => {
+  test('folds underscores and hyphens', () => {
+    expect(snakeToCamel('agent_id')).toBe('agentId');
+    expect(snakeToCamel('list-tools')).toBe('listTools');
+    expect(snakeToCamel('plain')).toBe('plain');
+  });
+});
+
+describe('operationIdToToolName', () => {
+  test('camelCase to kebab-case', () => {
+    expect(operationIdToToolName('listAgents')).toBe('list-agents');
+    expect(operationIdToToolName('GetAgent')).toBe('get-agent');
+  });
+});
+
+describe('getJsonSchemaType', () => {
+  test('maps every OpenAPI type', () => {
+    expect(getJsonSchemaType('integer')).toBe('number');
+    expect(getJsonSchemaType('number')).toBe('number');
+    expect(getJsonSchemaType('boolean')).toBe('boolean');
+    expect(getJsonSchemaType('array')).toBe('array');
+    expect(getJsonSchemaType('object')).toBe('object');
+    expect(getJsonSchemaType(undefined)).toBe('string');
+    expect(getJsonSchemaType('anything-else')).toBe('string');
+  });
+});
+
+describe('buildInputSchema', () => {
+  test('defaults array items to string when none declared', () => {
+    const schema = buildInputSchema(
+      [],
+      [],
+      [
+        {
+          snakeName: 'ids',
+          camelName: 'ids',
+          description: 'the ids',
+          required: false,
+          type: 'array',
+        },
+      ]
+    );
+    const props = schema.properties as Record<string, unknown>;
+    expect(props.ids).toEqual({
+      type: 'array',
+      items: { type: 'string' },
+      description: 'the ids',
+    });
+    expect(schema.required).toBeUndefined();
+  });
+
+  test('maps a boolean body prop', () => {
+    const schema = buildInputSchema(
+      [],
+      [],
+      [
+        {
+          snakeName: 'enabled',
+          camelName: 'enabled',
+          description: '',
+          required: true,
+          type: 'boolean',
+        },
+      ]
+    );
+    const props = schema.properties as Record<string, unknown>;
+    expect(props.enabled).toEqual({ type: 'boolean', description: '' });
+    expect(schema.required).toEqual(['enabled']);
+  });
+});
+
+describe('resolveParameter', () => {
+  const spec = {
+    components: { parameters: { Known: { name: 'known', in: 'query' } } },
+  };
+
+  test('returns {} for undefined', () => {
+    expect(resolveParameter(undefined, spec)).toEqual({});
+  });
+
+  test('resolves a known $ref', () => {
+    expect(
+      resolveParameter({ $ref: '#/components/parameters/Known' }, spec)
+    ).toEqual({ name: 'known', in: 'query' });
+  });
+
+  test('returns {} for an unresolvable $ref', () => {
+    expect(
+      resolveParameter({ $ref: '#/components/parameters/Missing' }, spec)
+    ).toEqual({});
+  });
+});
+
+describe('resolveSchema', () => {
+  test('returns {} for undefined', () => {
+    expect(resolveSchema(undefined, {})).toEqual({});
+  });
+
+  test('follows a top-level $ref into components.schemas', () => {
+    const spec = {
+      components: {
+        schemas: {
+          Widget: {
+            type: 'object',
+            properties: { size: {} },
+            required: ['size'],
+          },
+        },
+      },
+    };
+    const resolved = resolveSchema(
+      { $ref: '#/components/schemas/Widget' },
+      spec
+    );
+    expect(resolved.required).toEqual(['size']);
+    expect(resolved.properties).toHaveProperty('size');
+  });
+
+  test('merges anyOf alternatives (union props, intersection required)', () => {
+    const merged = resolveSchema(
+      {
+        anyOf: [
+          { type: 'object', properties: { a: {}, b: {} }, required: ['a'] },
+          {
+            type: 'object',
+            properties: { b: {}, c: {} },
+            required: ['a', 'c'],
+          },
+        ],
+      },
+      {}
+    );
+    expect(Object.keys(merged.properties ?? {}).sort()).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    expect(merged.required).toEqual(['a']);
+  });
+
+  test('collapses empty alternatives to undefined props/required', () => {
+    const merged = resolveSchema(
+      { oneOf: [{ type: 'object' }, { type: 'object' }] },
+      {}
+    );
+    expect(merged.properties).toBeUndefined();
+    expect(merged.required).toBeUndefined();
+  });
+});
+
+describe('dereferenceSchema', () => {
+  test('returns undefined when given no schema', () => {
+    expect(dereferenceSchema(undefined, {})).toBeUndefined();
+  });
+
+  test('inlines nested refs and stops at circular ones', () => {
+    const spec = {
+      components: {
+        schemas: {
+          A: {
+            type: 'object',
+            properties: { b: { $ref: '#/components/schemas/B' } },
+          },
+          B: {
+            type: 'object',
+            properties: { a: { $ref: '#/components/schemas/A' } },
+          },
+        },
+      },
+    };
+    const result = dereferenceSchema(
+      { $ref: '#/components/schemas/A' },
+      spec
+    ) as Record<
+      string,
+      { properties: { b: { properties: { a: Record<string, unknown> } } } }
+    >;
+    // A.b.a resolves back to A → circular guard returns {}.
+    expect(result.properties.b.properties.a).toEqual({});
+  });
+});
+
+describe('buildPathFn', () => {
+  test('leaves the placeholder when the arg is missing', () => {
+    const fn = buildPathFn('/a/{id}', [{ name: 'id', camelName: 'id' }]);
+    expect(fn({})).toBe('/a/{id}');
+  });
+});
+
+describe('buildQueryFn', () => {
+  test('returns an empty string when every value is absent', () => {
+    const fn = buildQueryFn([{ name: 'a', camelName: 'a' }]);
+    expect(fn?.({})).toBe('');
+  });
+});
+
+describe('path param without a name', () => {
+  test('defaults the name to an empty string', () => {
+    const [tool] = openApiToToolDefinitions({
+      spec: {
+        paths: {
+          '/x': {
+            get: { operationId: 'getX', parameters: [{ in: 'path' }] },
+          },
+        },
+      },
+    });
+    expect(tool.inputSchema.properties).toEqual({
+      '': { type: 'string', description: '' },
+    });
+  });
+});
+
+describe('sparse parameters fall back to defaults', () => {
+  test('unnamed / undescribed query param and typeless body prop', () => {
+    const [tool] = openApiToToolDefinitions({
+      spec: {
+        paths: {
+          '/x': {
+            post: {
+              operationId: 'postX',
+              parameters: [
+                // No name, no description, no schema — all defaulted.
+                { in: 'query' },
+              ],
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      // Property with neither type nor description.
+                      properties: { bare: {} },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const props = tool.inputSchema.properties as Record<
+      string,
+      { type: string; description?: string }
+    >;
+    // Unnamed query param camelCases to '' and defaults to a string.
+    expect(props['']).toEqual({ type: 'string', description: '' });
+    // Typeless body prop defaults to string with an empty description.
+    expect(props.bare).toEqual({ type: 'string', description: '' });
+    expect(tool.inputSchema.required).toBeUndefined();
+  });
+});
+
+describe('openApiToToolDefinitions with a custom server-managed extension', () => {
+  test('hides fields flagged by the configured extension only', () => {
+    const [tool] = openApiToToolDefinitions({
+      spec: {
+        paths: {
+          '/x': {
+            post: {
+              operationId: 'postX',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        keep: { type: 'string' },
+                        drop: { type: 'string', 'x-managed': true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      options: { serverManagedExtension: 'x-managed' },
+    });
+    const props = tool.inputSchema.properties as Record<string, unknown>;
+    expect(Object.keys(props)).toEqual(['keep']);
+    expect(tool.acceptedBodyFields.sort()).toEqual(['drop', 'keep']);
+  });
+});

--- a/packages/http-server-mcp-openapi/tests/unit/tests/openApiToToolDefinitions.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/openApiToToolDefinitions.test.ts
@@ -1,0 +1,218 @@
+import { openApiToToolDefinitions, type ToolDefinition } from 'src/index';
+
+import { testSpec } from '../fixtures/openApiSpec';
+
+const byName = (tools: ToolDefinition[], name: string): ToolDefinition => {
+  const tool = tools.find((t) => {
+    return t.name === name;
+  });
+  if (!tool) throw new Error(`tool ${name} not found`);
+  return tool;
+};
+
+describe('openApiToToolDefinitions', () => {
+  const tools = openApiToToolDefinitions({ spec: testSpec });
+
+  test('derives one tool per translatable operation', () => {
+    const names = tools
+      .map((t) => {
+        return t.name;
+      })
+      .sort();
+    expect(names).toEqual([
+      'create-actor',
+      'create-agent',
+      'delete-agent',
+      'get-agent',
+      'list-agents',
+    ]);
+  });
+
+  test('skips operations without an operationId', () => {
+    expect(
+      tools.some((t) => {
+        return t.pathTemplate === '/internal' && t.method === 'POST';
+      })
+    ).toBe(false);
+  });
+
+  test('skips unsupported HTTP methods (HEAD)', () => {
+    expect(
+      tools.some((t) => {
+        return t.operationId === 'headAgent';
+      })
+    ).toBe(false);
+  });
+
+  test('skips operations flagged with the exclude extension', () => {
+    expect(
+      tools.some((t) => {
+        return t.operationId === 'internalOp';
+      })
+    ).toBe(false);
+  });
+
+  test('kebab-cases the tool name and uppercases the method', () => {
+    const tool = byName(tools, 'list-agents');
+    expect(tool.method).toBe('GET');
+    expect(tool.operationId).toBe('listAgents');
+  });
+
+  test('sanitises description: escapes quotes and flattens newlines', () => {
+    const tool = byName(tools, 'list-agents');
+    expect(tool.description).toBe(
+      "List all agents. Supports filters.\\'quoted\\'"
+    );
+  });
+
+  test('exposes operation extensions verbatim', () => {
+    const tool = byName(tools, 'create-agent');
+    expect(tool.extensions['x-iam-action']).toBe('agents:CreateAgent');
+  });
+
+  describe('path parameters', () => {
+    test('camelCases path params and marks them required strings', () => {
+      const tool = byName(tools, 'get-agent');
+      expect(tool.inputSchema.properties).toEqual({
+        agentId: { type: 'string', description: '' },
+      });
+      expect(tool.inputSchema.required).toEqual(['agentId']);
+    });
+
+    test('builds a path with the param URL-encoded', () => {
+      const tool = byName(tools, 'get-agent');
+      expect(tool.path({ agentId: 'agt/1' })).toBe('/agents/agt%2F1');
+    });
+
+    test('has no query or body builder', () => {
+      const tool = byName(tools, 'get-agent');
+      expect(tool.query).toBeUndefined();
+      expect(tool.body).toBeUndefined();
+    });
+  });
+
+  describe('query parameters', () => {
+    const tool = byName(tools, 'list-agents');
+
+    test('resolves a parameter $ref (ProjectId)', () => {
+      expect(tool.inputSchema.properties).toHaveProperty('projectId');
+      expect(tool.inputSchema.required).toEqual(
+        expect.arrayContaining(['projectId', 'tags'])
+      );
+    });
+
+    test('maps integer query type to number and keeps optional out of required', () => {
+      const props = tool.inputSchema.properties as Record<
+        string,
+        { type: string; description?: string }
+      >;
+      expect(props.limit).toEqual({
+        type: 'number',
+        description: 'Max results',
+      });
+      expect(tool.inputSchema.required).not.toContain('limit');
+    });
+
+    test('models array query params with an items schema', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(props.tags).toEqual({
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Filter by tags',
+      });
+    });
+
+    test('serialises the query string, repeating array values', () => {
+      const qs = tool.query?.({
+        projectId: 'prj_1',
+        limit: 10,
+        tags: ['a', 'b'],
+      });
+      expect(qs).toBe('?limit=10&tags=a&tags=b&project_id=prj_1');
+    });
+
+    test('omits undefined and null query values', () => {
+      const qs = tool.query?.({ projectId: 'prj_1', limit: undefined });
+      expect(qs).toBe('?project_id=prj_1');
+    });
+  });
+
+  describe('request body', () => {
+    const tool = byName(tools, 'create-agent');
+
+    test('resolves a body $ref and camelCases properties', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(Object.keys(props).sort()).toEqual([
+        'modelConfig',
+        'name',
+        'skillIds',
+      ]);
+      expect(tool.inputSchema.required).toEqual(['name']);
+    });
+
+    test('hides server-managed fields from inputSchema but keeps them accepted', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(props).not.toHaveProperty('id');
+      expect(tool.acceptedBodyFields).toEqual(
+        expect.arrayContaining(['name', 'model_config', 'skill_ids', 'id'])
+      );
+    });
+
+    test('builds a snake_case body from camelCase args, dropping undefined', () => {
+      const body = tool.body?.({
+        name: 'Alpha',
+        skillIds: ['s1'],
+        modelConfig: undefined,
+      });
+      expect(body).toEqual({ name: 'Alpha', skill_ids: ['s1'] });
+    });
+  });
+
+  describe('oneOf / anyOf body', () => {
+    const tool = byName(tools, 'create-actor');
+
+    test('merges alternatives: union of props, intersection of required', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(Object.keys(props).sort()).toEqual(['agentId', 'chatId', 'name']);
+      // `name` is required in both alternatives; agent_id/chat_id only in one.
+      expect(tool.inputSchema.required).toEqual(['name']);
+    });
+  });
+
+  describe('multiple specs and options', () => {
+    test('flattens tools across an array of specs', () => {
+      const all = openApiToToolDefinitions({ spec: [testSpec, testSpec] });
+      expect(all).toHaveLength(tools.length * 2);
+    });
+
+    test('honours a custom exclude extension', () => {
+      const custom = openApiToToolDefinitions({
+        spec: {
+          paths: {
+            '/x': {
+              get: { operationId: 'getX', 'x-hide': true },
+              post: { operationId: 'postX' },
+            },
+          },
+        },
+        options: { excludeExtension: 'x-hide' },
+      });
+      expect(
+        custom.map((t) => {
+          return t.name;
+        })
+      ).toEqual(['post-x']);
+    });
+
+    test('empty schema for an operation with no params', () => {
+      const [tool] = openApiToToolDefinitions({
+        spec: { paths: { '/ping': { get: { operationId: 'ping' } } } },
+      });
+      expect(tool.inputSchema).toEqual({ type: 'object' });
+    });
+
+    test('handles a spec with no paths', () => {
+      expect(openApiToToolDefinitions({ spec: {} })).toEqual([]);
+    });
+  });
+});

--- a/packages/http-server-mcp-openapi/tests/unit/tests/registerOpenApiTools.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/registerOpenApiTools.test.ts
@@ -1,0 +1,200 @@
+import { App, bodyParser } from '@ttoss/http-server';
+import { createMcpRouter, McpServer } from '@ttoss/http-server-mcp';
+import { registerOpenApiTools, type ResolvedRequest } from 'src/index';
+import request from 'supertest';
+
+import { testSpec } from '../fixtures/openApiSpec';
+
+const sendMcpRequest = (
+  app: ReturnType<typeof App.prototype.callback>,
+  body: Record<string, unknown>
+) => {
+  return request(app)
+    .post('/mcp')
+    .send(body)
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json, text/event-stream');
+};
+
+/** Parse the JSON-RPC result out of an MCP HTTP response (JSON or SSE). */
+const parseRpc = (res: request.Response): Record<string, unknown> => {
+  if (typeof res.body === 'object' && res.body?.result) return res.body.result;
+  const text: string = res.text || '';
+  const line = text.split('\n').find((l) => {
+    return l.startsWith('data:');
+  });
+  const json = line ? line.replace(/^data:\s*/, '') : text;
+  return JSON.parse(json).result;
+};
+
+const buildApp = (calls: ResolvedRequest[]) => {
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  const tools = registerOpenApiTools({
+    server,
+    spec: testSpec,
+    callApi: (req) => {
+      calls.push(req);
+      return { ok: true, url: req.url };
+    },
+  });
+  const app = new App();
+  app.use(bodyParser());
+  const router = createMcpRouter(server);
+  app.use(router.routes());
+  app.use(router.allowedMethods());
+  return { app: app.callback(), tools };
+};
+
+describe('registerOpenApitools', () => {
+  test('returns the registered tool definitions', () => {
+    const { tools } = buildApp([]);
+    expect(
+      tools.map((t) => {
+        return t.name;
+      })
+    ).toContain('create-agent');
+  });
+
+  test('lists every derived tool over the MCP wire with its JSON Schema', async () => {
+    const { app } = buildApp([]);
+    const res = await sendMcpRequest(app, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    });
+    expect(res.status).toBe(200);
+    const result = parseRpc(res);
+    const list = result.tools as Array<{
+      name: string;
+      inputSchema: Record<string, unknown>;
+    }>;
+    const names = list
+      .map((t) => {
+        return t.name;
+      })
+      .sort();
+    expect(names).toEqual([
+      'create-actor',
+      'create-agent',
+      'delete-agent',
+      'get-agent',
+      'list-agents',
+    ]);
+    const getAgent = list.find((t) => {
+      return t.name === 'get-agent';
+    })!;
+    // Verbatim JSON Schema (not Zod-derived) is forwarded to clients.
+    expect(getAgent.inputSchema.properties).toEqual({
+      agentId: { type: 'string', description: '' },
+    });
+  });
+
+  test('resolves a GET tool call into a method/url and returns the payload', async () => {
+    const calls: ResolvedRequest[] = [];
+    const { app } = buildApp(calls);
+    const res = await sendMcpRequest(app, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'get-agent', arguments: { agentId: 'agt_1' } },
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe('/agents/agt_1');
+    expect(calls[0].body).toBeUndefined();
+    expect(calls[0].tool.operationId).toBe('getAgent');
+
+    const result = parseRpc(res);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0].text)).toEqual({
+      ok: true,
+      url: '/agents/agt_1',
+    });
+  });
+
+  test('resolves a POST tool call into a snake_case body', async () => {
+    const calls: ResolvedRequest[] = [];
+    const { app } = buildApp(calls);
+    await sendMcpRequest(app, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'create-agent',
+        arguments: { name: 'Alpha', skillIds: ['s1'] },
+      },
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('/agents');
+    expect(calls[0].body).toEqual({ name: 'Alpha', skill_ids: ['s1'] });
+  });
+
+  test('builds a query string for a list tool call', async () => {
+    const calls: ResolvedRequest[] = [];
+    const { app } = buildApp(calls);
+    await sendMcpRequest(app, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'list-agents',
+        arguments: { projectId: 'prj_1', tags: ['x'] },
+      },
+    });
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe('/agents?tags=x&project_id=prj_1');
+  });
+
+  test('custom toText controls the text payload; string data passes through', async () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' });
+    registerOpenApiTools({
+      server,
+      spec: testSpec,
+      callApi: () => {
+        return 'raw-string';
+      },
+      toText: (data) => {
+        return `wrapped:${String(data)}`;
+      },
+    });
+    const app = new App();
+    app.use(bodyParser());
+    const router = createMcpRouter(server);
+    app.use(router.routes());
+    const res = await sendMcpRequest(app.callback(), {
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'tools/call',
+      params: { name: 'get-agent', arguments: { agentId: 'a' } },
+    });
+    const result = parseRpc(res);
+    const content = result.content as Array<{ text: string }>;
+    expect(content[0].text).toBe('wrapped:raw-string');
+  });
+
+  test('default toText returns a string payload verbatim', async () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' });
+    registerOpenApiTools({
+      server,
+      spec: testSpec,
+      callApi: () => {
+        return 'plain';
+      },
+    });
+    const app = new App();
+    app.use(bodyParser());
+    const router = createMcpRouter(server);
+    app.use(router.routes());
+    const res = await sendMcpRequest(app.callback(), {
+      jsonrpc: '2.0',
+      id: 6,
+      method: 'tools/call',
+      params: { name: 'get-agent', arguments: { agentId: 'a' } },
+    });
+    const result = parseRpc(res);
+    const content = result.content as Array<{ text: string }>;
+    expect(content[0].text).toBe('plain');
+  });
+});

--- a/packages/http-server-mcp-openapi/tsconfig.json
+++ b/packages/http-server-mcp-openapi/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ttoss/config/tsconfig.json"
+}

--- a/packages/http-server-mcp-openapi/tsdown.config.ts
+++ b/packages/http-server-mcp-openapi/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { tsdownConfig } from '@ttoss/config';
+
+export default tsdownConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -767,7 +767,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -1536,6 +1536,28 @@ importers:
       '@types/koa':
         specifier: ^3.0.3
         version: 3.0.3
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+
+  packages/http-server-mcp-openapi:
+    dependencies:
+      '@ttoss/http-server-mcp':
+        specifier: workspace:^
+        version: link:../http-server-mcp
+    devDependencies:
+      '@ttoss/config':
+        specifier: workspace:^
+        version: link:../config
+      '@ttoss/http-server':
+        specifier: workspace:^
+        version: link:../http-server
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
@@ -24044,7 +24066,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -24055,7 +24077,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -24063,11 +24085,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -24076,13 +24098,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -24090,7 +24112,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@ts-morph/common@0.29.0':
@@ -34468,7 +34490,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
## Overview

Adds `@ttoss/http-server-mcp-openapi`, a new package that derives [Model Context Protocol](https://modelcontextprotocol.io) tools from one or more OpenAPI documents and registers them on a [`@ttoss/http-server-mcp`](https://ttoss.dev/docs/modules/packages/http-server-mcp) server.

This generalizes the OpenAPI→MCP tool derivation that SOAT (`ttoss/soat`) currently keeps private inside `@soat/server` (`soatTools.ts` + helpers), turning it into a reusable, transport-agnostic ttoss package. The OpenAPI spec becomes the single source of truth for both a REST surface and its MCP tool surface.

## What it does

Each translatable operation (has an `operationId`, a supported HTTP method — `GET`/`POST`/`PUT`/`PATCH`/`DELETE` — and is not excluded) becomes one MCP tool whose handler resolves the incoming **camelCase** arguments into a concrete HTTP request (method, path, query string, **snake_case** body) against the underlying REST API. The caller owns request execution via a `callApi` function, so the package stays free of base-URL/auth/fetch concerns.

## Public API

- **`openApiToToolDefinitions({ spec, options? })`** — pure `OpenApiSpec | OpenApiSpec[]` → `ToolDefinition[]` translation. Resolves `$ref`, merges `oneOf`/`anyOf` (union of properties, intersection of `required`), inlines array `items`, and guards against circular `$ref`s.
- **`registerOpenApiTools({ server, spec, callApi, toText?, options? })`** — convenience that registers every derived tool on an `McpServer` via `registerToolFromSchema`, returning the `ToolDefinition[]`.
- Lower-level helpers (`processOperation`, `extractBodyProps`, `buildPathFn`, `resolveSchema`, …) are exported for advanced use.

### Options / extensions

- `excludeExtension` (default `x-mcp-exclude`) — operations flagged truthy are skipped.
- `serverManagedExtension` (default `x-mcp-server-managed`) — body fields flagged truthy are hidden from the tool `inputSchema` but kept in `acceptedBodyFields`.
- Every `x-` operation extension is forwarded verbatim on `tool.extensions` (so consumers like SOAT can read `x-iam-action` without this package knowing about it).

## Tests

50 unit tests, 100% statement/branch/function/line coverage. Pure-parser tests plus integration tests that drive the real MCP endpoint (`tools/list` and `tools/call`) via `createMcpRouter` + supertest and assert the resolved `method`/`url`/`body`.

## Notes

- `pnpm build` cannot be verified in this environment — an unrelated, pre-existing `babel-plugin-formatjs` / `@babel/helper-plugin-utils` linking error fails the build for every package here (confirmed against an untouched package). Source was type-checked directly with `tsc` and passes.
- `syncpack lint` and the repo lint hooks pass. No changes to existing packages.

## Follow-up (not in this PR)

SOAT could adopt this package to replace its in-repo `soatTools.ts` derivation, keeping `x-iam-action` support via `tool.extensions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRycNBEYXLoeV9r3esGBpd)_