### PR TITLE
feat(openapi-codegen): add package to merge OpenAPI specs and generate CLI route manifests

### DIFF
--- a/packages/openapi-codegen/README.md
+++ b/packages/openapi-codegen/README.md
@@ -1,0 +1,85 @@
+# @ttoss/openapi-codegen
+
+Generate an SDK-ready merged OpenAPI document and a CLI route manifest from a
+directory of per-module OpenAPI spec files.
+
+This package extracts the spec-merging and CLI-route-generation logic that
+[SOAT](https://soat.ttoss.dev)'s `@soat/sdk` and `@soat/cli` packages use to
+turn their per-module OpenAPI YAML files into a generated SDK client and a
+generated CLI. It's generic: any project that authors one OpenAPI spec file
+per resource/module can reuse it to generate its own SDK and CLI.
+
+## Installation
+
+```bash
+pnpm add -D @ttoss/openapi-codegen
+```
+
+## `mergeOpenApiSpecs`
+
+Merges every `.yaml`/`.yml` file in a directory into a single OpenAPI
+document: `paths` are combined, `components` (`schemas`, `responses`,
+`securitySchemes`, `parameters`) are combined (first file to define a name
+wins on a collision), the first non-empty `servers` array found is kept, and
+cross-file `$ref`s (e.g. `./widgets.yaml#/components/schemas/Widget`) are
+rewritten to local refs (`#/components/schemas/Widget`) so the merged
+document is self-contained.
+
+```ts
+import fs from 'node:fs';
+
+import { mergeOpenApiSpecs } from '@ttoss/openapi-codegen';
+
+const merged = mergeOpenApiSpecs({
+  specsDir: './openapi/v1',
+  info: { title: 'My API', version: '1.0.0' },
+});
+
+fs.writeFileSync('./merged-spec.json', JSON.stringify(merged, null, 2));
+```
+
+Feed the resulting file to a spec-to-client generator such as
+[`@hey-api/openapi-ts`](https://heyapi.dev/) to produce a TypeScript SDK.
+
+## `generateCliRouteManifest` / `renderCliRoutesSource`
+
+Reads the same per-module spec files and builds a map from CLI command name
+(kebab-case, derived from `operationId`) to the SDK service class, HTTP
+method, path/query parameters, and request-body flags needed to dispatch and
+document that command — without running any HTTP-client codegen.
+
+```ts
+import fs from 'node:fs';
+
+import {
+  generateCliRouteManifest,
+  renderCliRoutesSource,
+} from '@ttoss/openapi-codegen';
+
+const routes = generateCliRouteManifest({
+  specsDir: './openapi/v1',
+  moduleDocsUrl: (moduleSlug) => `https://my-docs.dev/modules/${moduleSlug}`,
+});
+
+fs.writeFileSync('./src/generated/routes.ts', renderCliRoutesSource(routes));
+```
+
+A CLI entry point (e.g. built with [`commander`](https://www.npmjs.com/package/commander))
+then reads `routes.ts` and dynamically calls the matching SDK service method
+for each command.
+
+### Naming conventions
+
+By default, `operationId`s are converted to kebab-case commands
+(`listWidgets` → `list-widgets`) and tags are converted to PascalCase service
+class names (`AI Providers` → `AIProviders`). Pass `operationIdToCommand` and
+`tagToClassName` to `generateCliRouteManifest` to use different conventions.
+
+## Notes
+
+- Spec files are read in sorted filename order, so which file wins a
+  `components` naming collision is deterministic.
+- A request body's `oneOf` variants are merged into one flag set; a field is
+  only marked required when every variant requires it.
+- This package does not generate the SDK client itself — it produces the
+  merged spec that a client generator like `@hey-api/openapi-ts` consumes.

--- a/packages/openapi-codegen/package.json
+++ b/packages/openapi-codegen/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@ttoss/openapi-codegen",
+  "version": "0.1.0",
+  "description": "Generate an SDK-ready merged OpenAPI document and a CLI route manifest from per-module OpenAPI spec files",
+  "keywords": [
+    "cli",
+    "codegen",
+    "openapi",
+    "sdk"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ttoss/ttoss.git",
+    "directory": "packages/openapi-codegen"
+  },
+  "license": "MIT",
+  "author": "ttoss",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "test": "jest --projects tests/unit"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.1"
+  },
+  "devDependencies": {
+    "@ttoss/config": "workspace:^",
+    "@types/jest": "^30.0.0",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^24.12.0",
+    "jest": "^30.4.2",
+    "tsdown": "^0.22.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "types": "./dist/index.d.mts"
+      }
+    },
+    "provenance": true
+  }
+}

--- a/packages/openapi-codegen/src/generateCliRoutes.ts
+++ b/packages/openapi-codegen/src/generateCliRoutes.ts
@@ -1,0 +1,380 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { load } from 'js-yaml';
+
+import type {
+  CliOpenApiSpec,
+  OpenApiOperation,
+  OpenApiParameterFull,
+  OpenApiPathItem,
+  OpenApiRequestBodyProperty,
+  OpenApiRequestBodySchema,
+} from './openApiOperationTypes';
+
+/** Converts a camelCase `operationId` to a kebab-case CLI command name. */
+export const operationIdToKebabCommand = (operationId: string): string => {
+  return operationId
+    .replace(/([A-Z])/g, (letter) => {
+      return `-${letter.toLowerCase()}`;
+    })
+    .replace(/^-/, '');
+};
+
+/** Derives a PascalCase SDK service class name from a tag string (e.g. "AI Providers" → "AiProviders"). */
+export const tagToPascalClassName = (tag: string): string => {
+  return tag
+    .split(/\s+/)
+    .map((word) => {
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join('');
+};
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+/** Metadata for a single CLI flag, used to render `--help` output. */
+export interface Flag {
+  /** flag name in snake_case (e.g. project_id) */
+  name: string;
+  description: string;
+  required: boolean;
+  type: string;
+  /** where the value is sent: path, query, or body */
+  in: 'path' | 'query' | 'body';
+}
+
+export interface Route {
+  serviceClass: string;
+  operationId: string;
+  /** operation summary/description */
+  description: string;
+  /** URL to module documentation page */
+  moduleDocsUrl: string;
+  /** HTTP method the operation is mounted on */
+  httpMethod: (typeof HTTP_METHODS)[number];
+  /** snake_case path parameter names */
+  pathParams: string[];
+  /** snake_case query parameter names */
+  queryParams: string[];
+  /** snake_case flags (path, query, body) with metadata for --help. */
+  flags: Flag[];
+}
+
+/** Resolves same-file `$ref`s against a single spec's `components`. */
+interface RefResolvers {
+  resolveParam: (p: OpenApiParameterFull) => OpenApiParameterFull;
+  resolveSchema: (
+    schema: OpenApiRequestBodySchema & { $ref?: string }
+  ) => OpenApiRequestBodySchema;
+  resolveProperty: (
+    property: OpenApiRequestBodyProperty
+  ) => OpenApiRequestBodyProperty;
+}
+
+const createRefResolvers = (spec: CliOpenApiSpec): RefResolvers => {
+  return {
+    resolveParam: (p) => {
+      if (!p.$ref) return p;
+      const refKey = p.$ref.replace('#/components/parameters/', '');
+      return spec.components?.parameters?.[refKey] ?? p;
+    },
+    resolveSchema: (schema) => {
+      if (!schema.$ref) return schema;
+      const refKey = schema.$ref.replace('#/components/schemas/', '');
+      return spec.components?.schemas?.[refKey] ?? schema;
+    },
+    resolveProperty: (property) => {
+      if (!property.$ref?.startsWith('#/components/schemas/')) return property;
+      const refKey = property.$ref.replace('#/components/schemas/', '');
+      return spec.components?.schemas?.[refKey] ?? property;
+    },
+  };
+};
+
+/** Merges path-level parameters with operation-level ones (operation wins on name collision). */
+const mergeParams = (args: {
+  pathLevelParams: OpenApiParameterFull[];
+  opParams: OpenApiParameterFull[];
+}): OpenApiParameterFull[] => {
+  const { pathLevelParams, opParams } = args;
+  const opParamNames = new Set(
+    opParams.map((p) => {
+      return p.name;
+    })
+  );
+  return [
+    ...pathLevelParams.filter((p) => {
+      return !opParamNames.has(p.name);
+    }),
+    ...opParams,
+  ];
+};
+
+const buildParamFlags = (params: OpenApiParameterFull[]): Flag[] => {
+  return params
+    .filter((p): p is OpenApiParameterFull & { in: 'path' | 'query' } => {
+      return p.in === 'path' || p.in === 'query';
+    })
+    .map((p) => {
+      return {
+        name: p.name,
+        description: p.description ?? '',
+        required: p.required ?? p.in === 'path',
+        type: p.schema?.type ?? 'string',
+        in: p.in,
+      };
+    });
+};
+
+/** Collects a schema's own properties into `mergedProperties`/`requiredInAll` (first-schema-wins per property). */
+const collectSchemaProperties = (args: {
+  schema: OpenApiRequestBodySchema;
+  resolveProperty: RefResolvers['resolveProperty'];
+  mergedProperties: Record<string, OpenApiRequestBodyProperty>;
+  requiredInAll: Set<string>;
+}) => {
+  const { schema, resolveProperty, mergedProperties, requiredInAll } = args;
+  if (!schema.properties) return;
+
+  const required = new Set(schema.required ?? []);
+  for (const [propName, propSchema] of Object.entries(schema.properties)) {
+    if (mergedProperties[propName]) continue;
+    mergedProperties[propName] = resolveProperty(propSchema);
+    if (required.has(propName)) requiredInAll.add(propName);
+  }
+};
+
+/**
+ * Builds body flags from a requestBody schema. `oneOf` variants are merged
+ * into one flag set; a field is only required when every variant requires
+ * it (or, with no `oneOf`, when the single schema requires it).
+ */
+const buildBodyFlags = (args: {
+  bodySchema: OpenApiRequestBodySchema;
+  resolveProperty: RefResolvers['resolveProperty'];
+}): Flag[] => {
+  const { bodySchema, resolveProperty } = args;
+  const variants = bodySchema.oneOf ?? [bodySchema];
+
+  const mergedProperties: Record<string, OpenApiRequestBodyProperty> = {};
+  const requiredInAll = new Set<string>();
+  for (const variant of variants) {
+    collectSchemaProperties({
+      schema: variant,
+      resolveProperty,
+      mergedProperties,
+      requiredInAll,
+    });
+  }
+
+  const isRequired = (propName: string): boolean => {
+    if (!bodySchema.oneOf) return requiredInAll.has(propName);
+    return bodySchema.oneOf.every((variant) => {
+      return variant.required?.includes(propName);
+    });
+  };
+
+  return Object.entries(mergedProperties).map(([propName, propSchema]) => {
+    return {
+      name: propName,
+      description: propSchema.description ?? '',
+      required: isRequired(propName),
+      type: propSchema.type ?? 'string',
+      in: 'body' as const,
+    };
+  });
+};
+
+const buildRoute = (args: {
+  op: OpenApiOperation & { operationId: string };
+  method: (typeof HTTP_METHODS)[number];
+  tag: string;
+  params: OpenApiParameterFull[];
+  bodySchema: OpenApiRequestBodySchema | undefined;
+  resolveProperty: RefResolvers['resolveProperty'];
+  tagToClassName: (tag: string) => string;
+  moduleDocsUrl: string;
+}): Route => {
+  const {
+    op,
+    method,
+    tag,
+    params,
+    bodySchema,
+    resolveProperty,
+    tagToClassName,
+    moduleDocsUrl,
+  } = args;
+
+  const flags = buildParamFlags(params);
+  if (bodySchema) {
+    flags.push(...buildBodyFlags({ bodySchema, resolveProperty }));
+  }
+
+  return {
+    serviceClass: tagToClassName(tag),
+    operationId: op.operationId,
+    description: (op.description ?? op.summary ?? op.operationId)
+      .replace(/\s+/g, ' ')
+      .trim(),
+    moduleDocsUrl,
+    httpMethod: method,
+    pathParams: params
+      .filter((p) => {
+        return p.in === 'path';
+      })
+      .map((p) => {
+        return p.name;
+      }),
+    queryParams: params
+      .filter((p) => {
+        return p.in === 'query';
+      })
+      .map((p) => {
+        return p.name;
+      }),
+    flags,
+  };
+};
+
+const getBodySchema = (args: {
+  op: OpenApiOperation;
+  resolvers: RefResolvers;
+}): OpenApiRequestBodySchema | undefined => {
+  const { op, resolvers } = args;
+  const rawBodySchema = op.requestBody?.content?.['application/json']?.schema;
+  if (!rawBodySchema) return undefined;
+  return resolvers.resolveSchema(
+    rawBodySchema as OpenApiRequestBodySchema & { $ref?: string }
+  );
+};
+
+const processPathItem = (args: {
+  pathItem: OpenApiPathItem;
+  moduleTag: string | undefined;
+  docsUrl: string;
+  resolvers: RefResolvers;
+  operationIdToCommand: (operationId: string) => string;
+  tagToClassName: (tag: string) => string;
+  routes: Record<string, Route>;
+}) => {
+  const {
+    pathItem,
+    moduleTag,
+    docsUrl,
+    resolvers,
+    operationIdToCommand,
+    tagToClassName,
+    routes,
+  } = args;
+  const pathLevelParams = (pathItem.parameters ?? []).map(
+    resolvers.resolveParam
+  );
+
+  for (const method of HTTP_METHODS) {
+    const op = (pathItem as Record<string, OpenApiOperation>)[method];
+    if (!op?.operationId) continue;
+
+    const tag = op.tags?.[0] ?? moduleTag;
+    if (!tag) continue;
+
+    const opParams = (op.parameters ?? []).map(resolvers.resolveParam);
+    const params = mergeParams({ pathLevelParams, opParams });
+    const bodySchema = getBodySchema({ op, resolvers });
+
+    const command = operationIdToCommand(op.operationId);
+    routes[command] = buildRoute({
+      op: op as OpenApiOperation & { operationId: string },
+      method,
+      tag,
+      params,
+      bodySchema,
+      resolveProperty: resolvers.resolveProperty,
+      tagToClassName,
+      moduleDocsUrl: docsUrl,
+    });
+  }
+};
+
+const processSpecFile = (args: {
+  filePath: string;
+  moduleDocsUrl: (moduleSlug: string) => string;
+  operationIdToCommand: (operationId: string) => string;
+  tagToClassName: (tag: string) => string;
+  routes: Record<string, Route>;
+}) => {
+  const {
+    filePath,
+    moduleDocsUrl,
+    operationIdToCommand,
+    tagToClassName,
+    routes,
+  } = args;
+
+  const spec = load(fs.readFileSync(filePath, 'utf8')) as CliOpenApiSpec;
+  const moduleSlug = path.basename(filePath, path.extname(filePath));
+  const docsUrl = moduleDocsUrl(moduleSlug);
+  const moduleTag = spec.tags?.[0]?.name;
+  const resolvers = createRefResolvers(spec);
+
+  for (const pathItem of Object.values(spec.paths ?? {})) {
+    processPathItem({
+      pathItem,
+      moduleTag,
+      docsUrl,
+      resolvers,
+      operationIdToCommand,
+      tagToClassName,
+      routes,
+    });
+  }
+};
+
+export interface GenerateCliRouteManifestArgs {
+  /** Directory containing one `.yaml`/`.yml` OpenAPI spec file per module. */
+  specsDir: string;
+  /** Builds the documentation URL for a module, given its spec filename (without extension). */
+  moduleDocsUrl: (moduleSlug: string) => string;
+  /** Converts an `operationId` to a CLI command name. Defaults to kebab-case. */
+  operationIdToCommand?: (operationId: string) => string;
+  /** Converts a tag to the SDK service class name. Defaults to PascalCase. */
+  tagToClassName?: (tag: string) => string;
+}
+
+/**
+ * Reads every `.yaml`/`.yml` OpenAPI spec file in `specsDir` and builds a
+ * route manifest — a map from CLI command name to the SDK service class,
+ * operation, and flag metadata needed to dispatch and document that command.
+ */
+export const generateCliRouteManifest = (
+  args: GenerateCliRouteManifestArgs
+): Record<string, Route> => {
+  const {
+    specsDir,
+    moduleDocsUrl,
+    operationIdToCommand = operationIdToKebabCommand,
+    tagToClassName = tagToPascalClassName,
+  } = args;
+
+  const routes: Record<string, Route> = {};
+
+  const files = fs
+    .readdirSync(specsDir)
+    .filter((file) => {
+      return file.endsWith('.yaml') || file.endsWith('.yml');
+    })
+    .sort();
+
+  for (const file of files) {
+    processSpecFile({
+      filePath: path.join(specsDir, file),
+      moduleDocsUrl,
+      operationIdToCommand,
+      tagToClassName,
+      routes,
+    });
+  }
+
+  return routes;
+};

--- a/packages/openapi-codegen/src/index.ts
+++ b/packages/openapi-codegen/src/index.ts
@@ -1,0 +1,14 @@
+export type {
+  Flag,
+  GenerateCliRouteManifestArgs,
+  Route,
+} from './generateCliRoutes';
+export {
+  generateCliRouteManifest,
+  operationIdToKebabCommand,
+  tagToPascalClassName,
+} from './generateCliRoutes';
+export type { MergeOpenApiSpecsArgs } from './mergeOpenApiSpecs';
+export { mergeOpenApiSpecs } from './mergeOpenApiSpecs';
+export { renderCliRoutesSource } from './renderCliRoutesSource';
+export type { OpenApiComponents, OpenApiSpec } from './types';

--- a/packages/openapi-codegen/src/mergeOpenApiSpecs.ts
+++ b/packages/openapi-codegen/src/mergeOpenApiSpecs.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { load } from 'js-yaml';
+
+import type { OpenApiSpec } from './types';
+
+/**
+ * Merges a section of `components` (`schemas`, `responses`, `parameters`)
+ * across spec files. The first file to define a given key wins — later
+ * files defining the same key are ignored, mirroring how a single merged
+ * document can only hold one definition per name.
+ */
+const mergeComponentSection = (
+  target: Record<string, unknown>,
+  source: Record<string, unknown> | undefined
+) => {
+  if (!source) {
+    return;
+  }
+
+  for (const [name, value] of Object.entries(source)) {
+    if (!(name in target)) {
+      target[name] = value;
+    }
+  }
+};
+
+/**
+ * Rewrites cross-file `$ref`s (e.g. `./widgets.yaml#/components/schemas/Widget`)
+ * to local refs (`#/components/schemas/Widget`). Once every file's
+ * `components` are collected into a single merged document, the relative
+ * file path in the ref is no longer resolvable — everything lives under one
+ * root now.
+ */
+const rewriteCrossFileRefs = (spec: OpenApiSpec): OpenApiSpec => {
+  const specJson = JSON.stringify(spec).replace(
+    /"(\$ref)":\s*"[^"]*\.ya?ml#(\/components\/[^"]+)"/g,
+    '"$1": "#$2"'
+  );
+
+  return JSON.parse(specJson) as OpenApiSpec;
+};
+
+/** Keeps the first non-empty `servers` array found across spec files. */
+const mergeServers = (args: { merged: OpenApiSpec; spec: OpenApiSpec }) => {
+  const { merged, spec } = args;
+  if (!merged.servers?.length && spec.servers?.length) {
+    merged.servers = spec.servers;
+  }
+};
+
+const mergePaths = (args: { merged: OpenApiSpec; spec: OpenApiSpec }) => {
+  const { merged, spec } = args;
+  if (spec.paths) {
+    Object.assign(merged.paths!, spec.paths);
+  }
+};
+
+const mergeSecuritySchemes = (args: {
+  merged: OpenApiSpec;
+  spec: OpenApiSpec;
+}) => {
+  const { merged, spec } = args;
+  Object.assign(
+    merged.components!.securitySchemes!,
+    spec.components?.securitySchemes ?? {}
+  );
+};
+
+/**
+ * Merges a single parsed spec into the accumulator: combines `paths`,
+ * `components` (first-file-wins on collisions), `securitySchemes`, and
+ * keeps the first non-empty `servers` array found.
+ */
+const mergeSpecFile = (args: { merged: OpenApiSpec; spec: OpenApiSpec }) => {
+  const { merged, spec } = args;
+
+  mergeServers({ merged, spec });
+  mergePaths({ merged, spec });
+  mergeComponentSection(merged.components!.schemas!, spec.components?.schemas);
+  mergeComponentSection(
+    merged.components!.responses!,
+    spec.components?.responses
+  );
+  mergeComponentSection(
+    merged.components!.parameters!,
+    spec.components?.parameters
+  );
+  mergeSecuritySchemes({ merged, spec });
+};
+
+export interface MergeOpenApiSpecsArgs {
+  /** Directory containing one `.yaml`/`.yml` OpenAPI spec file per module. */
+  specsDir: string;
+  /** `info` object for the merged document. Omitted if not provided. */
+  info?: Record<string, unknown>;
+  /** OpenAPI version to stamp on the merged document. Defaults to `3.0.3`. */
+  openapiVersion?: string;
+}
+
+/**
+ * Merges every `.yaml`/`.yml` OpenAPI spec file in `specsDir` into a single
+ * OpenAPI document: `paths` are combined, `components` are combined
+ * (first-file-wins on name collisions), the first non-empty `servers` array
+ * found is kept, and cross-file `$ref`s are rewritten to local refs.
+ *
+ * Files are read in sorted filename order, so merge order — and therefore
+ * which file wins a naming collision — is deterministic.
+ */
+export const mergeOpenApiSpecs = (args: MergeOpenApiSpecsArgs): OpenApiSpec => {
+  const { specsDir, info, openapiVersion = '3.0.3' } = args;
+
+  const specFiles = fs
+    .readdirSync(specsDir)
+    .filter((file) => {
+      return file.endsWith('.yaml') || file.endsWith('.yml');
+    })
+    .sort()
+    .map((file) => {
+      return path.join(specsDir, file);
+    });
+
+  const merged: OpenApiSpec = {
+    openapi: openapiVersion,
+    ...(info ? { info } : {}),
+    servers: [],
+    paths: {},
+    components: {
+      schemas: {},
+      responses: {},
+      securitySchemes: {},
+      parameters: {},
+    },
+  };
+
+  for (const file of specFiles) {
+    const content = fs.readFileSync(file, 'utf-8');
+    const spec = load(content) as OpenApiSpec;
+    mergeSpecFile({ merged, spec });
+  }
+
+  return rewriteCrossFileRefs(merged);
+};

--- a/packages/openapi-codegen/src/openApiOperationTypes.ts
+++ b/packages/openapi-codegen/src/openApiOperationTypes.ts
@@ -1,0 +1,73 @@
+/**
+ * Narrow, CLI-generation-specific view of the OpenAPI shapes this package
+ * reads (parameters, request bodies, path items). Kept separate from the
+ * looser {@link import('./types').OpenApiSpec} used by `mergeOpenApiSpecs`,
+ * which only needs to move whole sections around without inspecting them.
+ */
+export interface OpenApiParameter {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'cookie';
+  $ref?: string;
+}
+
+export interface OpenApiSchema {
+  type?: string;
+  default?: unknown;
+}
+
+export interface OpenApiParameterFull extends OpenApiParameter {
+  description?: string;
+  required?: boolean;
+  schema?: OpenApiSchema;
+}
+
+export interface OpenApiRequestBodyProperty {
+  type?: string;
+  description?: string;
+  nullable?: boolean;
+  $ref?: string;
+}
+
+export interface OpenApiRequestBodySchema {
+  required?: string[];
+  properties?: Record<string, OpenApiRequestBodyProperty>;
+  oneOf?: OpenApiRequestBodySchema[];
+}
+
+export interface OpenApiRequestBody {
+  required?: boolean;
+  content?: {
+    'application/json'?: {
+      schema?: OpenApiRequestBodySchema;
+    };
+  };
+}
+
+export interface OpenApiOperation {
+  operationId?: string;
+  tags?: string[];
+  summary?: string;
+  description?: string;
+  parameters?: OpenApiParameterFull[];
+  requestBody?: OpenApiRequestBody;
+}
+
+export interface OpenApiPathItem {
+  get?: OpenApiOperation;
+  post?: OpenApiOperation;
+  put?: OpenApiOperation;
+  patch?: OpenApiOperation;
+  delete?: OpenApiOperation;
+  parameters?: OpenApiParameterFull[];
+}
+
+export interface OpenApiComponents {
+  parameters?: Record<string, OpenApiParameterFull>;
+  schemas?: Record<string, OpenApiRequestBodySchema & { $ref?: string }>;
+}
+
+export interface CliOpenApiSpec {
+  tags?: Array<{ name: string }>;
+  paths?: Record<string, OpenApiPathItem>;
+  components?: OpenApiComponents;
+}

--- a/packages/openapi-codegen/src/renderCliRoutesSource.ts
+++ b/packages/openapi-codegen/src/renderCliRoutesSource.ts
@@ -1,0 +1,53 @@
+import type { Route } from './generateCliRoutes';
+
+const renderRouteEntry = (command: string, route: Route): string => {
+  const flags = JSON.stringify(route.flags);
+  return `  '${command}': { serviceClass: '${route.serviceClass}', operationId: '${route.operationId}', description: ${JSON.stringify(route.description)}, moduleDocsUrl: ${JSON.stringify(route.moduleDocsUrl)}, httpMethod: '${route.httpMethod}', pathParams: ${JSON.stringify(route.pathParams)}, queryParams: ${JSON.stringify(route.queryParams)}, flags: ${flags} },`;
+};
+
+/**
+ * Renders a route manifest (from {@link generateCliRouteManifest}) as a
+ * standalone TypeScript source file exporting `Route`, `Flag`, and `routes`.
+ */
+export const renderCliRoutesSource = (
+  routes: Record<string, Route>
+): string => {
+  const lines = [
+    '// AUTO-GENERATED — do not edit. Regenerate via @ttoss/openapi-codegen.',
+    '',
+    'export interface Route {',
+    '  serviceClass: string;',
+    '  operationId: string;',
+    '  /** operation summary/description */',
+    '  description: string;',
+    '  /** URL to module documentation page */',
+    '  moduleDocsUrl: string;',
+    '  /** HTTP method the operation is mounted on */',
+    "  httpMethod: 'get' | 'post' | 'put' | 'patch' | 'delete';",
+    '  /** snake_case path parameter names */',
+    '  pathParams: string[];',
+    '  /** snake_case query parameter names */',
+    '  queryParams: string[];',
+    '  /** snake_case flags (path, query, body) with metadata for --help. */',
+    '  flags: Flag[];',
+    '}',
+    '',
+    '/** Metadata for a single CLI flag, used to render --help output. */',
+    'export interface Flag {',
+    '  name: string;',
+    '  description: string;',
+    '  required: boolean;',
+    '  type: string;',
+    "  in: 'path' | 'query' | 'body';",
+    '}',
+    '',
+    'export const routes: Record<string, Route> = {',
+    ...Object.entries(routes).map(([command, route]) => {
+      return renderRouteEntry(command, route);
+    }),
+    '};',
+    '',
+  ];
+
+  return lines.join('\n');
+};

--- a/packages/openapi-codegen/src/types.ts
+++ b/packages/openapi-codegen/src/types.ts
@@ -1,0 +1,16 @@
+export interface OpenApiComponents {
+  schemas?: Record<string, unknown>;
+  responses?: Record<string, unknown>;
+  securitySchemes?: Record<string, unknown>;
+  parameters?: Record<string, unknown>;
+}
+
+export interface OpenApiSpec {
+  openapi: string;
+  info?: Record<string, unknown>;
+  servers?: unknown[];
+  tags?: Array<{ name: string }>;
+  paths?: Record<string, unknown>;
+  components?: OpenApiComponents;
+  security?: unknown[];
+}

--- a/packages/openapi-codegen/tests/tsconfig.json
+++ b/packages/openapi-codegen/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@ttoss/config/tsconfig.test.json",
+  "compilerOptions": {
+    "paths": {
+      "src/*": ["../src/*"],
+      "tests/*": ["./*"]
+    }
+  }
+}

--- a/packages/openapi-codegen/tests/unit/babel.config.cjs
+++ b/packages/openapi-codegen/tests/unit/babel.config.cjs
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { babelConfig } = require('@ttoss/config');
+
+module.exports = babelConfig();

--- a/packages/openapi-codegen/tests/unit/fixtures/cliSpecs/gadgets.yaml
+++ b/packages/openapi-codegen/tests/unit/fixtures/cliSpecs/gadgets.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+tags:
+  - name: Gadgets
+paths:
+  /gadgets:
+    put:
+      operationId: replaceOrCreateGadget
+      tags: [Gadgets]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  required: [id, name]
+                  properties:
+                    id:
+                      type: string
+                      description: Existing gadget id
+                    name:
+                      type: string
+                      description: Gadget name
+                - type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                      description: Gadget name
+      responses:
+        '200':
+          description: ok
+components: {}

--- a/packages/openapi-codegen/tests/unit/fixtures/cliSpecs/refs.yaml
+++ b/packages/openapi-codegen/tests/unit/fixtures/cliSpecs/refs.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+paths:
+  /untagged:
+    get:
+      operationId: getUntagged
+      responses:
+        '200':
+          description: ok
+  /refs/{item_id}:
+    parameters:
+      - $ref: '#/components/parameters/ItemId'
+    post:
+      operationId: createFromRef
+      tags: [Refs]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePayload'
+      responses:
+        '201':
+          description: created
+components:
+  parameters:
+    ItemId:
+      name: item_id
+      in: path
+      required: true
+      schema:
+        type: string
+  schemas:
+    CreatePayload:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Name of the item
+        extra:
+          $ref: '#/components/schemas/ExtraInfo'
+    ExtraInfo:
+      type: string
+      description: Extra info resolved via nested $ref

--- a/packages/openapi-codegen/tests/unit/fixtures/cliSpecs/widgets.yaml
+++ b/packages/openapi-codegen/tests/unit/fixtures/cliSpecs/widgets.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+tags:
+  - name: Widgets
+paths:
+  /projects/{project_id}/widgets:
+    parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: listWidgets
+      tags: [Widgets]
+      summary: List widgets
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ok
+    post:
+      operationId: createWidget
+      tags: [Widgets]
+      description: Create a new widget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  description: Widget name
+                color:
+                  type: string
+                  description: Widget color
+components: {}

--- a/packages/openapi-codegen/tests/unit/fixtures/mergeSpecs/a-widgets.yaml
+++ b/packages/openapi-codegen/tests/unit/fixtures/mergeSpecs/a-widgets.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+servers:
+  - url: https://api.example.com
+tags:
+  - name: Widgets
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      tags: [Widgets]
+      responses:
+        '200':
+          $ref: './a-widgets.yaml#/components/responses/WidgetList'
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+  responses:
+    WidgetList:
+      description: A list of widgets
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    ProjectId:
+      name: project_id
+      in: path
+      required: true
+      schema:
+        type: string

--- a/packages/openapi-codegen/tests/unit/fixtures/mergeSpecs/b-gadgets.yaml
+++ b/packages/openapi-codegen/tests/unit/fixtures/mergeSpecs/b-gadgets.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+tags:
+  - name: Gadgets
+paths:
+  /gadgets:
+    get:
+      operationId: listGadgets
+      tags: [Gadgets]
+      parameters:
+        - $ref: './a-widgets.yaml#/components/parameters/ProjectId'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: './a-widgets.yaml#/components/schemas/Widget'
+components:
+  schemas:
+    Gadget:
+      type: object
+      properties:
+        widget:
+          $ref: './a-widgets.yaml#/components/schemas/Widget'

--- a/packages/openapi-codegen/tests/unit/fixtures/mergeSpecs/c-conflicting.yaml
+++ b/packages/openapi-codegen/tests/unit/fixtures/mergeSpecs/c-conflicting.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+tags:
+  - name: Conflicting
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        conflictingField:
+          type: string

--- a/packages/openapi-codegen/tests/unit/generateCliRoutes.test.ts
+++ b/packages/openapi-codegen/tests/unit/generateCliRoutes.test.ts
@@ -1,0 +1,196 @@
+import path from 'node:path';
+
+import {
+  generateCliRouteManifest,
+  operationIdToKebabCommand,
+  tagToPascalClassName,
+} from 'src/generateCliRoutes';
+import { renderCliRoutesSource } from 'src/renderCliRoutesSource';
+
+const specsDir = path.join(__dirname, 'fixtures/cliSpecs');
+
+describe('operationIdToKebabCommand', () => {
+  test('converts camelCase to kebab-case', () => {
+    expect(operationIdToKebabCommand('listWidgets')).toBe('list-widgets');
+    expect(operationIdToKebabCommand('createWidget')).toBe('create-widget');
+  });
+});
+
+describe('tagToPascalClassName', () => {
+  test('converts a tag to a PascalCase class name', () => {
+    expect(tagToPascalClassName('Widgets')).toBe('Widgets');
+    expect(tagToPascalClassName('AI Providers')).toBe('AIProviders');
+  });
+});
+
+describe('generateCliRouteManifest', () => {
+  const moduleDocsUrl = (moduleSlug: string) => {
+    return `https://example.com/docs/modules/${moduleSlug}`;
+  };
+
+  test('builds a command per operation, keyed by kebab-case name', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    expect(Object.keys(routes)).toEqual(
+      expect.arrayContaining([
+        'list-widgets',
+        'create-widget',
+        'replace-or-create-gadget',
+      ])
+    );
+  });
+
+  test('merges path-level parameters into every operation on that path', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    expect(routes['list-widgets'].pathParams).toEqual(['project_id']);
+    expect(routes['list-widgets'].queryParams).toEqual(['page']);
+    expect(routes['create-widget'].pathParams).toEqual(['project_id']);
+  });
+
+  test('marks path parameters as required and query parameters per their schema', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    const flagsByName = Object.fromEntries(
+      routes['list-widgets'].flags.map((flag) => {
+        return [flag.name, flag];
+      })
+    );
+
+    expect(flagsByName.project_id).toMatchObject({
+      required: true,
+      in: 'path',
+      type: 'string',
+    });
+    expect(flagsByName.page).toMatchObject({
+      required: false,
+      in: 'query',
+      type: 'integer',
+    });
+  });
+
+  test('derives body flags from the requestBody schema', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    const flagsByName = Object.fromEntries(
+      routes['create-widget'].flags.map((flag) => {
+        return [flag.name, flag];
+      })
+    );
+
+    expect(flagsByName.name).toMatchObject({
+      required: true,
+      in: 'body',
+      description: 'Widget name',
+    });
+    expect(flagsByName.color).toMatchObject({
+      required: false,
+      in: 'body',
+    });
+  });
+
+  test('a field is only required when required in every oneOf variant', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    const flagsByName = Object.fromEntries(
+      routes['replace-or-create-gadget'].flags.map((flag) => {
+        return [flag.name, flag];
+      })
+    );
+
+    // `id` is required in only one of the two oneOf variants.
+    expect(flagsByName.id).toMatchObject({ required: false, in: 'body' });
+    // `name` is required in both variants.
+    expect(flagsByName.name).toMatchObject({ required: true, in: 'body' });
+  });
+
+  test('sets serviceClass from the operation tag and moduleDocsUrl from the builder', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    expect(routes['list-widgets'].serviceClass).toBe('Widgets');
+    expect(routes['list-widgets'].moduleDocsUrl).toBe(
+      'https://example.com/docs/modules/widgets'
+    );
+    expect(routes['replace-or-create-gadget'].serviceClass).toBe('Gadgets');
+  });
+
+  test('falls back from description to summary to operationId', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    expect(routes['list-widgets'].description).toBe('List widgets');
+    expect(routes['create-widget'].description).toBe('Create a new widget');
+  });
+
+  test('skips operations with no tag and no module-level tag', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    expect(routes['get-untagged']).toBeUndefined();
+  });
+
+  test('resolves a $ref path-level parameter against components.parameters', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    expect(routes['create-from-ref'].pathParams).toEqual(['item_id']);
+    const itemIdFlag = routes['create-from-ref'].flags.find((flag) => {
+      return flag.name === 'item_id';
+    });
+    expect(itemIdFlag).toMatchObject({ required: true, in: 'path' });
+  });
+
+  test('resolves a requestBody schema that is itself a $ref, including a nested $ref property', () => {
+    const routes = generateCliRouteManifest({ specsDir, moduleDocsUrl });
+
+    const flagsByName = Object.fromEntries(
+      routes['create-from-ref'].flags.map((flag) => {
+        return [flag.name, flag];
+      })
+    );
+
+    expect(flagsByName.name).toMatchObject({
+      required: true,
+      in: 'body',
+      description: 'Name of the item',
+    });
+    expect(flagsByName.extra).toMatchObject({
+      required: false,
+      in: 'body',
+      type: 'string',
+      description: 'Extra info resolved via nested $ref',
+    });
+  });
+
+  test('supports overriding the command and class naming functions', () => {
+    const routes = generateCliRouteManifest({
+      specsDir,
+      moduleDocsUrl,
+      operationIdToCommand: (operationId) => {
+        return operationId.toLowerCase();
+      },
+      tagToClassName: (tag) => {
+        return tag.toUpperCase();
+      },
+    });
+
+    expect(routes.listwidgets).toBeDefined();
+    expect(routes.listwidgets.serviceClass).toBe('WIDGETS');
+  });
+});
+
+describe('renderCliRoutesSource', () => {
+  test('renders a TypeScript module exporting the route manifest', () => {
+    const routes = generateCliRouteManifest({
+      specsDir,
+      moduleDocsUrl: (moduleSlug) => {
+        return `https://example.com/docs/modules/${moduleSlug}`;
+      },
+    });
+
+    const source = renderCliRoutesSource(routes);
+
+    expect(source).toContain('export interface Route {');
+    expect(source).toContain('export interface Flag {');
+    expect(source).toContain('export const routes: Record<string, Route> = {');
+    expect(source).toContain("'list-widgets': { serviceClass: 'Widgets'");
+    expect(source).toContain("operationId: 'createWidget'");
+  });
+});

--- a/packages/openapi-codegen/tests/unit/jest.config.ts
+++ b/packages/openapi-codegen/tests/unit/jest.config.ts
@@ -1,0 +1,14 @@
+import { jestUnitConfig } from '@ttoss/config';
+
+const config = jestUnitConfig({
+  coverageThreshold: {
+    global: {
+      statements: 99.2,
+      branches: 84.2,
+      lines: 100,
+      functions: 100,
+    },
+  },
+});
+
+export default config;

--- a/packages/openapi-codegen/tests/unit/mergeOpenApiSpecs.test.ts
+++ b/packages/openapi-codegen/tests/unit/mergeOpenApiSpecs.test.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+
+import { mergeOpenApiSpecs } from 'src/mergeOpenApiSpecs';
+
+const specsDir = path.join(__dirname, 'fixtures/mergeSpecs');
+
+describe('mergeOpenApiSpecs', () => {
+  test('combines paths from every spec file', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+
+    expect(Object.keys(merged.paths ?? {})).toEqual(
+      expect.arrayContaining(['/widgets', '/gadgets'])
+    );
+  });
+
+  test('combines components.schemas from every spec file', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+
+    expect(Object.keys(merged.components?.schemas ?? {})).toEqual(
+      expect.arrayContaining(['Widget', 'Gadget'])
+    );
+  });
+
+  test('combines components.responses, securitySchemes, and parameters', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+
+    expect(merged.components?.responses?.WidgetList).toBeDefined();
+    expect(merged.components?.securitySchemes?.bearerAuth).toBeDefined();
+    expect(merged.components?.parameters?.ProjectId).toBeDefined();
+  });
+
+  test('first file wins on a components.schemas name collision', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+
+    const widget = merged.components?.schemas?.Widget as {
+      properties: Record<string, unknown>;
+    };
+
+    // a-widgets.yaml (sorted first) defines `id`; c-conflicting.yaml
+    // (sorted last) redefines Widget with `conflictingField` — the merge
+    // must keep the first file's definition.
+    expect(widget.properties).toHaveProperty('id');
+    expect(widget.properties).not.toHaveProperty('conflictingField');
+  });
+
+  test('keeps the first non-empty servers array found', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+
+    expect(merged.servers).toEqual([{ url: 'https://api.example.com' }]);
+  });
+
+  test('rewrites cross-file $refs to local refs', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+    const serialized = JSON.stringify(merged);
+
+    expect(serialized).not.toMatch(/\.ya?ml#/);
+    expect(serialized).toContain('"$ref":"#/components/schemas/Widget"');
+    expect(serialized).toContain('"$ref":"#/components/parameters/ProjectId"');
+  });
+
+  test('stamps the requested openapi version and info', () => {
+    const merged = mergeOpenApiSpecs({
+      specsDir,
+      openapiVersion: '3.1.0',
+      info: { title: 'Example API', version: '1.0.0' },
+    });
+
+    expect(merged.openapi).toBe('3.1.0');
+    expect(merged.info).toEqual({ title: 'Example API', version: '1.0.0' });
+  });
+
+  test('omits info when not provided', () => {
+    const merged = mergeOpenApiSpecs({ specsDir });
+
+    expect(merged.info).toBeUndefined();
+  });
+});

--- a/packages/openapi-codegen/tsconfig.json
+++ b/packages/openapi-codegen/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ttoss/config/tsconfig.json"
+}

--- a/packages/openapi-codegen/tsdown.config.ts
+++ b/packages/openapi-codegen/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { tsdownConfig } from '@ttoss/config';
+
+export default tsdownConfig({ format: ['esm'] });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1838,6 +1838,31 @@ importers:
         specifier: ^0.22.2
         version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
 
+  packages/openapi-codegen:
+    dependencies:
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.3.0
+    devDependencies:
+      '@ttoss/config':
+        specifier: workspace:^
+        version: link:../config
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.12.4
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+
   packages/postgresdb:
     dependencies:
       pg:
@@ -13020,10 +13045,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
@@ -20259,7 +20280,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lodash: 4.18.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -20851,7 +20872,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(postcss@8.5.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fs-extra: 11.3.5
       joi: 17.13.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -20885,7 +20906,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -27546,7 +27567,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -29712,7 +29733,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -31087,11 +31108,6 @@ snapshots:
   js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@3.15.0:
     dependencies:


### PR DESCRIPTION
## Summary

Adds `@ttoss/openapi-codegen`, extracted from the spec-merging and CLI-route-generation logic that [SOAT](https://soat.ttoss.dev)'s `@soat/sdk` and `@soat/cli` packages currently hand-roll in their own `scripts/generate.ts` files. Any project that authors one OpenAPI spec file per module (SOAT today, naturali.ai potentially) can reuse this instead of maintaining its own copy.

- `mergeOpenApiSpecs({ specsDir, info?, openapiVersion? })` — merges every `.yaml`/`.yml` file in a directory into one OpenAPI document (`paths` combined, `components` combined first-file-wins on collisions, first non-empty `servers` kept) and rewrites cross-file `$ref`s to local refs. Feed the result to a spec-to-client generator such as `@hey-api/openapi-ts`.
- `generateCliRouteManifest({ specsDir, moduleDocsUrl, operationIdToCommand?, tagToClassName? })` — builds a map from CLI command name to SDK service class, HTTP method, and path/query/body flag metadata, with pluggable naming conventions.
- `renderCliRoutesSource(routes)` — renders that manifest as a standalone `.ts` module.

This PR only adds the new package; it does not yet migrate `@soat/sdk`/`@soat/cli` to consume it — that's a natural follow-up once this package is available on npm.

## Open questions resolved this session

```txt
Q: Should this PR also migrate soat's packages/sdk and packages/cli to consume the new package?
A: No, ship the package alone first — resolved by long-term; checked: soat's generate scripts live in a
   separate repo/PR surface, and migrating them here would couple an unreviewed new package's first
   release to soat's own release process. Smaller, independently reviewable PR wins on debt containment.
   Migrating soat is a follow-up once @ttoss/openapi-codegen is available on npm.
```

## Test plan

- [x] `pnpm --filter @ttoss/openapi-codegen test` — 22 tests passing, covering `mergeOpenApiSpecs` (path/component merging, first-file-wins collisions, cross-file `$ref` rewriting, servers/info handling) and `generateCliRouteManifest`/`renderCliRoutesSource` (path/query/body flags, `$ref` resolution, `oneOf` request bodies, naming overrides)
- [x] `git add packages/openapi-codegen && pnpm run -w lint` — clean
- [ ] `pnpm turbo run build --filter=@ttoss/openapi-codegen` — blocked in my sandbox by a pre-existing, unrelated environment issue (`@babel/helper-plugin-utils` not linked for `babel-plugin-formatjs`, reproducible on unmodified `packages/i18n-cli` and `packages/read-config-file` too); please confirm this passes in CI

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01P7vfQah6r6Ch3mW6CAqrZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7vfQah6r6Ch3mW6CAqrZE)_