### PR TITLE
fix(geovis): use absolute ADR URLs in README to unblock docs build

### DIFF
--- a/packages/geovis/README.md
+++ b/packages/geovis/README.md
@@ -1055,7 +1055,7 @@ const LayerControls = () => {
 
 ## AI Action Surface (`dispatch`)
 
-`runtime.dispatch(action)` is the recommended way to steer a live map — a closed, typed vocabulary of semantic operations (PRD-002, [ADR-0003](./docs/adr/0003-semantic-action-surface.md)) that validates against the current spec before compiling to the same `SpecPatch`/`update`/`setView` mechanisms `applyPatch` uses. Prefer it over hand-written `SpecPatch`es: it targets stable ids instead of internal paint paths, rejects unknown targets with a repairable `GeoVisResult`, and every call — accepted or rejected — is recorded on the action log for audit.
+`runtime.dispatch(action)` is the recommended way to steer a live map — a closed, typed vocabulary of semantic operations (PRD-002, [ADR-0003](https://github.com/ttoss/ttoss/blob/main/packages/geovis/docs/adr/0003-semantic-action-surface.md)) that validates against the current spec before compiling to the same `SpecPatch`/`update`/`setView` mechanisms `applyPatch` uses. Prefer it over hand-written `SpecPatch`es: it targets stable ids instead of internal paint paths, rejects unknown targets with a repairable `GeoVisResult`, and every call — accepted or rejected — is recorded on the action log for audit.
 
 Currently implemented (the full v1 vocabulary): `toggle-layer`, `select-feature`, `set-map-data`, `set-filter`, `set-view-preset`.
 
@@ -1177,7 +1177,7 @@ Every dispatched action is recorded, accepted or rejected, with its `rationale` 
 
 ### Context packet
 
-`runtime.getContextPacket()` returns a versioned, read-only, metadata-only summary of the current map ([ADR-0004](./docs/adr/0004-ai-context-packet.md)) — never GeoJSON geometry, `mapData` rows, or full color/threshold lists. It names the same stable ids `dispatch()` accepts, so an AI (or any consumer) can decide what to do next without reading the full spec:
+`runtime.getContextPacket()` returns a versioned, read-only, metadata-only summary of the current map ([ADR-0004](https://github.com/ttoss/ttoss/blob/main/packages/geovis/docs/adr/0004-ai-context-packet.md)) — never GeoJSON geometry, `mapData` rows, or full color/threshold lists. It names the same stable ids `dispatch()` accepts, so an AI (or any consumer) can decide what to do next without reading the full spec:
 
 ```ts
 runtime.getContextPacket();


### PR DESCRIPTION
## Problem

The publish pipeline (`main.yml` → `.cicd/commands/main.sh`) runs `pnpm turbo run i18n build test` across the monorepo **before** `pnpm -r publish`. That build has failed on every push to `main` since the geovis docs landed (July 20) — runs for #1140, #1146, and #1157 all failed at the same step:

```
[ERROR] Client bundle compiled with errors therefore further build is impossible.
× MDX compilation failed for "docs/modules/packages/geovis/index.md"
  Cause: Markdown link `_media/0003-semantic-action-surface.md` (1058:133) couldn't be resolved.
Failed: @docs/website#build
```

Because the build fails before the publish step, **no package has published since the last successful release (#1132)** — including newly merged packages.

## Cause

`packages/geovis/README.md` links ADR-0003 and ADR-0004 with relative paths (`./docs/adr/*.md`). TypeDoc ingests the README as the package's docs page and rewrites relative Markdown links into `_media/…`, which the Docusaurus MDX loader cannot resolve. With `onBrokenMarkdownLinks: 'throw'` (docs/website config), this hard-fails `@docs/website#build`.

## Fix

Switch both links to absolute `github.com` URLs, matching the convention already used in `packages/geovis/docs/prds/prd-002-ai-operation-surface.md` (which links the same two ADRs by absolute URL). Verified these were the only two relative `.md` links in the README, and that no other package README has the same latent issue.

Since the PR pipeline runs `turbo run i18n build test --filter=...[main]`, `@docs/website` (a dependent of the changed geovis package) is rebuilt here — so this PR's own CI exercises the docs build and validates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRycNBEYXLoeV9r3esGBpd)_