### PR TITLE
fix(docs/website): exclude fsl-bench from API doc generation

### DIFF
--- a/docs/website/scripts/typedoc-packages.mts
+++ b/docs/website/scripts/typedoc-packages.mts
@@ -23,7 +23,7 @@ const packagesDir = path.resolve(websiteDir, '../../packages');
  * Packages excluded from API doc generation (documented manually or without a
  * public API surface worth generating).
  */
-const excludedPackages = ['eslint-config'];
+const excludedPackages = ['eslint-config', 'fsl-bench'];
 
 /**
  * Returns the list of package directory names that should have API docs


### PR DESCRIPTION
## Summary

- The `@docs/website#build` job (run: https://github.com/ttoss/ttoss/actions/runs/30390458282/job/90380418859) was failing during API doc generation because TypeDoc could not find an entry point for `@ttoss/fsl-bench`.
- `fsl-bench` is a private benchmark harness (`packages/fsl-bench`) whose `package.json` has no `exports` field, so the doc generator's entry-point fallback resolved to `src/index.ts` — a file that doesn't exist there (the package only exposes CLI entry scripts: `runner.ts`, `reportCli.ts`).
- Added `fsl-bench` to the `excludedPackages` list in `docs/website/scripts/typedoc-packages.mts`, alongside the existing `eslint-config` exclusion (which is excluded for the same reason: no public API surface worth documenting).

## Test plan

- [x] Ran `node scripts/generate-api-docs.mts` from `docs/website` — API doc generation now completes for all packages without error.
- [x] Ran `pnpm run build` in `docs/website` — the Docusaurus build completes successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DdkpK6Ptz4bCB9iWkeagJc)_