### PR TITLE
fix(http-server-mcp-openapi): merge path-item-level OpenAPI parameters

### DIFF
--- a/packages/http-server-mcp-openapi/README.md
+++ b/packages/http-server-mcp-openapi/README.md
@@ -62,6 +62,9 @@ Each OpenAPI operation with an `operationId` and a supported HTTP method
 
 Path params are always required strings. Query and body params carry their
 declared type and `required` flag. Array params keep their `items` schema.
+Parameters declared at the **path-item level** (shared by every operation on a
+path) are merged into each operation; an operation-level parameter overrides a
+path-item one with the same `name`+`in`.
 
 Tool arguments are **camelCase** (`agentId`, `projectId`); the generated
 request path, query string, and body use the original **snake_case** names.

--- a/packages/http-server-mcp-openapi/src/toolDefinitions.ts
+++ b/packages/http-server-mcp-openapi/src/toolDefinitions.ts
@@ -135,11 +135,24 @@ export const buildInputSchema = (
   };
 };
 
+/**
+ * Deduplicates parameter entries by `name`, keeping the last occurrence. When
+ * path-item-level and operation-level parameters are concatenated (operation
+ * last), this makes the operation-level entry win — as the OpenAPI spec requires.
+ */
+const dedupeByName = <T extends { name: string }>(items: T[]): T[] => {
+  const byName = new Map<string, T>();
+  for (const item of items) {
+    byName.set(item.name, item);
+  }
+  return [...byName.values()];
+};
+
 export const extractPathParams = (args: {
   parameters?: Array<{ name?: string; in?: string; [key: string]: unknown }>;
   spec: OpenApiSpec;
 }): Array<{ name: string; camelName: string }> => {
-  return (args.parameters || [])
+  const params = (args.parameters || [])
     .map((p) => {
       return resolveParameter(p, args.spec);
     })
@@ -152,6 +165,7 @@ export const extractPathParams = (args: {
         camelName: snakeToCamel(p.name || ''),
       };
     });
+  return dedupeByName(params);
 };
 
 export const extractQueryParams = (args: {
@@ -164,7 +178,7 @@ export const extractQueryParams = (args: {
   required: boolean;
   type: string;
 }> => {
-  return (args.parameters || [])
+  const params = (args.parameters || [])
     .map((p) => {
       return resolveParameter(p, args.spec);
     })
@@ -180,6 +194,7 @@ export const extractQueryParams = (args: {
         type: p.schema?.type || 'string',
       };
     });
+  return dedupeByName(params);
 };
 
 const resolveBodySchema = (args: {
@@ -259,6 +274,16 @@ export const processOperation = (args: {
   operation: OperationSpec;
   spec: OpenApiSpec;
   options: Required<OpenApiToToolsOptions>;
+  /**
+   * Parameters declared at the path-item level (shared by every operation on
+   * the path). Merged ahead of the operation's own parameters so operation-level
+   * entries win on a `name`+`in` clash.
+   */
+  pathItemParameters?: Array<{
+    name?: string;
+    in?: string;
+    [key: string]: unknown;
+  }>;
 }): ToolDefinition | null => {
   const httpMethod = args.method.toUpperCase();
   if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(httpMethod)) {
@@ -273,13 +298,20 @@ export const processOperation = (args: {
 
   const toolName = operationIdToToolName(args.operation.operationId);
 
+  // OpenAPI applies path-item-level parameters to every operation on the path;
+  // operation-level parameters override them on a matching name+in.
+  const parameters = [
+    ...(args.pathItemParameters ?? []),
+    ...(args.operation.parameters ?? []),
+  ];
+
   const pathParams = extractPathParams({
-    parameters: args.operation.parameters || [],
+    parameters,
     spec: args.spec,
   });
 
   const queryParams = extractQueryParams({
-    parameters: args.operation.parameters || [],
+    parameters,
     spec: args.spec,
   });
 
@@ -317,14 +349,23 @@ export const processPath = (args: {
   spec: OpenApiSpec;
   options: Required<OpenApiToToolsOptions>;
 }): ToolDefinition[] => {
+  // `parameters` is a path-item-level key (shared params), not an operation.
+  const rawPathItemParameters = (args.pathItem as { parameters?: unknown })
+    .parameters;
+  const pathItemParameters = Array.isArray(rawPathItemParameters)
+    ? rawPathItemParameters
+    : [];
+
   const tools: ToolDefinition[] = [];
   for (const [method, operation] of Object.entries(args.pathItem)) {
+    if (method === 'parameters') continue;
     const tool = processOperation({
       pathTemplate: args.pathTemplate,
       method,
       operation,
       spec: args.spec,
       options: args.options,
+      pathItemParameters,
     });
     if (tool) {
       tools.push(tool);

--- a/packages/http-server-mcp-openapi/tests/unit/tests/openApiToToolDefinitions.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/openApiToToolDefinitions.test.ts
@@ -1,4 +1,8 @@
-import { openApiToToolDefinitions, type ToolDefinition } from 'src/index';
+import {
+  openApiToToolDefinitions,
+  processOperation,
+  type ToolDefinition,
+} from 'src/index';
 
 import { testSpec } from '../fixtures/openApiSpec';
 
@@ -213,6 +217,134 @@ describe('openApiToToolDefinitions', () => {
 
     test('handles a spec with no paths', () => {
       expect(openApiToToolDefinitions({ spec: {} })).toEqual([]);
+    });
+  });
+
+  describe('path-item-level parameters', () => {
+    const spec = {
+      paths: {
+        '/projects/{project_id}/agents/{agent_id}': {
+          // Shared across every operation on this path (incl. a $ref and a query param).
+          parameters: [
+            {
+              name: 'project_id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+            { $ref: '#/components/parameters/AgentId' },
+            {
+              name: 'verbose',
+              in: 'query',
+              required: false,
+              schema: { type: 'boolean' },
+            },
+          ],
+          get: { operationId: 'getAgent', description: 'Get agent' },
+          delete: { operationId: 'deleteAgent', description: 'Delete agent' },
+        },
+      },
+      components: {
+        parameters: {
+          AgentId: {
+            name: 'agent_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        },
+      },
+    };
+    const tools = openApiToToolDefinitions({ spec });
+    const get = tools.find((t) => {
+      return t.name === 'get-agent';
+    })!;
+
+    test('applies path-item params (including a $ref) to the operation', () => {
+      expect(get.path({ projectId: 'p1', agentId: 'a1' })).toBe(
+        '/projects/p1/agents/a1'
+      );
+      expect(get.inputSchema.required).toEqual(
+        expect.arrayContaining(['projectId', 'agentId'])
+      );
+      const props = get.inputSchema.properties as Record<string, unknown>;
+      expect(props.verbose).toEqual({ type: 'boolean', description: '' });
+    });
+
+    test('every operation on the path inherits the shared params', () => {
+      const del = tools.find((t) => {
+        return t.name === 'delete-agent';
+      })!;
+      expect(del.path({ projectId: 'p1', agentId: 'a1' })).toBe(
+        '/projects/p1/agents/a1'
+      );
+      expect(del.inputSchema.required).toEqual(
+        expect.arrayContaining(['projectId', 'agentId'])
+      );
+    });
+
+    test('operation-level parameter overrides a path-item one on name+in', () => {
+      const [tool] = openApiToToolDefinitions({
+        spec: {
+          paths: {
+            '/things': {
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  required: false,
+                  description: 'shared',
+                  schema: { type: 'integer' },
+                },
+              ],
+              get: {
+                operationId: 'listThings',
+                parameters: [
+                  {
+                    name: 'limit',
+                    in: 'query',
+                    required: true,
+                    description: 'op',
+                    schema: { type: 'integer' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+      const props = tool.inputSchema.properties as Record<
+        string,
+        { description?: string }
+      >;
+      // No duplicate `limit`; the operation-level definition wins.
+      expect(Object.keys(props)).toEqual(['limit']);
+      expect(props.limit.description).toBe('op');
+      expect(tool.inputSchema.required).toEqual(['limit']);
+    });
+
+    test('processOperation works when called without path-item parameters', () => {
+      const tool = processOperation({
+        pathTemplate: '/x/{id}',
+        method: 'get',
+        operation: {
+          operationId: 'getX',
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+        },
+        spec: {},
+        options: {
+          excludeExtension: 'x-mcp-exclude',
+          serverManagedExtension: 'x-mcp-server-managed',
+        },
+      });
+      expect(tool?.path({ id: 'a' })).toBe('/x/a');
     });
   });
 });


### PR DESCRIPTION
## Problem

`@ttoss/http-server-mcp-openapi` (0.1.0) only read **operation-level** `parameters`. OpenAPI also allows a `parameters` array at the **path-item level** — shared by every operation on that path, commonly via `$ref` (e.g. `#/components/parameters/ProjectId`). Those were silently dropped.

The effect: for a path like `/v1/projects/{project_id}/agents/{agent_id}` that declares `project_id`/`agent_id` at the path-item level, the generated tools were **broken** — the path template was never substituted (`get-agent` resolved to `/v1/projects/{project_id}/agents/{agent_id}`) and the params never appeared in the tool `inputSchema`, so a client couldn't supply them.

This surfaced while wiring the MCP surface onto `naturali.ai`, whose specs declare path params at the path-item level.

## Fix

- Merge path-item-level parameters into every operation on the path.
- Operation-level parameters override a path-item one that shares the same `name`+`in` (per the OpenAPI spec).
- Deduplicate resolved parameters by `name` so a param declared at both levels isn't emitted twice.

`$ref`s at the path-item level are resolved via the existing `resolveParameter` path, so shared `#/components/parameters/*` work.

## Tests

Added coverage for: path-item params (including a `$ref`) applied to each operation on the path, every operation inheriting the shared params, operation-level override winning on a `name`+`in` clash, and `processOperation` called without path-item params. Package stays at 100% statements/branches/functions/lines (54 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRycNBEYXLoeV9r3esGBpd)_