### PR TITLE
feat(http-server-mcp,auth-core): add resource indicator and OIDC verifier

### DIFF
--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -1,7 +1,8 @@
 # @ttoss/auth-core
 
 Framework-agnostic authentication primitives for Node.js, with zero
-dependencies beyond `node:crypto` (Amazon Cognito verification excepted).
+dependencies beyond `node:crypto` (Amazon Cognito verification and generic
+OIDC verification excepted).
 
 ## Installation
 
@@ -49,6 +50,48 @@ const payload = verifyJwt({ token, secret: process.env.JWT_SECRET });
 
 For Amazon Cognito tokens, use `@ttoss/auth-core/amazon-cognito`, which
 re-exports [`aws-jwt-verify`](https://github.com/awslabs/aws-jwt-verify).
+
+For any other standards-compliant OIDC provider (Entra ID, Okta, Auth0,
+Google, …), use `@ttoss/auth-core/oidc` — see [OIDC](#oidc) below.
+
+## OIDC
+
+`createOidcVerifier` builds a token verifier for any OIDC provider with no
+manual JWKS wiring: it fetches the provider's `/.well-known/openid-configuration`
+document to discover its signing keys, caches them, handles key rotation
+transparently, and verifies the token's signature, issuer, and expiry.
+
+```ts
+import { createOidcVerifier } from '@ttoss/auth-core/oidc';
+
+const verifyToken = createOidcVerifier({
+  issuer: 'https://login.microsoftonline.com/<tenant>/v2.0',
+});
+
+const payload = await verifyToken(bearerToken);
+```
+
+Audience / resource-indicator validation is intentionally left to the
+caller — the expected audience is a property of the resource server, not the
+identity provider. When wiring this into `@ttoss/http-server-mcp`, pass
+`resourceIndicator` alongside `verifyToken`:
+
+```ts
+import { createOidcVerifier } from '@ttoss/auth-core/oidc';
+import { createMcpRouter } from '@ttoss/http-server-mcp';
+
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    verifyToken: createOidcVerifier({
+      issuer: 'https://login.microsoftonline.com/<tenant>/v2.0',
+    }),
+    resourceIndicator: 'https://mcp.example.com',
+  },
+});
+```
+
+Create one verifier at startup and reuse it across requests — discovery and
+the JWKS cache are scoped to the verifier instance, not the process.
 
 ## One-time tokens
 

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -22,7 +22,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./amazon-cognito": "./src/AmazonCognito/index.ts"
+    "./amazon-cognito": "./src/AmazonCognito/index.ts",
+    "./oidc": "./src/Oidc/index.ts"
   },
   "files": [
     "dist"
@@ -32,7 +33,8 @@
     "test": "jest --projects tests/unit"
   },
   "dependencies": {
-    "aws-jwt-verify": "^4.0.1"
+    "aws-jwt-verify": "^4.0.1",
+    "jose": "^6.0.0"
   },
   "devDependencies": {
     "@ttoss/config": "workspace:^",
@@ -51,6 +53,11 @@
         "import": "./dist/AmazonCognito/index.mjs",
         "require": "./dist/AmazonCognito/index.cjs",
         "types": "./dist/AmazonCognito/index.d.mts"
+      },
+      "./oidc": {
+        "import": "./dist/Oidc/index.mjs",
+        "require": "./dist/Oidc/index.cjs",
+        "types": "./dist/Oidc/index.d.mts"
       }
     },
     "provenance": true

--- a/packages/auth-core/src/Oidc/discovery.ts
+++ b/packages/auth-core/src/Oidc/discovery.ts
@@ -1,0 +1,53 @@
+/** The subset of an OIDC discovery document this package consumes. */
+export interface OidcDiscoveryDocument {
+  /** The issuer identifier, echoed back from the discovery document. */
+  issuer: string;
+  /** JWKS endpoint used to fetch the signing keys for token verification. */
+  jwksUri: string;
+  /** Authorization endpoint, when advertised by the provider. */
+  authorizationEndpoint?: string;
+  /** Token endpoint, when advertised by the provider. */
+  tokenEndpoint?: string;
+}
+
+/**
+ * Fetches and parses an OpenID Connect discovery document from
+ * `<issuer>/.well-known/openid-configuration` (per the OIDC Discovery 1.0
+ * spec, which Entra ID, Okta, and every standards-compliant OIDC provider
+ * implement).
+ *
+ * Throws when the endpoint is unreachable, returns a non-2xx status, or the
+ * document is missing `jwks_uri` — there is no way to verify tokens without it.
+ */
+export const discoverOidcConfiguration = async (
+  issuer: string
+): Promise<OidcDiscoveryDocument> => {
+  const base = issuer.replace(/\/$/, '');
+  const discoveryUrl = `${base}/.well-known/openid-configuration`;
+
+  const response = await fetch(discoveryUrl);
+  if (!response.ok) {
+    throw new Error(
+      `OIDC discovery failed for issuer "${issuer}": GET ${discoveryUrl} returned HTTP ${response.status}`
+    );
+  }
+
+  const doc = (await response.json()) as Record<string, unknown>;
+
+  if (typeof doc.jwks_uri !== 'string') {
+    throw new Error(
+      `OIDC discovery document for issuer "${issuer}" is missing "jwks_uri"`
+    );
+  }
+
+  return {
+    issuer: typeof doc.issuer === 'string' ? doc.issuer : base,
+    jwksUri: doc.jwks_uri,
+    authorizationEndpoint:
+      typeof doc.authorization_endpoint === 'string'
+        ? doc.authorization_endpoint
+        : undefined,
+    tokenEndpoint:
+      typeof doc.token_endpoint === 'string' ? doc.token_endpoint : undefined,
+  };
+};

--- a/packages/auth-core/src/Oidc/index.ts
+++ b/packages/auth-core/src/Oidc/index.ts
@@ -1,0 +1,5 @@
+export {
+  discoverOidcConfiguration,
+  type OidcDiscoveryDocument,
+} from './discovery';
+export { createOidcVerifier, type CreateOidcVerifierOptions } from './verifier';

--- a/packages/auth-core/src/Oidc/verifier.ts
+++ b/packages/auth-core/src/Oidc/verifier.ts
@@ -1,0 +1,78 @@
+import { createRemoteJWKSet, type JWTPayload, jwtVerify } from 'jose';
+
+import { discoverOidcConfiguration } from './discovery';
+
+/** Options for {@link createOidcVerifier}. */
+export interface CreateOidcVerifierOptions {
+  /**
+   * The OIDC issuer URL (e.g. `https://login.microsoftonline.com/<tenant>/v2.0`
+   * for Entra ID, or `https://<domain>.okta.com/oauth2/default` for Okta).
+   * The provider's `/.well-known/openid-configuration` document is fetched
+   * from this URL to discover its JWKS endpoint, and the token's `iss` claim
+   * must match it exactly.
+   */
+  issuer: string;
+}
+
+/**
+ * Builds a token verifier for any standards-compliant OIDC provider (Entra
+ * ID, Okta, Auth0, Google, …) with no manual JWKS wiring: the provider's
+ * signing keys are discovered from its `/.well-known/openid-configuration`
+ * document and cached, key rotation is handled transparently, and the
+ * token's signature, issuer, and expiry are verified before the payload is
+ * returned.
+ *
+ * The returned function matches the `verifyToken` shape expected by
+ * `McpAuthOptions` in `@ttoss/http-server-mcp` — pass it directly as
+ * `auth.verifyToken`. Audience / resource-indicator validation is left to
+ * the caller (e.g. `McpAuthOptions.resourceIndicator`), since the expected
+ * audience is a property of the resource server, not the identity provider.
+ *
+ * Discovery runs once per verifier instance — create one verifier at
+ * startup and reuse it across requests rather than calling this per request.
+ *
+ * @example
+ * ```typescript
+ * import { createOidcVerifier } from '@ttoss/auth-core/oidc';
+ * import { createMcpRouter } from '@ttoss/http-server-mcp';
+ *
+ * const verifyToken = createOidcVerifier({
+ *   issuer: 'https://login.microsoftonline.com/<tenant>/v2.0',
+ * });
+ *
+ * const mcpRouter = createMcpRouter(mcpServer, {
+ *   auth: {
+ *     verifyToken,
+ *     resourceIndicator: 'https://mcp.example.com',
+ *   },
+ * });
+ * ```
+ */
+export const createOidcVerifier = (
+  options: CreateOidcVerifierOptions
+): ((token: string) => Promise<JWTPayload>) => {
+  const { issuer } = options;
+
+  let jwksSetPromise:
+    Promise<ReturnType<typeof createRemoteJWKSet>> | undefined;
+
+  const getJwks = (): Promise<ReturnType<typeof createRemoteJWKSet>> => {
+    if (!jwksSetPromise) {
+      jwksSetPromise = discoverOidcConfiguration(issuer).then(({ jwksUri }) => {
+        return createRemoteJWKSet(new URL(jwksUri));
+      });
+      // Reset on failure so a transient discovery error doesn't permanently
+      // wedge the verifier — the next call retries discovery.
+      jwksSetPromise.catch(() => {
+        jwksSetPromise = undefined;
+      });
+    }
+    return jwksSetPromise;
+  };
+
+  return async (token: string): Promise<JWTPayload> => {
+    const jwks = await getJwks();
+    const { payload } = await jwtVerify(token, jwks, { issuer });
+    return payload;
+  };
+};

--- a/packages/auth-core/tests/unit/tests/Oidc/discovery.test.ts
+++ b/packages/auth-core/tests/unit/tests/Oidc/discovery.test.ts
@@ -1,0 +1,105 @@
+import { discoverOidcConfiguration } from 'src/Oidc/discovery';
+
+const mockFetch = (
+  response: Partial<Response> & { json: () => Promise<unknown> }
+) => {
+  global.fetch = jest.fn().mockResolvedValue(response) as never;
+};
+
+describe('discoverOidcConfiguration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('fetches the well-known discovery document and extracts jwks_uri', async () => {
+    mockFetch({
+      ok: true,
+      json: () => {
+        return Promise.resolve({
+          issuer: 'https://login.microsoftonline.com/tenant/v2.0',
+          jwks_uri:
+            'https://login.microsoftonline.com/tenant/discovery/v2.0/keys',
+          authorization_endpoint:
+            'https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize',
+          token_endpoint:
+            'https://login.microsoftonline.com/tenant/oauth2/v2.0/token',
+        });
+      },
+    });
+
+    const doc = await discoverOidcConfiguration(
+      'https://login.microsoftonline.com/tenant/v2.0'
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration'
+    );
+    expect(doc).toEqual({
+      issuer: 'https://login.microsoftonline.com/tenant/v2.0',
+      jwksUri: 'https://login.microsoftonline.com/tenant/discovery/v2.0/keys',
+      authorizationEndpoint:
+        'https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize',
+      tokenEndpoint:
+        'https://login.microsoftonline.com/tenant/oauth2/v2.0/token',
+    });
+  });
+
+  test('strips a trailing slash from the issuer before building the discovery URL', async () => {
+    mockFetch({
+      ok: true,
+      json: () => {
+        return Promise.resolve({
+          jwks_uri: 'https://example.com/keys',
+        });
+      },
+    });
+
+    await discoverOidcConfiguration('https://example.okta.com/oauth2/default/');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.okta.com/oauth2/default/.well-known/openid-configuration'
+    );
+  });
+
+  test('falls back to the issuer argument when the document omits issuer', async () => {
+    mockFetch({
+      ok: true,
+      json: () => {
+        return Promise.resolve({ jwks_uri: 'https://example.com/keys' });
+      },
+    });
+
+    const doc = await discoverOidcConfiguration('https://example.com');
+
+    expect(doc.issuer).toBe('https://example.com');
+    expect(doc.authorizationEndpoint).toBeUndefined();
+    expect(doc.tokenEndpoint).toBeUndefined();
+  });
+
+  test('throws when the discovery endpoint returns a non-2xx status', async () => {
+    mockFetch({
+      ok: false,
+      status: 404,
+      json: () => {
+        return Promise.resolve({});
+      },
+    });
+
+    await expect(
+      discoverOidcConfiguration('https://example.com')
+    ).rejects.toThrow('HTTP 404');
+  });
+
+  test('throws when the discovery document is missing jwks_uri', async () => {
+    mockFetch({
+      ok: true,
+      json: () => {
+        return Promise.resolve({});
+      },
+    });
+
+    await expect(
+      discoverOidcConfiguration('https://example.com')
+    ).rejects.toThrow('missing "jwks_uri"');
+  });
+});

--- a/packages/auth-core/tests/unit/tests/Oidc/verifier.test.ts
+++ b/packages/auth-core/tests/unit/tests/Oidc/verifier.test.ts
@@ -1,0 +1,97 @@
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createOidcVerifier } from 'src/Oidc/verifier';
+
+jest.mock('jose', () => {
+  return {
+    createRemoteJWKSet: jest.fn(),
+    jwtVerify: jest.fn(),
+  };
+});
+
+jest.mock('src/Oidc/discovery', () => {
+  return {
+    discoverOidcConfiguration: jest.fn(),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { discoverOidcConfiguration } = jest.requireMock('src/Oidc/discovery');
+
+const ISSUER = 'https://login.microsoftonline.com/tenant/v2.0';
+const JWKS_URI = 'https://login.microsoftonline.com/tenant/discovery/v2.0/keys';
+
+describe('createOidcVerifier', () => {
+  beforeEach(() => {
+    jest.mocked(discoverOidcConfiguration).mockResolvedValue({
+      issuer: ISSUER,
+      jwksUri: JWKS_URI,
+    });
+    jest.mocked(createRemoteJWKSet).mockReturnValue('jwks-set' as never);
+  });
+
+  test('discovers the issuer once, builds a remote JWKS, and verifies the token', async () => {
+    jest
+      .mocked(jwtVerify)
+      .mockResolvedValue({ payload: { sub: 'user-1' } } as never);
+
+    const verify = createOidcVerifier({ issuer: ISSUER });
+
+    const payload = await verify('token-1');
+
+    expect(discoverOidcConfiguration).toHaveBeenCalledWith(ISSUER);
+    expect(createRemoteJWKSet).toHaveBeenCalledWith(new URL(JWKS_URI));
+    expect(jwtVerify).toHaveBeenCalledWith('token-1', 'jwks-set', {
+      issuer: ISSUER,
+    });
+    expect(payload).toEqual({ sub: 'user-1' });
+  });
+
+  test('reuses the discovered JWKS across multiple verify calls', async () => {
+    jest
+      .mocked(jwtVerify)
+      .mockResolvedValue({ payload: { sub: 'user-1' } } as never);
+
+    const verify = createOidcVerifier({ issuer: ISSUER });
+
+    await verify('token-1');
+    await verify('token-2');
+
+    expect(discoverOidcConfiguration).toHaveBeenCalledTimes(1);
+    expect(createRemoteJWKSet).toHaveBeenCalledTimes(1);
+  });
+
+  test('propagates a jwtVerify rejection (invalid signature, issuer, or expiry)', async () => {
+    jest
+      .mocked(jwtVerify)
+      .mockRejectedValue(new Error('signature verification failed'));
+
+    const verify = createOidcVerifier({ issuer: ISSUER });
+
+    await expect(verify('bad-token')).rejects.toThrow(
+      'signature verification failed'
+    );
+  });
+
+  test('retries discovery on the next call after a discovery failure', async () => {
+    jest
+      .mocked(discoverOidcConfiguration)
+      .mockRejectedValueOnce(new Error('discovery unreachable'))
+      .mockResolvedValueOnce({ issuer: ISSUER, jwksUri: JWKS_URI });
+    jest
+      .mocked(jwtVerify)
+      .mockResolvedValue({ payload: { sub: 'user-1' } } as never);
+
+    const verify = createOidcVerifier({ issuer: ISSUER });
+
+    await expect(verify('token-1')).rejects.toThrow('discovery unreachable');
+
+    // Allow the internal `.catch` that clears the cached promise to run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const payload = await verify('token-2');
+
+    expect(discoverOidcConfiguration).toHaveBeenCalledTimes(2);
+    expect(payload).toEqual({ sub: 'user-1' });
+  });
+});

--- a/packages/auth-core/tsdown.config.ts
+++ b/packages/auth-core/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { tsdownConfig } from '@ttoss/config';
 
 export default tsdownConfig({
-  entry: ['src/index.ts', 'src/AmazonCognito/index.ts'],
+  entry: ['src/index.ts', 'src/AmazonCognito/index.ts', 'src/Oidc/index.ts'],
 });

--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -266,6 +266,41 @@ mcpServer.registerTool(
 
 Cognito encodes scopes as a space-separated string in `payload.scope` (e.g. `"openid mcp:access admin"`).
 
+### Resource indicator validation (RFC 8707)
+
+`requiredScopes` checks _what_ a token can do; `resourceIndicator` checks that the token was minted _for this server_ in the first place. Without it, a token issued by your authorization server for a different resource (another API, another MCP server) would still pass verification here as long as the signature checks out — the classic confused-deputy risk RFC 8707 exists to close.
+
+```typescript
+createMcpRouter(mcpServer, {
+  auth: {
+    cognitoUserPool: { userPoolId: '...', clientId: '...' },
+    resourceIndicator: 'https://mcp.example.com',
+  },
+});
+```
+
+The verified token's `aud` claim must include at least one of the configured values (a single string or an array of strings, for servers reachable under multiple hostnames), or the request receives `401 Unauthorized`. This applies uniformly regardless of the verification method — `cognitoUserPool`, a custom `verifyToken`, or `@ttoss/auth-core/oidc`'s `createOidcVerifier` below.
+
+### OIDC providers (Entra ID, Okta, Auth0, …)
+
+For any standards-compliant OIDC provider beyond Cognito, use `createOidcVerifier` from `@ttoss/auth-core/oidc`. It discovers the provider's signing keys from its `/.well-known/openid-configuration` document — no manual JWKS URL, no hand-rolled discovery:
+
+```typescript
+import { createOidcVerifier } from '@ttoss/auth-core/oidc';
+import { createMcpRouter } from '@ttoss/http-server-mcp';
+
+const mcpRouter = createMcpRouter(mcpServer, {
+  auth: {
+    verifyToken: createOidcVerifier({
+      issuer: 'https://login.microsoftonline.com/<tenant>/v2.0',
+    }),
+    resourceIndicator: 'https://mcp.example.com',
+  },
+});
+```
+
+`createOidcVerifier` deliberately does not validate `aud` itself — pass `resourceIndicator` alongside it, as shown, so audience validation stays consistent across every auth method this router supports. See the [`@ttoss/auth-core` README](https://ttoss.dev/docs/modules/packages/auth-core) for details on key caching and rotation.
+
 ### OAuth Protected Resource Metadata
 
 MCP clients (Claude, Cursor, etc.) fetch `/.well-known/oauth-protected-resource` to discover which authorization server issues tokens for your MCP server. The endpoint must be **unauthenticated** — MCP clients call it before they have a token.
@@ -460,6 +495,7 @@ Creates a Koa router configured to handle MCP protocol requests.
     - `auth.resourceServerUrl` + `auth.authorizationServerUrl` — Enable `/.well-known/oauth-protected-resource`; the metadata `resource` is set to `resourceServerUrl + path` so clients following `resource` land on the actual MCP endpoint
     - `auth.publicMethods` — JSON-RPC methods that bypass verification (default `['initialize', 'tools/list']`)
     - `auth.resourceMetadataUrl` — Emit RFC 9728 `WWW-Authenticate: Bearer resource_metadata="…"` on 401
+    - `auth.resourceIndicator` — Expected `aud` value(s) (RFC 8707); rejects tokens minted for a different resource. See [Resource indicator validation](#resource-indicator-validation-rfc-8707)
 
 **Returns:** `Router` — Koa router instance
 

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -1,12 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- value import required so declaration bundler emits `export { McpServer }` not `export type { McpServer }`
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { CognitoJwtVerifier } from '@ttoss/auth-core/amazon-cognito';
 import { Router } from '@ttoss/http-server';
 import { authMiddleware } from '@ttoss/http-server-auth';
 import type Koa from 'koa';
-import { z } from 'zod';
 
 import { getIdentity, requestContextStore } from './context';
 
@@ -62,30 +60,87 @@ export interface McpAuthOptions {
   resourceServerUrl?: string;
   /** URL of the OAuth Authorization Server that issues tokens for this resource. */
   authorizationServerUrl?: string;
+  /**
+   * Expected audience — the resource indicator (RFC 8707) this MCP server
+   * identifies as. When set, the verified token's `aud` claim must include at
+   * least one of these values, or the request is rejected with `401`. Without
+   * this check, a token minted for a *different* resource but signed by the
+   * same authorization server would still be accepted here — the classic
+   * confused-deputy risk RFC 8707 exists to close.
+   *
+   * Applies uniformly regardless of whether verification is done via
+   * `cognitoUserPool`, a custom `verifyToken`, or `@ttoss/auth-core/oidc`'s
+   * `createOidcVerifier` (which intentionally leaves audience validation to
+   * the caller for this reason).
+   *
+   * @example 'https://mcp.example.com'
+   */
+  resourceIndicator?: string | string[];
 }
 
 /** MCP lifecycle/discovery methods reachable before a client authenticates. */
 const DEFAULT_PUBLIC_METHODS = ['initialize', 'tools/list'];
 
+/**
+ * Asserts that a verified token's `aud` claim includes at least one of the
+ * expected resource indicator values. `aud` may be a single string or an
+ * array of strings per the JWT spec (RFC 7519); both forms are checked.
+ */
+const assertResourceIndicator = (
+  payload: unknown,
+  resourceIndicator: string | string[]
+): void => {
+  const expected = Array.isArray(resourceIndicator)
+    ? resourceIndicator
+    : [resourceIndicator];
+
+  const aud = (payload as { aud?: unknown } | undefined)?.aud;
+  const actualAudiences =
+    typeof aud === 'string' ? [aud] : Array.isArray(aud) ? aud : [];
+
+  const matches = actualAudiences.some((audience) => {
+    return typeof audience === 'string' && expected.includes(audience);
+  });
+
+  if (!matches) {
+    throw new Error(
+      `Token audience does not include the expected resource indicator ` +
+        `(expected one of: ${expected.join(', ')}).`
+    );
+  }
+};
+
 /** Builds the token verifier from the MCP auth options. */
 const buildVerifyToken = (
   auth: McpAuthOptions
 ): ((token: string) => Promise<unknown>) => {
-  if (auth.cognitoUserPool) {
-    const verifier = CognitoJwtVerifier.create({
-      tokenUse: 'access',
-      ...auth.cognitoUserPool,
-    });
-    return (token) => {
-      return verifier.verify(token);
-    };
+  const verify = (() => {
+    if (auth.cognitoUserPool) {
+      const verifier = CognitoJwtVerifier.create({
+        tokenUse: 'access',
+        ...auth.cognitoUserPool,
+      });
+      return (token: string) => {
+        return verifier.verify(token);
+      };
+    }
+    if (auth.verifyToken) {
+      return auth.verifyToken;
+    }
+    throw new Error(
+      'McpAuthOptions requires either cognitoUserPool or verifyToken'
+    );
+  })();
+
+  if (!auth.resourceIndicator) {
+    return verify;
   }
-  if (auth.verifyToken) {
-    return auth.verifyToken;
-  }
-  throw new Error(
-    'McpAuthOptions requires either cognitoUserPool or verifyToken'
-  );
+
+  return async (token: string) => {
+    const payload = await verify(token);
+    assertResourceIndicator(payload, auth.resourceIndicator!);
+    return payload;
+  };
 };
 
 /**
@@ -247,8 +302,7 @@ export { getIdentity } from './context';
  */
 export const checkScopes = (required: string[]): void => {
   const identity = getIdentity() as
-    | { scope?: string; scopes?: string[] }
-    | undefined;
+    { scope?: string; scopes?: string[] } | undefined;
   let scopeString: string | null = null;
   if (typeof identity?.scope === 'string') {
     scopeString = identity.scope;
@@ -465,8 +519,7 @@ export const createMcpRouter = (
   // so that unrelated paths like /.well-known/* are never intercepted — even
   // when aliases contains '/', which would otherwise prefix-match everything.
   let authCheck:
-    | ((ctx: Context, next: () => Promise<void>) => Promise<void>)
-    | undefined;
+    ((ctx: Context, next: () => Promise<void>) => Promise<void>) | undefined;
 
   if (auth) {
     const verifyToken = buildVerifyToken(auth);
@@ -614,185 +667,11 @@ export const createMcpRouter = (
   return router;
 };
 
-/**
- * A plain JSON Schema object (draft-07 compatible) describing the shape of a
- * tool's input. Used with {@link registerToolFromSchema} as an alternative to
- * providing a Zod shape, enabling lossless round-trips for schemas that contain
- * features not expressible in Zod v3 (`anyOf`, `$ref`, `pattern`, `allOf`, …).
- */
-export interface JsonObjectSchema {
-  type: 'object';
-  properties?: Record<string, unknown>;
-  required?: string[];
-  [key: string]: unknown;
-}
-
-/**
- * Parameters accepted by {@link registerToolFromSchema}.
- */
-export interface RegisterToolFromSchemaParams {
-  /** Unique tool name. */
-  name: string;
-  /** Human-readable description shown to the AI client. */
-  description?: string;
-  /**
-   * Plain JSON Schema that describes the tool's input object.
-   * This schema is forwarded verbatim over the MCP wire protocol, so any
-   * JSON Schema feature (`anyOf`, `$ref`, `pattern`, …) is preserved without
-   * loss. Defaults to `{ type: 'object', properties: {} }` when omitted.
-   */
-  inputSchema?: JsonObjectSchema;
-  /**
-   * Tool handler invoked when the AI client calls the tool.
-   * Receives the raw request arguments as a plain object (no Zod validation is
-   * applied, so the shape matches whatever the client sends).
-   */
-  handler: (
-    args: Record<string, unknown>
-  ) => CallToolResult | Promise<CallToolResult>;
-}
-
-// Module-level WeakMaps so they survive across calls but are GC-friendly.
-const rawSchemaRegistryMap = new WeakMap<
-  McpServer,
-  Map<string, JsonObjectSchema>
->();
-const patchedServerSet = new WeakSet<McpServer>();
-
-/**
- * Registers a tool on an MCP server using a **plain JSON Schema** object for
- * `inputSchema` instead of a Zod shape.
- *
- * This is useful when tool definitions are shared between the MCP server and an
- * AI SDK agent (e.g. Vercel AI SDK's `tool()` helper), because both consume a
- * plain JSON Schema at runtime. Using this helper eliminates the lossy
- * JSON-Schema→Zod conversion that would otherwise be required.
- *
- * Internally the helper:
- * 1. Registers the tool via the standard `McpServer.registerTool` API using a
- *    Zod `z.record(z.unknown())` pass-through schema so that the existing MCP
- *    `tools/call` handler correctly routes requests and delivers raw args to
- *    your handler.
- * 2. Stores the original JSON Schema and patches the `tools/list` response
- *    handler so clients receive the verbatim JSON Schema over the wire.
- *
- * @param server - The `McpServer` instance to register the tool on.
- * @param params - Tool configuration including name, description, inputSchema,
- *   and handler.
- *
- * @example
- * ```typescript
- * import { registerToolFromSchema, McpServer } from '@ttoss/http-server-mcp';
- *
- * const server = new McpServer({ name: 'my-server', version: '1.0.0' });
- *
- * registerToolFromSchema(server, {
- *   name: 'get-project',
- *   description: 'Get a project by ID',
- *   inputSchema: {
- *     type: 'object',
- *     properties: { id: { type: 'string', description: 'Project public ID' } },
- *     required: ['id'],
- *   },
- *   handler: async ({ id }) => ({
- *     content: [{ type: 'text', text: `Project: ${id}` }],
- *   }),
- * });
- * ```
- */
-export const registerToolFromSchema = (
-  server: McpServer,
-  params: RegisterToolFromSchemaParams
-): void => {
-  const {
-    name,
-    description,
-    inputSchema = { type: 'object', properties: {} },
-    handler,
-  } = params;
-
-  // Ensure we have a schema registry for this server.
-  if (!rawSchemaRegistryMap.has(server)) {
-    rawSchemaRegistryMap.set(server, new Map());
-  }
-
-  const registry = rawSchemaRegistryMap.get(server)!;
-  registry.set(name, inputSchema);
-
-  // Register the tool with a Zod record schema so that:
-  //  - `tools/call` validation always passes for any object input.
-  //  - The handler receives the raw args object from the request.
-  server.registerTool(
-    name,
-    {
-      description,
-      inputSchema: z.record(z.string(), z.unknown()),
-    },
-    async (args) => {
-      return handler(args as Record<string, unknown>);
-    }
-  );
-
-  // Patch the `tools/list` response handler once per server so that the
-  // verbatim JSON Schema is returned instead of the Zod-derived one.
-  if (!patchedServerSet.has(server)) {
-    patchedServerSet.add(server);
-
-    // Access the underlying `Server` instance and its internal request-handler
-    // map. This relies on McpServer exposing a `server` property (documented in
-    // the SDK's public API) and Protocol storing handlers in `_requestHandlers`
-    // (an internal implementation detail). If the MCP SDK refactors its
-    // internals, the patching is simply skipped and tools remain functional —
-    // the only degradation is that the Zod-derived schema is shown instead of
-    // the verbatim JSON Schema in `tools/list`.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rawServer = (server as any).server;
-    const origHandler = rawServer?._requestHandlers?.get('tools/list') as
-      | ((req: unknown, extra: unknown) => Promise<{ tools: unknown[] }>)
-      | undefined;
-
-    if (!origHandler && process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[registerToolFromSchema] Could not patch tools/list — ' +
-          'internal MCP SDK structure may have changed. ' +
-          'The tool will still be callable, but tools/list may return ' +
-          'a Zod-derived schema instead of the verbatim JSON Schema.'
-      );
-    }
-
-    if (origHandler) {
-      rawServer._requestHandlers.set(
-        'tools/list',
-        async (rawRequest: unknown, extra: unknown) => {
-          const result = await origHandler(rawRequest, extra);
-
-          const schemas = rawSchemaRegistryMap.get(server);
-          if (!schemas) {
-            return result;
-          }
-
-          return {
-            ...result,
-            tools: (
-              result.tools as Array<{
-                name: string;
-                inputSchema: unknown;
-                [key: string]: unknown;
-              }>
-            ).map((tool) => {
-              const raw = schemas.get(tool.name);
-              if (raw !== undefined) {
-                return { ...tool, inputSchema: raw };
-              }
-              return tool;
-            }),
-          };
-        }
-      );
-    }
-  }
-};
+export {
+  type JsonObjectSchema,
+  registerToolFromSchema,
+  type RegisterToolFromSchemaParams,
+} from './registerToolFromSchema';
 
 /**
  * Re-export MCP SDK types and classes for convenience

--- a/packages/http-server-mcp/src/registerToolFromSchema.ts
+++ b/packages/http-server-mcp/src/registerToolFromSchema.ts
@@ -1,0 +1,183 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+/**
+ * A plain JSON Schema object (draft-07 compatible) describing the shape of a
+ * tool's input. Used with {@link registerToolFromSchema} as an alternative to
+ * providing a Zod shape, enabling lossless round-trips for schemas that contain
+ * features not expressible in Zod v3 (`anyOf`, `$ref`, `pattern`, `allOf`, …).
+ */
+export interface JsonObjectSchema {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * Parameters accepted by {@link registerToolFromSchema}.
+ */
+export interface RegisterToolFromSchemaParams {
+  /** Unique tool name. */
+  name: string;
+  /** Human-readable description shown to the AI client. */
+  description?: string;
+  /**
+   * Plain JSON Schema that describes the tool's input object.
+   * This schema is forwarded verbatim over the MCP wire protocol, so any
+   * JSON Schema feature (`anyOf`, `$ref`, `pattern`, …) is preserved without
+   * loss. Defaults to `{ type: 'object', properties: {} }` when omitted.
+   */
+  inputSchema?: JsonObjectSchema;
+  /**
+   * Tool handler invoked when the AI client calls the tool.
+   * Receives the raw request arguments as a plain object (no Zod validation is
+   * applied, so the shape matches whatever the client sends).
+   */
+  handler: (
+    args: Record<string, unknown>
+  ) => CallToolResult | Promise<CallToolResult>;
+}
+
+// Module-level WeakMaps so they survive across calls but are GC-friendly.
+const rawSchemaRegistryMap = new WeakMap<
+  McpServer,
+  Map<string, JsonObjectSchema>
+>();
+const patchedServerSet = new WeakSet<McpServer>();
+
+/**
+ * Registers a tool on an MCP server using a **plain JSON Schema** object for
+ * `inputSchema` instead of a Zod shape.
+ *
+ * This is useful when tool definitions are shared between the MCP server and an
+ * AI SDK agent (e.g. Vercel AI SDK's `tool()` helper), because both consume a
+ * plain JSON Schema at runtime. Using this helper eliminates the lossy
+ * JSON-Schema→Zod conversion that would otherwise be required.
+ *
+ * Internally the helper:
+ * 1. Registers the tool via the standard `McpServer.registerTool` API using a
+ *    Zod `z.record(z.unknown())` pass-through schema so that the existing MCP
+ *    `tools/call` handler correctly routes requests and delivers raw args to
+ *    your handler.
+ * 2. Stores the original JSON Schema and patches the `tools/list` response
+ *    handler so clients receive the verbatim JSON Schema over the wire.
+ *
+ * @param server - The `McpServer` instance to register the tool on.
+ * @param params - Tool configuration including name, description, inputSchema,
+ *   and handler.
+ *
+ * @example
+ * ```typescript
+ * import { registerToolFromSchema, McpServer } from '@ttoss/http-server-mcp';
+ *
+ * const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+ *
+ * registerToolFromSchema(server, {
+ *   name: 'get-project',
+ *   description: 'Get a project by ID',
+ *   inputSchema: {
+ *     type: 'object',
+ *     properties: { id: { type: 'string', description: 'Project public ID' } },
+ *     required: ['id'],
+ *   },
+ *   handler: async ({ id }) => ({
+ *     content: [{ type: 'text', text: `Project: ${id}` }],
+ *   }),
+ * });
+ * ```
+ */
+export const registerToolFromSchema = (
+  server: McpServer,
+  params: RegisterToolFromSchemaParams
+): void => {
+  const {
+    name,
+    description,
+    inputSchema = { type: 'object', properties: {} },
+    handler,
+  } = params;
+
+  // Ensure we have a schema registry for this server.
+  if (!rawSchemaRegistryMap.has(server)) {
+    rawSchemaRegistryMap.set(server, new Map());
+  }
+
+  const registry = rawSchemaRegistryMap.get(server)!;
+  registry.set(name, inputSchema);
+
+  // Register the tool with a Zod record schema so that:
+  //  - `tools/call` validation always passes for any object input.
+  //  - The handler receives the raw args object from the request.
+  server.registerTool(
+    name,
+    {
+      description,
+      inputSchema: z.record(z.string(), z.unknown()),
+    },
+    async (args) => {
+      return handler(args as Record<string, unknown>);
+    }
+  );
+
+  // Patch the `tools/list` response handler once per server so that the
+  // verbatim JSON Schema is returned instead of the Zod-derived one.
+  if (!patchedServerSet.has(server)) {
+    patchedServerSet.add(server);
+
+    // Access the underlying `Server` instance and its internal request-handler
+    // map. This relies on McpServer exposing a `server` property (documented in
+    // the SDK's public API) and Protocol storing handlers in `_requestHandlers`
+    // (an internal implementation detail). If the MCP SDK refactors its
+    // internals, the patching is simply skipped and tools remain functional —
+    // the only degradation is that the Zod-derived schema is shown instead of
+    // the verbatim JSON Schema in `tools/list`.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rawServer = (server as any).server;
+    const origHandler = rawServer?._requestHandlers?.get('tools/list') as
+      | ((req: unknown, extra: unknown) => Promise<{ tools: unknown[] }>)
+      | undefined;
+
+    if (!origHandler && process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[registerToolFromSchema] Could not patch tools/list — ' +
+          'internal MCP SDK structure may have changed. ' +
+          'The tool will still be callable, but tools/list may return ' +
+          'a Zod-derived schema instead of the verbatim JSON Schema.'
+      );
+    }
+
+    if (origHandler) {
+      rawServer._requestHandlers.set(
+        'tools/list',
+        async (rawRequest: unknown, extra: unknown) => {
+          const result = await origHandler(rawRequest, extra);
+
+          const schemas = rawSchemaRegistryMap.get(server);
+          if (!schemas) {
+            return result;
+          }
+
+          return {
+            ...result,
+            tools: (
+              result.tools as Array<{
+                name: string;
+                inputSchema: unknown;
+                [key: string]: unknown;
+              }>
+            ).map((tool) => {
+              const raw = schemas.get(tool.name);
+              if (raw !== undefined) {
+                return { ...tool, inputSchema: raw };
+              }
+              return tool;
+            }),
+          };
+        }
+      );
+    }
+  }
+};

--- a/packages/http-server-mcp/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp/tests/unit/jest.config.ts
@@ -4,10 +4,10 @@ export default {
   ...jestUnitConfig(),
   coverageThreshold: {
     global: {
-      statements: 99.3,
-      branches: 93.7,
+      statements: 99.4,
+      branches: 94.6,
       functions: 100,
-      lines: 99.3,
+      lines: 99.4,
     },
   },
 };

--- a/packages/http-server-mcp/tests/unit/tests/auth.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/auth.test.ts
@@ -391,6 +391,117 @@ describe('auth — verifyToken', () => {
   });
 });
 
+describe('auth — resourceIndicator (RFC 8707)', () => {
+  const buildApp = (payload: unknown, resourceIndicator: string | string[]) => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    mcpServer.registerTool(
+      'whoami',
+      { description: 'Returns identity', inputSchema: {} },
+      async () => {
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }
+    );
+
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          verifyToken: () => {
+            return Promise.resolve(payload);
+          },
+          resourceIndicator,
+        },
+      }).routes()
+    );
+    return app;
+  };
+
+  const callTool = (app: ReturnType<typeof buildApp>) => {
+    return request(app.callback())
+      .post('/mcp')
+      .send(makeMcpRequest('tools/call', { name: 'whoami', arguments: {} }, 1))
+      .set('Content-Type', 'application/json')
+      .set('Accept', MCP_ACCEPT)
+      .set('Authorization', 'Bearer tok');
+  };
+
+  test('allows a token whose string aud matches the expected resource indicator', async () => {
+    const app = buildApp(
+      { sub: 'u1', aud: 'https://mcp.example.com' },
+      'https://mcp.example.com'
+    );
+
+    const res = await callTool(app);
+    expect(res.status).toBe(200);
+  });
+
+  test('allows a token whose aud array includes the expected resource indicator', async () => {
+    const app = buildApp(
+      {
+        sub: 'u1',
+        aud: ['https://other.example.com', 'https://mcp.example.com'],
+      },
+      'https://mcp.example.com'
+    );
+
+    const res = await callTool(app);
+    expect(res.status).toBe(200);
+  });
+
+  test('allows a token when resourceIndicator is any of a list of accepted values', async () => {
+    const app = buildApp({ sub: 'u1', aud: 'https://mcp-eu.example.com' }, [
+      'https://mcp.example.com',
+      'https://mcp-eu.example.com',
+    ]);
+
+    const res = await callTool(app);
+    expect(res.status).toBe(200);
+  });
+
+  test('rejects with 401 when aud does not include the expected resource indicator', async () => {
+    const app = buildApp(
+      { sub: 'u1', aud: 'https://a-different-resource.example.com' },
+      'https://mcp.example.com'
+    );
+
+    const res = await callTool(app);
+    expect(res.status).toBe(401);
+  });
+
+  test('rejects with 401 when the token has no aud claim at all', async () => {
+    const app = buildApp({ sub: 'u1' }, 'https://mcp.example.com');
+
+    const res = await callTool(app);
+    expect(res.status).toBe(401);
+  });
+
+  test('requests pass through unchanged when resourceIndicator is not configured', async () => {
+    const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+    mcpServer.registerTool(
+      'whoami',
+      { description: 'Returns identity', inputSchema: {} },
+      async () => {
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }
+    );
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        auth: {
+          verifyToken: () => {
+            return Promise.resolve({ sub: 'u1' }); // no aud claim
+          },
+        },
+      }).routes()
+    );
+
+    const res = await callTool(app);
+    expect(res.status).toBe(200);
+  });
+});
+
 describe('auth — public methods and RFC 9728 discovery', () => {
   const buildApp = (authOverrides: {
     publicMethods?: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,9 @@ importers:
       aws-jwt-verify:
         specifier: ^4.0.1
         version: 4.0.1
+      jose:
+        specifier: ^6.0.0
+        version: 6.2.3
     devDependencies:
       '@ttoss/config':
         specifier: workspace:^
@@ -819,7 +822,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -1590,7 +1593,7 @@ importers:
         version: 3.0.3
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@26.1.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3))
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -15164,6 +15167,7 @@ packages:
 
   react-grid-layout@1.5.3:
     resolution: {integrity: sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==}
+    deprecated: 'Ships stray files that were never in the repo: an ip_fetcher binary and its curl-sample source (1.5.0-1.5.3), plus a yarn-error.log containing local paths (1.5.3). Upgrade to 1.5.4, which is byte-identical apart from removing them. See https://github.com/react-grid-layout/react-grid-layout/issues/2269'
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
@@ -24632,7 +24636,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -24643,7 +24647,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -24651,11 +24655,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -24664,13 +24668,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -24678,7 +24682,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
@@ -35351,7 +35355,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
## Summary

Phase 1 of #1168 (Upgrade `@ttoss/http-server-mcp` to MCP spec 2026-07-28) — auth hardening, shippable independently of any SDK upgrade.

- **`auth.resourceIndicator` (RFC 8707)** on `createMcpRouter`: the verified token's `aud` claim must include at least one configured value, or the request is rejected with `401`. Without this, a token minted for a *different* resource but signed by the same authorization server would still be accepted — the confused-deputy risk RFC 8707 exists to close. Applies uniformly across `cognitoUserPool`, a custom `verifyToken`, or the new OIDC verifier below.
- **`@ttoss/auth-core/oidc`**: `createOidcVerifier({ issuer })` discovers a provider's signing keys from `/.well-known/openid-configuration` (Entra ID, Okta, Auth0, …), caches them, and verifies signature/issuer/expiry — no manual JWKS wiring. Audience validation is intentionally left to `resourceIndicator` above, so it stays consistent across every auth method.
- `registerToolFromSchema` and its supporting types move from `src/index.ts` to their own module (`src/registerToolFromSchema.ts`) — a pure extraction to stay under the repo's `max-lines` ESLint rule after the auth additions; no behavior change.

Not included (left for later phases per #1168): the stateless-core SDK bump, MCP Apps/Tasks, and the `tools/list` public-method default (already documented as a deliberate, separately-decided change).

## Test plan

- [x] `pnpm run test` in `packages/auth-core` — 172 tests passing, new `Oidc` module at 100% coverage
- [x] `pnpm run test` in `packages/http-server-mcp` — 98 tests passing; `coverageThreshold` bumped to match
- [x] `pnpm run test` in `packages/http-server-mcp-openapi` (dependent package) — 54 tests passing, unaffected
- [x] `pnpm run -w lint` on staged files — clean
- [ ] `pnpm turbo run build --filter=...@ttoss/http-server-mcp` — not verified in this environment; `tsdown` fails on an unrelated, pre-existing sandbox issue (`@babel/helper-plugin-utils` module-linking error in `babel-plugin-formatjs`) that also reproduces on `main` for untouched packages (`@ttoss/i18n-cli`, `@ttoss/graphql-api-cli`). Verified instead via Jest (babel-jest transform, not rolldown/tsdown) and ESLint, both clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee7RAe7MxUgfg54qA19gRG)_