### PR TITLE
feat(http-server-mcp): serve the MCP 2026-07-28 revision alongside 2025-era traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,5 @@ BREAKING CHANGE: this is a breaking change
 ```
 
 In a GitHub pull request, you can add the message to the commit message before merging it.
+
+This is only the mechanics of declaring a break. Before declaring one, read the [Breaking Changes guideline](https://ttoss.dev/docs/engineering/guidelines/breaking-changes) — most breaks are incidental to how a change was implemented rather than required by it, and are avoidable.

--- a/docs/website/docs/engineering/guidelines/breaking-changes.md
+++ b/docs/website/docs/engineering/guidelines/breaking-changes.md
@@ -1,0 +1,77 @@
+---
+title: Breaking Changes
+---
+
+A breaking change is a cost we impose on every consumer of a package: they must read, understand, and act before they can take any other improvement we ship. That cost is sometimes worth paying. It is never free, and it is far more often avoidable than it first appears.
+
+Declaring a break correctly is mechanical — a `BREAKING CHANGE:` footer, and `@lerna-lite/version` bumps the major. Deciding whether you should have one at all is the judgment this guideline covers.
+
+## Separate the goal from its side effects
+
+Most unnecessary breaks are not decisions anyone made. They fall out of _how_ a change was implemented, then get documented as though they were intended.
+
+So enumerate every break the change introduces and ask of each one: **is this required by the goal, or incidental to the implementation?** Write the answer down. An incidental break is almost always avoidable, and you will not notice it is incidental unless you ask the question explicitly.
+
+[#1171](https://github.com/ttoss/ttoss/pull/1171) is the worked example. The goal was to support a new MCP protocol revision. It arrived carrying four breaking changes, was documented thoroughly, and passed review on its own terms. None of the four were required by the goal. The one with the largest blast radius — arguments to a tool suddenly being validated — was a side effect of deleting an unrelated monkey-patch, and had not been recognised as a break at all.
+
+```mermaid
+flowchart TD
+    A[Change introduces a break] --> B{Required by the goal,<br/>or incidental?}
+    B -->|Incidental| C[Remove it:<br/>keep the old path alongside the new]
+    B -->|Required| D{How does it fail<br/>for a consumer?}
+    D -->|Loud: install, compile, test| E[Ship it and document it]
+    D -->|Silent: runtime, data-dependent| F[Make it opt-in,<br/>flip the default later]
+```
+
+## Classify breaks by how loudly they fail
+
+Not all breaks cost the same, and the difference is not severity — it is **how a consumer finds out**.
+
+| Fails at                  | Discovered by                | Treatment                                       |
+| ------------------------- | ---------------------------- | ----------------------------------------------- |
+| Install                   | Package manager, immediately | Ship it; the consumer cannot miss it            |
+| Compile                   | `tsc`, before merge          | Ship it; the type error _is_ the migration note |
+| Test                      | CI, before deploy            | Ship it; document the fix                       |
+| Runtime, on every request | First smoke test             | Ship it with care                               |
+| Runtime, on _some_ inputs | Production, eventually       | Make it opt-in                                  |
+
+That last row is the one worth protecting against. A break that only fires on certain data survives code review, type checking, CI, and a manual smoke test, then fails for a real user weeks later. A consumer who reads the migration guide cover to cover can still miss it, because the guide cannot enumerate their data.
+
+When strictness is the correct end state but would land silently, ship the mechanism disabled and let each consumer enable it once they have verified their own case. This is [Feature Flags](/docs/engineering/guidelines/feature-flags) reasoning applied to a package API: decouple shipping the capability from activating it. Flip the default in a later, deliberate major.
+
+## Prefer an additive path over a replacement
+
+When new behavior and old behavior can be distinguished at a boundary, serve both. Classify each request, input, or call at the edge, route old-shaped work down the existing path untouched, and route new-shaped work to the new implementation. Both can share the same underlying state and configuration, so the new capability costs consumers nothing.
+
+This is usually cheaper than it sounds, and it converts a major release into a minor one. Be aware that a library's own convenience wrapper may not preserve the behavior you need — if it hardcodes an option you were relying on, own that branch yourself rather than accepting the regression as inevitable.
+
+## Separate advertisement from enforcement
+
+A contract that is merely **incomplete** becomes **wrong** the moment something starts enforcing it.
+
+Schemas, types, and generated clients routinely describe less than what a system actually accepts — a field that may be sent as `null` to clear it, a property accepting several shapes, an optional argument nobody documented. While nothing validates against that description, the gap is invisible and harmless. Turn on validation and every gap becomes a rejected call that used to work.
+
+So treat "what we publish to consumers" and "what we enforce on input" as separate decisions. Publishing a richer contract is safe and useful. Enforcing it is a behavior change that needs the loudness analysis above — and before enforcing anything generated, fix the generator so the contract describes reality.
+
+## Verify against real consumers
+
+Do not reason about whether a change breaks a consumer. Read the consumer's actual deployed contract and run it through the new code path.
+
+Inference and empirical checks disagree more often than expected, and in the case above the empirical result was materially worse than the analysis: reading tool schemas off a live deployment showed the failure tracked a _documented, pervasive idiom_ rather than a handful of edge cases. That difference changed the decision. A short throwaway script against the real published dependency is worth more than any amount of careful reading.
+
+## Divergence is evidence of an unstated invariant
+
+When code diverges from a spec, a best practice, or the obvious simplification, treat it as evidence of an invariant nobody wrote down — not as a bug — until proven otherwise.
+
+Workarounds attract deletion during upgrades, because the reason for them is rarely in a comment and often attributed to a dependency version that has since moved on. Before removing one, reproduce the problem it solved against the new version. In [#1171](https://github.com/ttoss/ttoss/pull/1171) a request-serialization queue looked like obsolete cruft from an old SDK; the constraint it worked around still existed, and removing it deadlocked under concurrent load. A hanging test was the only thing standing between that and production.
+
+## When a break is genuinely necessary
+
+Only once the steps above have failed to avoid it:
+
+1. Add a `BREAKING CHANGE:` footer to the commit (see [How to version breaking changes?](https://github.com/ttoss/ttoss#how-to-version-breaking-changes) for the mechanics). A `!` in the type prefix works too; the footer carries the explanation.
+2. Add a `MIGRATIONS.md` to the package, newest change first, covering only what requires consumer action. Show a diff for each change, and state the failure mode a consumer will observe if they miss it — not just what to edit.
+3. Link it from the package `README.md`.
+4. Cover the new behavior with tests, per [Tests](/docs/engineering/guidelines/tests). For a break that fails silently, the test asserting the _old_ behavior is the one that documents what you changed.
+
+The presence of a `MIGRATIONS.md` should mean someone tried to avoid the break and could not. It is a last resort, not evidence of diligence.

--- a/packages/http-server-mcp-openapi/src/toolDefinitions.ts
+++ b/packages/http-server-mcp-openapi/src/toolDefinitions.ts
@@ -52,6 +52,48 @@ const sanitizeDescription = (description: string | undefined): string => {
   return (description || '').replace(/'/g, "\\'").replace(/\n/g, ' ').trim();
 };
 
+/**
+ * Builds a single body/query property's `JsonSchemaProperty`. Split out of
+ * {@link buildInputSchema} to keep that function's size and branching down.
+ */
+const buildTypedProperty = (param: {
+  type: string;
+  description: string;
+  items?: unknown;
+  nullable?: boolean;
+  oneOf?: unknown[];
+  anyOf?: unknown[];
+}): JsonSchemaProperty => {
+  const description = sanitizeDescription(param.description);
+
+  // A property with `oneOf`/`anyOf` (e.g. a string-or-object union) is
+  // forwarded verbatim rather than collapsed to a single guessed primitive —
+  // collapsing would reject every alternative shape except whichever one the
+  // collapse happened to guess.
+  if (param.oneOf && param.oneOf.length > 0) {
+    return { oneOf: param.oneOf, description };
+  }
+  if (param.anyOf && param.anyOf.length > 0) {
+    return { anyOf: param.anyOf, description };
+  }
+
+  const jsonType = getJsonSchemaType(param.type);
+  // OpenAPI `nullable: true` has no direct JSON Schema draft-07 equivalent;
+  // representing it as a two-entry `type` array (accepted by the 2020-12
+  // dialect the MCP SDK validates against) lets a property stay its declared
+  // type while still accepting an explicit `null` — the OpenAPI-documented
+  // way to clear a field.
+  const finalType =
+    param.nullable === true ? [jsonType, 'null' as const] : jsonType;
+
+  if (param.type === 'array') {
+    const itemsSchema = param.items ? param.items : { type: 'string' as const };
+    return { type: finalType, items: itemsSchema, description };
+  }
+
+  return { type: finalType, description };
+};
+
 export const buildInputSchema = (
   pathParams: Array<{ name: string; camelName: string }>,
   queryParams: Array<{
@@ -68,6 +110,9 @@ export const buildInputSchema = (
     required: boolean;
     type: string;
     items?: unknown;
+    nullable?: boolean;
+    oneOf?: unknown[];
+    anyOf?: unknown[];
   }>
 ): JsonObjectSchema => {
   const allParams = [...pathParams, ...queryParams, ...bodyProps];
@@ -100,32 +145,10 @@ export const buildInputSchema = (
 
   const properties: Record<string, JsonSchemaProperty> = {};
   for (const param of allParams) {
-    if ('type' in param) {
-      const jsonType = getJsonSchemaType(param.type);
-      const description = sanitizeDescription(param.description);
-      if (param.type === 'array') {
-        const itemsSchema =
-          'items' in param && param.items
-            ? param.items
-            : { type: 'string' as const };
-        properties[param.camelName] = {
-          type: 'array',
-          items: itemsSchema,
-          description,
-        };
-      } else {
-        properties[param.camelName] = {
-          type: jsonType,
-          description,
-        };
-      }
-    } else {
-      // path param
-      properties[param.camelName] = {
-        type: 'string',
-        description: '',
-      };
-    }
+    properties[param.camelName] =
+      'type' in param
+        ? buildTypedProperty(param)
+        : { type: 'string', description: '' }; // path param
   }
 
   return {
@@ -229,6 +252,9 @@ export const extractBodyProps = (args: {
   required: boolean;
   type: string;
   items?: unknown;
+  nullable: boolean;
+  oneOf?: unknown[];
+  anyOf?: unknown[];
 }> => {
   const bodySchema = resolveBodySchema(args);
   if (!bodySchema?.properties) return [];
@@ -243,6 +269,9 @@ export const extractBodyProps = (args: {
       description?: unknown;
       type?: unknown;
       items?: unknown;
+      nullable?: unknown;
+      oneOf?: unknown;
+      anyOf?: unknown;
     };
     return {
       snakeName: key,
@@ -251,6 +280,9 @@ export const extractBodyProps = (args: {
       required: (bodySchema.required || []).includes(key),
       type: typeof val.type === 'string' ? val.type : 'string',
       items: val.items,
+      nullable: val.nullable === true,
+      oneOf: Array.isArray(val.oneOf) ? val.oneOf : undefined,
+      anyOf: Array.isArray(val.anyOf) ? val.anyOf : undefined,
     };
   });
 };

--- a/packages/http-server-mcp-openapi/src/types.ts
+++ b/packages/http-server-mcp-openapi/src/types.ts
@@ -1,22 +1,31 @@
 import type { JsonObjectSchema } from '@ttoss/http-server-mcp';
 
+/** The JSON Schema primitive types this generator can derive from an OpenAPI `type`. */
+export type JsonSchemaPrimitiveType =
+  'string' | 'number' | 'boolean' | 'array' | 'integer' | 'object' | 'null';
+
 /**
  * A single JSON Schema property descriptor as emitted for a tool's
  * `inputSchema`. Only the subset of JSON Schema the generator produces is
  * modelled here; the value is forwarded verbatim over the MCP wire protocol.
+ *
+ * A property with OpenAPI `oneOf`/`anyOf` is forwarded as-is (no `type`) so a
+ * client-side validator enforces the same alternatives the REST API does,
+ * rather than collapsing to a single guessed primitive. `type` may be an
+ * array of two entries (e.g. `['string', 'null']`) to represent an OpenAPI
+ * `nullable: true` property without losing its declared type.
  */
-export interface JsonSchemaProperty {
-  type:
-    | 'string'
-    | 'number'
-    | 'boolean'
-    | 'array'
-    | 'integer'
-    | 'object'
-    | 'null';
-  description?: string;
-  items?: unknown;
-}
+export type JsonSchemaProperty =
+  | {
+      type: JsonSchemaPrimitiveType | JsonSchemaPrimitiveType[];
+      description?: string;
+      items?: unknown;
+    }
+  | {
+      oneOf?: unknown[];
+      anyOf?: unknown[];
+      description?: string;
+    };
 
 /**
  * A REST-backed MCP tool derived from a single OpenAPI operation.

--- a/packages/http-server-mcp-openapi/tests/unit/fixtures/openApiSpec.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/fixtures/openApiSpec.ts
@@ -56,6 +56,25 @@ export const testSpec: OpenApiSpec = {
           },
         ],
       },
+      patch: {
+        operationId: 'updateAgent',
+        description: 'Update an agent',
+        parameters: [
+          {
+            name: 'agent_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/UpdateAgentBody' },
+            },
+          },
+        },
+      },
       delete: {
         operationId: 'deleteAgent',
         description: 'Delete an agent',
@@ -156,6 +175,41 @@ export const testSpec: OpenApiSpec = {
         properties: {
           name: { type: 'string' },
           chat_id: { type: 'string' },
+        },
+      },
+      UpdateAgentBody: {
+        type: 'object',
+        properties: {
+          // Nullable primitive: must keep its declared type while also
+          // accepting `null` (the OpenAPI-documented way to clear a field).
+          description: {
+            type: 'string',
+            description: 'Agent description',
+            nullable: true,
+          },
+          // Property-level oneOf: must be forwarded verbatim, not collapsed
+          // to a single guessed primitive.
+          tool_choice: {
+            description: 'Tool selection strategy',
+            oneOf: [
+              { type: 'string', enum: ['auto', 'required'] },
+              {
+                type: 'object',
+                properties: {
+                  type: { type: 'string' },
+                  name: { type: 'string' },
+                },
+              },
+            ],
+          },
+          // Property-level anyOf: same requirement as oneOf above.
+          labels: {
+            description: 'Labels, or null to clear them',
+            anyOf: [
+              { type: 'array', items: { type: 'string' } },
+              { type: 'null' },
+            ],
+          },
         },
       },
     },

--- a/packages/http-server-mcp-openapi/tests/unit/tests/openApiToToolDefinitions.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/openApiToToolDefinitions.test.ts
@@ -29,6 +29,7 @@ describe('openApiToToolDefinitions', () => {
       'delete-agent',
       'get-agent',
       'list-agents',
+      'update-agent',
     ]);
   });
 
@@ -180,6 +181,49 @@ describe('openApiToToolDefinitions', () => {
       expect(Object.keys(props).sort()).toEqual(['agentId', 'chatId', 'name']);
       // `name` is required in both alternatives; agent_id/chat_id only in one.
       expect(tool.inputSchema.required).toEqual(['name']);
+    });
+  });
+
+  describe('nullable and property-level oneOf', () => {
+    const tool = byName(tools, 'update-agent');
+
+    test('nullable primitive keeps its declared type as a two-entry type array', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(props.description).toEqual({
+        type: ['string', 'null'],
+        description: 'Agent description',
+      });
+    });
+
+    test('property-level oneOf is forwarded verbatim, not collapsed to a primitive', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(props.toolChoice).toEqual({
+        oneOf: [
+          { type: 'string', enum: ['auto', 'required'] },
+          {
+            type: 'object',
+            properties: {
+              type: { type: 'string' },
+              name: { type: 'string' },
+            },
+          },
+        ],
+        description: 'Tool selection strategy',
+      });
+    });
+
+    test('property-level anyOf is forwarded verbatim, not collapsed to a primitive', () => {
+      const props = tool.inputSchema.properties as Record<string, unknown>;
+      expect(props.labels).toEqual({
+        anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }],
+        description: 'Labels, or null to clear them',
+      });
+    });
+
+    test('neither nullable nor oneOf/anyOf fields are marked required', () => {
+      expect(tool.inputSchema.required).not.toContain('description');
+      expect(tool.inputSchema.required).not.toContain('toolChoice');
+      expect(tool.inputSchema.required).not.toContain('labels');
     });
   });
 

--- a/packages/http-server-mcp-openapi/tests/unit/tests/registerOpenApiTools.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/registerOpenApiTools.test.ts
@@ -80,6 +80,7 @@ describe('registerOpenApitools', () => {
       'delete-agent',
       'get-agent',
       'list-agents',
+      'update-agent',
     ]);
     const getAgent = list.find((t) => {
       return t.name === 'get-agent';

--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -593,9 +593,16 @@ Use this when tool definitions are shared between the MCP server and an AI SDK a
 - `params.name` (`string`) — Unique tool name
 - `params.description` (`string`, optional) — Human-readable description
 - `params.inputSchema` (`JsonObjectSchema`, optional) — Plain JSON Schema object (defaults to `{ type: 'object', properties: {} }`)
+- `params.validateArguments` (`boolean`, optional) — Enforce `inputSchema` on `tools/call` (default: `false`); see [Argument validation](#argument-validation)
 - `params.handler` (`(args: Record<string, unknown>) => CallToolResult | Promise<CallToolResult>`) — Tool handler receiving the raw request arguments
 
 **Returns:** `void`
+
+#### Argument validation
+
+By default, `inputSchema` is **advertised but not enforced**: it round-trips verbatim over `tools/list` so clients know what to send, while arguments reach your handler unchecked. Pass `validateArguments: true` to reject mismatched calls with an MCP error before the handler runs.
+
+Enable it once you're confident `inputSchema` describes every value the tool genuinely accepts. Schemas derived from an OpenAPI document are a common source of _incomplete_ ones — a field a client may send as `null` to clear it, or one that accepts several shapes, is easily emitted as a bare `{ type: 'string' }`. Validating against a schema like that rejects calls the underlying API would have accepted. To describe those cases accurately, use `{ type: ['string', 'null'] }` for a nullable field and forward `oneOf`/`anyOf` verbatim rather than collapsing to one type.
 
 ## Examples
 
@@ -787,7 +794,9 @@ app.listen(3000);
 
 ## Protocol Details
 
-This package implements the [Model Context Protocol](https://spec.modelcontextprotocol.io/) over HTTP using JSON responses (no SSE streaming). It uses the `StreamableHTTPServerTransport` from the MCP SDK with `enableJsonResponse: true` and adapts Koa's context-based middleware to work with the MCP SDK's Node.js request/response expectations.
+This package implements the [Model Context Protocol](https://spec.modelcontextprotocol.io/) over HTTP using JSON responses (no SSE streaming), and serves each request over the protocol revision it actually speaks.
+
+Requests are classified once at the boundary. Traffic from today's MCP clients is served over `NodeStreamableHTTPServerTransport` with `enableJsonResponse: true`, adapting Koa's context-based middleware to the SDK's Node.js request/response expectations. Requests carrying the `2026-07-28` revision's per-request envelope are served by that revision's stateless core (`createMcpHandler`) instead. Both paths are served from the same `McpServer` instance and the same registered tools, so supporting the newer revision requires no configuration.
 
 **Supported HTTP methods:**
 
@@ -811,6 +820,8 @@ If you authenticate with `auth.verifyToken`, you do not need `sessionIdGenerator
 | ------------------------------- | --------------------------------------------- | ------------------------------------- |
 | Stateless (default)             | Bearer/API tokens, serverless, multi-instance | DB/verify hit per request             |
 | Stateful (`sessionIdGenerator`) | SSE events, context-preserving streams        | Needs session affinity / shared state |
+
+The `2026-07-28` revision has no session concept in its core, so requests speaking that revision are always served statelessly regardless of `sessionIdGenerator`.
 
 ## Testing an MCP server
 
@@ -864,7 +875,7 @@ Use the default when token auth is handled outside the OAuth flow (Cognito, API 
 
 The default **stateless** mode (see [Stateless vs stateful mode](#stateless-vs-stateful-mode)) is built for serverless: a fresh transport is created per request, nothing is kept in memory between invocations, and responses are plain JSON (no SSE) — exactly the request/response shape API Gateway and Lambda Function URLs expect.
 
-Use [`@ttoss/http-server-serverless`](https://github.com/ttoss/ttoss/tree/main/packages/http-server-serverless) as the Lambda adapter. It wraps `serverless-http` and additionally populates `req.rawHeaders` from the API Gateway event before the request reaches Koa. Without this step, `@hono/node-server` — used internally by the MCP transport — drops all headers (including `Accept`) and every `initialize` request returns HTTP 406.
+Use [`@ttoss/http-server-serverless`](https://github.com/ttoss/ttoss/tree/main/packages/http-server-serverless) as the Lambda adapter. It wraps `serverless-http` and additionally populates `req.rawHeaders` from the API Gateway event before the request reaches Koa. Without this step, the adapter sitting between Koa and the MCP transport can drop all headers (including `Accept`), making every `initialize` request return HTTP 406.
 
 ```mermaid
 flowchart LR
@@ -913,7 +924,8 @@ Keep the following in mind:
 
 - [@ttoss/http-server](https://ttoss.dev/docs/modules/packages/http-server) - HTTP server foundation
 - [@ttoss/http-server-serverless](https://github.com/ttoss/ttoss/tree/main/packages/http-server-serverless) - AWS Lambda adapter (required for MCP on Lambda)
-- [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/sdk) - MCP SDK
+- [@modelcontextprotocol/server](https://github.com/modelcontextprotocol/typescript-sdk) - MCP server SDK (2026-07-28 core)
+- [@modelcontextprotocol/node](https://github.com/modelcontextprotocol/typescript-sdk) - Node.js request/response bridge for the SDK's fetch-based handler
 
 ## Resources
 

--- a/packages/http-server-mcp/package.json
+++ b/packages/http-server-mcp/package.json
@@ -33,7 +33,8 @@
     "test": "jest --projects tests/unit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@ttoss/auth-core": "workspace:^",
     "@ttoss/http-server": "workspace:^",
     "@ttoss/http-server-auth": "workspace:^",
@@ -45,9 +46,6 @@
     "jest": "^30.4.2",
     "supertest": "^7.2.2",
     "tsdown": "^0.22.2"
-  },
-  "peerDependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/http-server-mcp/src/createGatedToolRegistrar.ts
+++ b/packages/http-server-mcp/src/createGatedToolRegistrar.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- value import required so declaration bundler emits `export { McpServer }` not `export type { McpServer }`
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 
 import { getIdentity } from './context';
 

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -1,12 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- value import required so declaration bundler emits `export { McpServer }` not `export type { McpServer }`
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpServer } from '@modelcontextprotocol/server';
 import { CognitoJwtVerifier } from '@ttoss/auth-core/amazon-cognito';
 import { Router } from '@ttoss/http-server';
 import { authMiddleware } from '@ttoss/http-server-auth';
 import type Koa from 'koa';
 
 import { getIdentity, requestContextStore } from './context';
+import { createMcpRequestServer } from './serveMcpRequest';
 
 type Context = Koa.Context;
 
@@ -356,6 +356,10 @@ export interface McpRouterOptions {
    * When provided, a single shared transport is created and sessions are tracked.
    * When undefined (default), the server operates in stateless mode where each
    * HTTP request uses its own transport instance.
+   *
+   * Applies to 2025-era traffic. The `2026-07-28` protocol revision has no
+   * session concept in its core, so requests speaking that revision are always
+   * served statelessly regardless of this option.
    */
   sessionIdGenerator?: () => string;
 
@@ -482,36 +486,15 @@ export const createMcpRouter = (
     getApiHeaders,
     auth,
   } = options;
-  const isStateful = sessionIdGenerator !== undefined;
   const needsContext =
     apiBaseUrl !== undefined ||
     getApiHeaders !== undefined ||
     auth !== undefined;
 
-  // Stateful mode: single shared transport connected once at startup
-  let sharedTransport: StreamableHTTPServerTransport | undefined;
-  if (isStateful) {
-    sharedTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator,
-      enableJsonResponse: true,
-    });
-    // Connect the shared transport to the MCP server
-    server.connect(sharedTransport);
-  }
-
-  // Stateless mode: SDK 1.x requires a fresh transport per request.
-  // Requests are serialised so only one stateless transport is connected at a time.
-  let statelessQueue: Promise<void> = Promise.resolve();
-
-  const enqueueStateless = (work: () => Promise<void>): Promise<void> => {
-    const result = statelessQueue.then(() => {
-      return work();
-    });
-    // Keep the queue alive even if this work rejects so subsequent
-    // requests are not blocked by a previous failure.
-    statelessQueue = result.catch(() => {});
-    return result;
-  };
+  // Serves each request over the protocol revision it actually speaks: the
+  // existing transport wiring for 2025-era traffic, the 2026-07-28 stateless
+  // core for requests carrying that revision's per-request envelope.
+  const serveRequest = createMcpRequestServer({ server, sessionIdGenerator });
 
   const router = new Router();
 
@@ -570,55 +553,27 @@ export const createMcpRouter = (
     // `authMiddleware` stores the verified payload on `ctx.state.user`.
     const identity = (ctx.state as { user?: unknown }).user;
 
-    const runRequest = async (
-      transport: StreamableHTTPServerTransport
-    ): Promise<void> => {
-      await transport.handleRequest(ctx.req, ctx.res, body);
+    // Forward the already-verified identity as the SDK's pass-through
+    // `authInfo` (it reads `req.auth`, set by convention — the same field
+    // Express's `requireBearerAuth` populates). This is purely additive: tool
+    // code written against this package keeps reading identity via
+    // `getIdentity()` below.
+    (ctx.req as unknown as { auth?: unknown }).auth = identity;
+
+    const runRequest = async (): Promise<void> => {
+      await serveRequest(ctx, body);
       // Prevent Koa from sending its own response
       // The MCP SDK has already handled the response
       ctx.respond = false;
     };
 
-    if (isStateful && sharedTransport) {
-      // Stateful mode: reuse the shared transport
-      if (needsContext) {
-        await requestContextStore.run(
-          { apiBaseUrl, apiHeaders, identity },
-          () => {
-            return runRequest(sharedTransport!);
-          }
-        );
-      } else {
-        await runRequest(sharedTransport);
-      }
+    if (needsContext) {
+      await requestContextStore.run(
+        { apiBaseUrl, apiHeaders, identity },
+        runRequest
+      );
     } else {
-      // Stateless mode: SDK requires a fresh transport per request.
-      // Serialise so only one transport is connected at a time.
-      await enqueueStateless(async () => {
-        const transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: undefined,
-          enableJsonResponse: true,
-        });
-        // Connect and run inside try/finally so the transport is always closed,
-        // even if connect() throws — preventing server state corruption.
-        try {
-          await server.connect(transport);
-          if (needsContext) {
-            await requestContextStore.run(
-              { apiBaseUrl, apiHeaders, identity },
-              () => {
-                return runRequest(transport);
-              }
-            );
-          } else {
-            await runRequest(transport);
-          }
-        } finally {
-          // Close the transport to reset the server's internal transport reference,
-          // allowing the next request to connect a fresh transport.
-          await transport.close();
-        }
-      });
+      await runRequest();
     }
   };
 
@@ -676,7 +631,7 @@ export {
 /**
  * Re-export MCP SDK types and classes for convenience
  */
-export { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+export { McpServer } from '@modelcontextprotocol/server';
 
 /**
  * Re-export Zod for request/response schema definitions

--- a/packages/http-server-mcp/src/registerToolFromSchema.ts
+++ b/packages/http-server-mcp/src/registerToolFromSchema.ts
@@ -1,6 +1,11 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { z } from 'zod';
+import type {
+  CallToolResult,
+  JsonSchemaType,
+  McpServer,
+  StandardSchemaWithJSON,
+} from '@modelcontextprotocol/server';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- value import required; fromJsonSchema is called at runtime
+import { fromJsonSchema } from '@modelcontextprotocol/server';
 
 /**
  * A plain JSON Schema object (draft-07 compatible) describing the shape of a
@@ -31,42 +36,85 @@ export interface RegisterToolFromSchemaParams {
    */
   inputSchema?: JsonObjectSchema;
   /**
+   * Whether `tools/call` arguments are validated against `inputSchema` before
+   * the handler runs, rejecting a mismatch with an MCP error.
+   *
+   * Defaults to `false`, which forwards arguments to the handler unchecked —
+   * the behavior this helper has always had. `inputSchema` is still advertised
+   * verbatim over `tools/list` either way; this only controls enforcement.
+   *
+   * Enable it once you know `inputSchema` describes every value the tool
+   * genuinely accepts. Schemas generated from an OpenAPI document are a common
+   * source of *incomplete* ones — a field a client may send as `null` to clear
+   * it, or one accepting several shapes, is easy to emit as a bare
+   * `{ type: 'string' }`. Validating against a schema like that rejects calls
+   * the underlying API would have accepted.
+   *
+   * @default false
+   */
+  validateArguments?: boolean;
+  /**
    * Tool handler invoked when the AI client calls the tool.
-   * Receives the raw request arguments as a plain object (no Zod validation is
-   * applied, so the shape matches whatever the client sends).
+   * Receives the request arguments, validated against `inputSchema` only when
+   * `validateArguments` is enabled.
    */
   handler: (
     args: Record<string, unknown>
   ) => CallToolResult | Promise<CallToolResult>;
 }
 
-// Module-level WeakMaps so they survive across calls but are GC-friendly.
-const rawSchemaRegistryMap = new WeakMap<
-  McpServer,
-  Map<string, JsonObjectSchema>
->();
-const patchedServerSet = new WeakSet<McpServer>();
+/**
+ * Converts a plain JSON Schema into the Standard Schema `registerTool` accepts.
+ *
+ * A Standard Schema keeps advertisement and enforcement in separate fields:
+ * `~standard.jsonSchema` is what `tools/list` publishes, `~standard.validate`
+ * is what `tools/call` runs. Replacing only `validate` therefore keeps the
+ * schema fully visible to clients while leaving arguments unchecked.
+ */
+const toStandardSchema = ({
+  inputSchema,
+  validateArguments,
+}: {
+  inputSchema: JsonObjectSchema;
+  validateArguments: boolean;
+}): StandardSchemaWithJSON => {
+  // `JsonObjectSchema` deliberately keeps `properties` as `Record<string,
+  // unknown>` for a simple public API; `fromJsonSchema` wants the SDK's
+  // recursive `JsonSchemaType`. The runtime shape is the same JSON Schema
+  // object either way — only the static type is looser here.
+  const schema = fromJsonSchema(inputSchema as JsonSchemaType);
+
+  if (validateArguments) {
+    return schema;
+  }
+
+  return {
+    '~standard': {
+      ...schema['~standard'],
+      validate: (value: unknown) => {
+        return { value };
+      },
+    },
+  } as StandardSchemaWithJSON;
+};
 
 /**
  * Registers a tool on an MCP server using a **plain JSON Schema** object for
  * `inputSchema` instead of a Zod shape.
  *
- * This is useful when tool definitions are shared between the MCP server and an
- * AI SDK agent (e.g. Vercel AI SDK's `tool()` helper), because both consume a
- * plain JSON Schema at runtime. Using this helper eliminates the lossy
+ * This is useful when tool definitions are shared between the MCP server and
+ * an AI SDK agent (e.g. Vercel AI SDK's `tool()` helper), because both consume
+ * a plain JSON Schema at runtime. Using this helper eliminates the lossy
  * JSON-Schema→Zod conversion that would otherwise be required.
  *
- * Internally the helper:
- * 1. Registers the tool via the standard `McpServer.registerTool` API using a
- *    Zod `z.record(z.unknown())` pass-through schema so that the existing MCP
- *    `tools/call` handler correctly routes requests and delivers raw args to
- *    your handler.
- * 2. Stores the original JSON Schema and patches the `tools/list` response
- *    handler so clients receive the verbatim JSON Schema over the wire.
+ * Thin wrapper over `@modelcontextprotocol/server`'s `fromJsonSchema`, which
+ * converts a JSON Schema into a Standard Schema that `registerTool` accepts
+ * directly, so the schema round-trips verbatim over `tools/list`. Arguments
+ * reach the handler unchecked unless `validateArguments` is enabled.
  *
  * @param server - The `McpServer` instance to register the tool on.
  * @param params - Tool configuration including name, description, inputSchema,
- *   and handler.
+ *   validateArguments, and handler.
  *
  * @example
  * ```typescript
@@ -96,88 +144,18 @@ export const registerToolFromSchema = (
     name,
     description,
     inputSchema = { type: 'object', properties: {} },
+    validateArguments = false,
     handler,
   } = params;
 
-  // Ensure we have a schema registry for this server.
-  if (!rawSchemaRegistryMap.has(server)) {
-    rawSchemaRegistryMap.set(server, new Map());
-  }
-
-  const registry = rawSchemaRegistryMap.get(server)!;
-  registry.set(name, inputSchema);
-
-  // Register the tool with a Zod record schema so that:
-  //  - `tools/call` validation always passes for any object input.
-  //  - The handler receives the raw args object from the request.
   server.registerTool(
     name,
     {
       description,
-      inputSchema: z.record(z.string(), z.unknown()),
+      inputSchema: toStandardSchema({ inputSchema, validateArguments }),
     },
     async (args) => {
       return handler(args as Record<string, unknown>);
     }
   );
-
-  // Patch the `tools/list` response handler once per server so that the
-  // verbatim JSON Schema is returned instead of the Zod-derived one.
-  if (!patchedServerSet.has(server)) {
-    patchedServerSet.add(server);
-
-    // Access the underlying `Server` instance and its internal request-handler
-    // map. This relies on McpServer exposing a `server` property (documented in
-    // the SDK's public API) and Protocol storing handlers in `_requestHandlers`
-    // (an internal implementation detail). If the MCP SDK refactors its
-    // internals, the patching is simply skipped and tools remain functional —
-    // the only degradation is that the Zod-derived schema is shown instead of
-    // the verbatim JSON Schema in `tools/list`.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rawServer = (server as any).server;
-    const origHandler = rawServer?._requestHandlers?.get('tools/list') as
-      | ((req: unknown, extra: unknown) => Promise<{ tools: unknown[] }>)
-      | undefined;
-
-    if (!origHandler && process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[registerToolFromSchema] Could not patch tools/list — ' +
-          'internal MCP SDK structure may have changed. ' +
-          'The tool will still be callable, but tools/list may return ' +
-          'a Zod-derived schema instead of the verbatim JSON Schema.'
-      );
-    }
-
-    if (origHandler) {
-      rawServer._requestHandlers.set(
-        'tools/list',
-        async (rawRequest: unknown, extra: unknown) => {
-          const result = await origHandler(rawRequest, extra);
-
-          const schemas = rawSchemaRegistryMap.get(server);
-          if (!schemas) {
-            return result;
-          }
-
-          return {
-            ...result,
-            tools: (
-              result.tools as Array<{
-                name: string;
-                inputSchema: unknown;
-                [key: string]: unknown;
-              }>
-            ).map((tool) => {
-              const raw = schemas.get(tool.name);
-              if (raw !== undefined) {
-                return { ...tool, inputSchema: raw };
-              }
-              return tool;
-            }),
-          };
-        }
-      );
-    }
-  }
 };

--- a/packages/http-server-mcp/src/serveMcpRequest.ts
+++ b/packages/http-server-mcp/src/serveMcpRequest.ts
@@ -1,0 +1,146 @@
+import {
+  NodeStreamableHTTPServerTransport,
+  toNodeHandler,
+} from '@modelcontextprotocol/node';
+import type { McpServer } from '@modelcontextprotocol/server';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- value imports required; both are called at runtime
+import {
+  classifyInboundRequest,
+  createMcpHandler,
+} from '@modelcontextprotocol/server';
+import type Koa from 'koa';
+
+type Context = Koa.Context;
+
+/** Parameters for {@link createMcpRequestServer}. */
+export interface CreateMcpRequestServerParams {
+  /** The MCP server instance whose tools and resources are being served. */
+  server: McpServer;
+  /**
+   * When provided, 2025-era traffic is served statefully through a single
+   * shared transport connected once, rather than a fresh transport per request.
+   */
+  sessionIdGenerator?: () => string;
+}
+
+/**
+ * Reads a header as `string | undefined`. Koa's `ctx.get` returns `''` for a
+ * missing header, which the classifier would read as "header present but
+ * empty" rather than absent.
+ */
+const header = (ctx: Context, name: string): string | undefined => {
+  const value = ctx.get(name);
+  return value === '' ? undefined : value;
+};
+
+/**
+ * Builds the per-request serving function used by `createMcpRouter`, routing
+ * each request to the protocol revision it actually speaks.
+ *
+ * Requests are classified once at the boundary with the SDK's own
+ * `classifyInboundRequest`:
+ *
+ * - **2025-era traffic** (everything without a `2026-07-28` per-request
+ *   envelope — which is all traffic from today's MCP clients) is served over
+ *   `NodeStreamableHTTPServerTransport` with `enableJsonResponse: true`, the
+ *   same wiring and the same plain-JSON responses this package has always
+ *   produced.
+ * - **`2026-07-28` traffic** is served by `createMcpHandler` with
+ *   `legacy: 'reject'`, so the modern revision is handled by the SDK's
+ *   stateless core rather than the transport above. Malformed requests are
+ *   routed here too, so the SDK emits its own spec-defined rejection instead of
+ *   this package inventing one.
+ *
+ * Splitting on the classifier — instead of letting `createMcpHandler` serve
+ * both eras through its built-in legacy fallback — is what keeps 2025-era
+ * responses byte-compatible. That fallback constructs its transport with only
+ * `sessionIdGenerator: undefined` and no way to pass `enableJsonResponse`, so
+ * every response it produces is SSE-framed (`text/event-stream`) regardless of
+ * the handler's `responseMode`. Owning the legacy branch keeps `application/json`.
+ */
+export const createMcpRequestServer = ({
+  server,
+  sessionIdGenerator,
+}: CreateMcpRequestServerParams): ((
+  ctx: Context,
+  body?: unknown
+) => Promise<void>) => {
+  const isStateful = sessionIdGenerator !== undefined;
+
+  const modernHandler = toNodeHandler(
+    createMcpHandler(
+      () => {
+        return server;
+      },
+      { legacy: 'reject' }
+    )
+  );
+
+  // Stateful mode: single shared transport connected once at startup.
+  let sharedTransport: NodeStreamableHTTPServerTransport | undefined;
+  if (isStateful) {
+    sharedTransport = new NodeStreamableHTTPServerTransport({
+      sessionIdGenerator,
+      enableJsonResponse: true,
+    });
+    server.connect(sharedTransport);
+  }
+
+  // Stateless mode requires a fresh transport per request, and closing one
+  // while another is mid-flight on the same `McpServer` deadlocks — so
+  // requests are serialised, keeping exactly one stateless transport connected
+  // at a time. Only the legacy branch needs this; the modern handler builds its
+  // own request-scoped serving unit per exchange and runs fully concurrently.
+  let statelessQueue: Promise<void> = Promise.resolve();
+
+  const enqueueStateless = (work: () => Promise<void>): Promise<void> => {
+    const result = statelessQueue.then(() => {
+      return work();
+    });
+    // Keep the queue alive even if this work rejects so subsequent
+    // requests are not blocked by a previous failure.
+    statelessQueue = result.catch(() => {});
+    return result;
+  };
+
+  const isLegacy = (ctx: Context, body?: unknown): boolean => {
+    return (
+      classifyInboundRequest({
+        httpMethod: ctx.method,
+        protocolVersionHeader: header(ctx, 'mcp-protocol-version'),
+        mcpMethodHeader: header(ctx, 'mcp-method'),
+        mcpNameHeader: header(ctx, 'mcp-name'),
+        body,
+      }).kind === 'legacy'
+    );
+  };
+
+  return async (ctx: Context, body?: unknown): Promise<void> => {
+    if (!isLegacy(ctx, body)) {
+      await modernHandler(ctx.req, ctx.res, body);
+      return;
+    }
+
+    if (sharedTransport) {
+      await sharedTransport.handleRequest(ctx.req, ctx.res, body);
+      return;
+    }
+
+    await enqueueStateless(async () => {
+      const transport = new NodeStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      // Connect and run inside try/finally so the transport is always closed,
+      // even if connect() throws — preventing server state corruption.
+      try {
+        await server.connect(transport);
+        await transport.handleRequest(ctx.req, ctx.res, body);
+      } finally {
+        // Close the transport to reset the server's internal transport
+        // reference, allowing the next request to connect a fresh transport.
+        await transport.close();
+      }
+    });
+  };
+};

--- a/packages/http-server-mcp/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp/tests/unit/jest.config.ts
@@ -4,10 +4,10 @@ export default {
   ...jestUnitConfig(),
   coverageThreshold: {
     global: {
-      statements: 99.4,
-      branches: 94.6,
+      statements: 100,
+      branches: 95,
       functions: 100,
-      lines: 99.4,
+      lines: 100,
     },
   },
 };

--- a/packages/http-server-mcp/tests/unit/tests/mcp-router.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/mcp-router.test.ts
@@ -277,6 +277,137 @@ describe('createMcpRouter', () => {
     connectSpy.mockRestore();
   });
 
+  test('POST handler returns 500 when getApiHeaders throws', async () => {
+    const mcpServer = new McpServer({
+      name: 'test-server',
+      version: '1.0.0',
+    });
+
+    const app = new App();
+    app.use(bodyParser());
+    const router = createMcpRouter(mcpServer, {
+      getApiHeaders: () => {
+        throw new Error('getApiHeaders failed');
+      },
+    });
+    app.use(router.routes());
+
+    const response = await request(app.callback())
+      .post('/mcp')
+      .send({ jsonrpc: '2.0', method: 'initialize', params: {}, id: 1 })
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream');
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toMatch(/getApiHeaders failed/);
+  });
+
+  test('DELETE handler returns 500 when getApiHeaders throws', async () => {
+    const mcpServer = new McpServer({
+      name: 'test-server',
+      version: '1.0.0',
+    });
+
+    const app = new App();
+    const router = createMcpRouter(mcpServer, {
+      getApiHeaders: () => {
+        throw new Error('getApiHeaders failed');
+      },
+    });
+    app.use(router.routes());
+
+    const response = await request(app.callback()).delete('/mcp');
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toMatch(/getApiHeaders failed/);
+  });
+
+  describe('2026-07-28 protocol revision', () => {
+    /**
+     * A request speaking the 2026-07-28 revision: the per-request envelope in
+     * `params._meta` plus the `Mcp-Method` header the revision requires. Such a
+     * request is served by that revision's stateless core rather than the
+     * transport that answers 2025-era traffic.
+     */
+    const modernRequest = (method: string) => {
+      return {
+        body: {
+          jsonrpc: '2.0',
+          method,
+          id: 1,
+          params: {
+            _meta: {
+              'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+              'io.modelcontextprotocol/clientCapabilities': {},
+            },
+          },
+        },
+        headers: { 'Mcp-Method': method },
+      };
+    };
+
+    const buildApp = () => {
+      const mcpServer = new McpServer({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+      mcpServer.registerTool(
+        'test-tool',
+        { description: 'A test tool', inputSchema: { param: z.string() } },
+        async ({ param }) => {
+          return { content: [{ type: 'text', text: param }] };
+        }
+      );
+      const app = new App();
+      app.use(bodyParser());
+      app.use(createMcpRouter(mcpServer).routes());
+      return app;
+    };
+
+    test('serves tools/list from the same registered tools', async () => {
+      const { body, headers } = modernRequest('tools/list');
+
+      const response = await request(buildApp().callback())
+        .post('/mcp')
+        .send(body)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set(headers);
+
+      expect(response.status).toBe(200);
+      expect(response.body.result.tools).toEqual([
+        expect.objectContaining({ name: 'test-tool' }),
+      ]);
+    });
+
+    test('answers with plain JSON, same as 2025-era traffic', async () => {
+      const { body, headers } = modernRequest('tools/list');
+
+      const response = await request(buildApp().callback())
+        .post('/mcp')
+        .send(body)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set(headers);
+
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+
+    test('a 2025-era request is still served by the legacy transport', async () => {
+      const response = await request(buildApp().callback())
+        .post('/mcp')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: 1, params: {} })
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(response.body.result.tools).toEqual([
+        expect.objectContaining({ name: 'test-tool' }),
+      ]);
+    });
+  });
+
   describe('aliases', () => {
     test('POST at alias path is handled', async () => {
       const mcpServer = new McpServer({

--- a/packages/http-server-mcp/tests/unit/tests/register-tool-from-schema.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/register-tool-from-schema.test.ts
@@ -14,12 +14,11 @@ const sendMcpRequest = async (
   app: ReturnType<typeof App.prototype.callback>,
   body: Record<string, unknown>
 ) => {
-  const res = await request(app)
+  return request(app)
     .post('/mcp')
     .send(body)
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json, text/event-stream');
-  return res;
 };
 
 describe('registerToolFromSchema', () => {
@@ -121,7 +120,7 @@ describe('registerToolFromSchema', () => {
     expect(res.status).toBe(200);
 
     const tools: Array<{ name: string; inputSchema: unknown }> =
-      res.body?.result?.tools ?? [];
+      res.body.result?.tools ?? [];
 
     const tool = tools.find((t) => {
       return t.name === 'get-project';
@@ -156,7 +155,7 @@ describe('registerToolFromSchema', () => {
     });
 
     const tools: Array<{ name: string; inputSchema: unknown }> =
-      res.body?.result?.tools ?? [];
+      res.body.result?.tools ?? [];
 
     const tool = tools.find((t) => {
       return t.name === 'list-all';
@@ -205,7 +204,7 @@ describe('registerToolFromSchema', () => {
     });
 
     const tools: Array<{ name: string; inputSchema: unknown }> =
-      res.body?.result?.tools ?? [];
+      res.body.result?.tools ?? [];
 
     const zodTool = tools.find((t) => {
       return t.name === 'zod-tool';
@@ -259,7 +258,7 @@ describe('registerToolFromSchema', () => {
 
     expect(res.status).toBe(200);
 
-    const content = res.body?.result?.content ?? [];
+    const content = res.body.result?.content ?? [];
     expect(content).toContainEqual({ type: 'text', text: 'Hello, World!' });
   });
 
@@ -304,6 +303,163 @@ describe('registerToolFromSchema', () => {
     expect(capturedArgs[0]).toEqual({ id: 'abc', options: { limit: 10 } });
   });
 
+  describe('tools/call argument validation', () => {
+    const buildApp = (
+      inputSchema: Record<string, unknown>,
+      validateArguments?: boolean
+    ) => {
+      const server = new McpServer({ name: 'test', version: '1.0.0' });
+      registerToolFromSchema(server, {
+        name: 'validated',
+        description: 'Validated tool',
+        inputSchema: inputSchema as never,
+        validateArguments,
+        handler: async (args) => {
+          return { content: [{ type: 'text', text: JSON.stringify(args) }] };
+        },
+      });
+      const app = new App();
+      app.use(bodyParser());
+      app.use(createMcpRouter(server).routes());
+      return app.callback();
+    };
+
+    const callWith = (
+      app: ReturnType<typeof App.prototype.callback>,
+      args: Record<string, unknown>
+    ) => {
+      return sendMcpRequest(app, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'validated', arguments: args },
+      });
+    };
+
+    const stringSchema = {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+    };
+
+    describe('by default (validateArguments omitted)', () => {
+      // Arguments are forwarded to the handler unchecked, so a schema that
+      // describes its input incompletely — the usual shape of one generated
+      // from an OpenAPI document — never rejects a call the underlying API
+      // would have accepted.
+
+      test('a null reaches the handler even though the schema says string', async () => {
+        const res = await callWith(buildApp(stringSchema), { value: null });
+
+        expect(res.body.result?.isError).toBeFalsy();
+        expect(res.body.result?.content?.[0]?.text).toBe('{"value":null}');
+      });
+
+      test('a value of the wrong type reaches the handler', async () => {
+        const res = await callWith(buildApp(stringSchema), { value: 42 });
+
+        expect(res.body.result?.isError).toBeFalsy();
+        expect(res.body.result?.content?.[0]?.text).toBe('{"value":42}');
+      });
+
+      test('the schema is still advertised verbatim over tools/list', async () => {
+        const res = await sendMcpRequest(buildApp(stringSchema), {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+        });
+
+        expect(res.body.result?.tools?.[0]?.inputSchema).toEqual(stringSchema);
+      });
+    });
+
+    describe('with validateArguments: true', () => {
+      test('a schema without `nullable` rejects an explicit null for that field', async () => {
+        const res = await callWith(buildApp(stringSchema, true), {
+          value: null,
+        });
+
+        expect(res.body.result?.isError).toBe(true);
+        expect(res.body.result?.content?.[0]?.text).toContain(
+          'Invalid arguments'
+        );
+      });
+
+      test('a `[type, "null"]` schema accepts both the declared type and null', async () => {
+        const app = buildApp(
+          {
+            type: 'object',
+            properties: { value: { type: ['string', 'null'] } },
+          },
+          true
+        );
+
+        const withValue = await callWith(app, { value: 'hi' });
+        expect(withValue.body.result?.isError).toBeFalsy();
+
+        const withNull = await callWith(app, { value: null });
+        expect(withNull.body.result?.isError).toBeFalsy();
+      });
+
+      test('a value of the wrong type is rejected', async () => {
+        const res = await callWith(buildApp(stringSchema, true), { value: 42 });
+
+        expect(res.body.result?.isError).toBe(true);
+      });
+
+      test('a property-level oneOf accepts either alternative', async () => {
+        const app = buildApp(
+          {
+            type: 'object',
+            properties: {
+              toolChoice: {
+                oneOf: [
+                  { type: 'string', enum: ['auto', 'required'] },
+                  {
+                    type: 'object',
+                    properties: {
+                      type: { type: 'string' },
+                      name: { type: 'string' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          true
+        );
+
+        const withString = await callWith(app, { toolChoice: 'auto' });
+        expect(withString.body.result?.isError).toBeFalsy();
+
+        const withObject = await callWith(app, {
+          toolChoice: { type: 'tool', name: 'get_weather' },
+        });
+        expect(withObject.body.result?.isError).toBeFalsy();
+      });
+
+      test('required: undefined is treated the same as omitting required', async () => {
+        const app = buildApp(
+          {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+            required: undefined,
+          },
+          true
+        );
+
+        const res = await callWith(app, {});
+
+        expect(res.body.result?.isError).toBeFalsy();
+      });
+
+      test('a zero-arg schema ({ type: "object" }, no properties) accepts an empty call', async () => {
+        const res = await callWith(buildApp({ type: 'object' }, true), {});
+
+        expect(res.body.result?.isError).toBeFalsy();
+      });
+    });
+  });
+
   test('works together with createMcpRouter', () => {
     const server = new McpServer({ name: 'test', version: '1.0.0' });
 
@@ -317,44 +473,5 @@ describe('registerToolFromSchema', () => {
     const router = createMcpRouter(server);
     expect(router).toBeDefined();
     expect(typeof router.routes).toBe('function');
-  });
-
-  test('emits a dev-time warning when the tools/list handler cannot be patched', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const origEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'test';
-
-    try {
-      // Use a fresh server and delete the tools/list handler after the SDK installs
-      // it (via a normal registerTool call), to simulate the "origHandler undefined"
-      // branch inside registerToolFromSchema's patching logic.
-      const server = new McpServer({ name: 'server-warn', version: '1.0.0' });
-
-      server.registerTool(
-        'seed',
-        { description: 'seed', inputSchema: { x: z.string() } },
-        async ({ x }) => {
-          return { content: [{ type: 'text', text: x }] };
-        }
-      );
-
-      // Remove the tools/list handler so origHandler will be undefined
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (server as any).server?._requestHandlers?.delete('tools/list');
-
-      registerToolFromSchema(server, {
-        name: 'my-tool',
-        handler: async () => {
-          return { content: [{ type: 'text', text: 'hi' }] };
-        },
-      });
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Could not patch tools/list')
-      );
-    } finally {
-      process.env.NODE_ENV = origEnv;
-      warnSpy.mockRestore();
-    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,7 +822,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -1569,9 +1569,12 @@ importers:
 
   packages/http-server-mcp:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/node':
+        specifier: ^2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.23)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ttoss/auth-core':
         specifier: workspace:^
         version: link:../auth-core
@@ -1593,7 +1596,7 @@ importers:
         version: 3.0.3
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+        version: 30.4.2(@types/node@26.1.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3))
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -5912,15 +5915,23 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: ^4.11.4
     peerDependenciesMeta:
-      '@cfworker/json-schema':
+      hono:
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@module-federation/error-codes@0.22.0':
     resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
@@ -9206,10 +9217,6 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   accessor-fn@1.5.3:
     resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
     engines: {node: '>=12'}
@@ -9261,14 +9268,6 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -9732,10 +9731,6 @@ packages:
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
 
   bonjour-service@1.4.0:
     resolution: {integrity: sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==}
@@ -10221,10 +10216,6 @@ packages:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -10311,10 +10302,6 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -11509,14 +11496,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -11543,19 +11522,9 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
-  express-rate-limit@8.5.2:
-    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -11675,10 +11644,6 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   find-cache-dir@3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
     engines: {node: '>=8'}
@@ -11793,10 +11758,6 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -12349,10 +12310,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
-
   icss-utils@5.1.0:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
@@ -12490,10 +12447,6 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -12685,9 +12638,6 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -13111,9 +13061,6 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -13573,10 +13520,6 @@ packages:
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
-
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -13931,10 +13874,6 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
-    engines: {node: '>= 0.6'}
-
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -14423,10 +14362,6 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
-
-  pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
-    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -15082,10 +15017,6 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
-
   rc-motion@2.9.5:
     resolution: {integrity: sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==}
     peerDependencies:
@@ -15661,10 +15592,6 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
@@ -15768,10 +15695,6 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
 
@@ -15838,10 +15761,6 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
 
   serve@14.2.6:
     resolution: {integrity: sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==}
@@ -17538,11 +17457,6 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
-
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -22499,27 +22413,21 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.23)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.8
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
       hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@module-federation/error-codes@0.22.0': {}
 
@@ -24636,7 +24544,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -24647,7 +24555,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -24655,11 +24563,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -24668,13 +24576,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -24682,7 +24590,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       react: 19.2.6
 
   '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
@@ -26269,11 +26177,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
   accessor-fn@1.5.3: {}
 
   acorn-import-phases@1.0.4(acorn@8.16.0):
@@ -26314,10 +26217,6 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
-  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
 
@@ -26884,20 +26783,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   bonjour-service@1.4.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -27420,8 +27305,6 @@ snapshots:
 
   content-disposition@1.0.1: {}
 
-  content-disposition@1.1.0: {}
-
   content-type@1.0.5: {}
 
   content-type@2.0.0: {}
@@ -27509,11 +27392,6 @@ snapshots:
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -28973,12 +28851,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.8: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.0.8
-
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -29018,11 +28890,6 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.2.0
-
   express@4.22.2:
     dependencies:
       accepts: 1.3.8
@@ -29055,39 +28922,6 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -29235,17 +29069,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-cache-dir@3.3.2:
     dependencies:
       commondir: 1.0.1
@@ -29385,8 +29208,6 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fresh@0.5.2: {}
-
-  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -30127,10 +29948,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
   icss-utils@5.1.0(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
@@ -30235,8 +30052,6 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
-
-  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -30400,8 +30215,6 @@ snapshots:
   is-port-reachable@4.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
-
-  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -31200,8 +31013,6 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema-typed@8.0.2: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stable-stringify@1.3.0:
@@ -31803,8 +31614,6 @@ snapshots:
 
   merge-descriptors@1.0.3: {}
 
-  merge-descriptors@2.0.0: {}
-
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -32307,8 +32116,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
-
-  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -32844,8 +32651,6 @@ snapshots:
   picoquery@2.5.0: {}
 
   pirates@4.0.7: {}
-
-  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -33553,13 +33358,6 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
-      unpipe: 1.0.0
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc-motion@2.9.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -34374,16 +34172,6 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   rrweb-cssom@0.8.0: {}
 
   rtlcss@4.3.0:
@@ -34497,22 +34285,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
@@ -34589,15 +34361,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.1:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -35355,7 +35118,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -36669,10 +36432,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
Adds support for the MCP `2026-07-28` spec revision to `@ttoss/http-server-mcp`. Tracking issue: #1168. Builds on the auth hardening from #1170.

**This is no longer a breaking change.** Earlier revisions of this PR were — see [the rewrite note](#rewritten-to-be-non-breaking) below for what changed and why.

## Why

`@modelcontextprotocol/sdk`, this package's previous dependency, is frozen at `1.30.0` and will not support `2026-07-28`. That support shipped only under a new package family: `@modelcontextprotocol/server` + `@modelcontextprotocol/node`, both at `2.0.0`.

## How

Requests are classified once at the boundary using the SDK's own `classifyInboundRequest`, then served over the revision they actually speak:

- **2025-era traffic** — everything today's MCP clients send — is served over `NodeStreamableHTTPServerTransport` with `enableJsonResponse: true`: the same wiring, the same plain-JSON responses, and `sessionIdGenerator` still working.
- **`2026-07-28` traffic** (requests carrying that revision's per-request envelope) is served by the revision's stateless core, `createMcpHandler` with `legacy: 'reject'`.

Both paths share one `McpServer` instance and the same registered tools, so supporting the new revision needs no configuration.

Splitting on the classifier — rather than letting `createMcpHandler` serve both eras through its built-in legacy fallback — is what keeps 2025-era responses byte-compatible. That fallback constructs its transport with no way to pass `enableJsonResponse`, so everything it answers is SSE-framed regardless of `responseMode`. Owning the legacy branch keeps `application/json`.

`registerToolFromSchema` now wraps the SDK's `fromJsonSchema` instead of patching `McpServer`'s internal `_requestHandlers` map, deleting ~150 lines of monkey-patching.

## Rewritten to be non-breaking

The first version of this PR carried four breaking changes. A [review](https://github.com/ttoss/ttoss/pull/1171#pullrequestreview-4811212947) checking the diff against the SOAT and naturali.ai MCP servers found that the most consequential one wasn't documented as breaking at all, which prompted re-examining whether any of them were actually necessary. None were:

| Was breaking | Now |
| --- | --- |
| `sessionIdGenerator` removed | Kept and working — the legacy transport still accepts it |
| Responses SSE-framed instead of plain JSON | Plain `application/json`, as before |
| Peer dependency swap | Peer dependency dropped entirely; the SDK packages are plain `dependencies`, so consumers need no install change |
| `tools/call` arguments validated against `inputSchema` | Opt-in via `validateArguments` (default `false` — the existing pass-through) |

The validation change is the one worth explaining. It was never a *goal* — it arrived as a side effect of dropping the monkey-patch, because `fromJsonSchema` validates and the old `z.record(z.unknown())` pass-through did not. Left on, it would have coupled "get 2026-07-28 support" to "audit every schema in every consumer," and it fails at runtime on data-dependent paths rather than loudly at build time. A Standard Schema keeps `~standard.jsonSchema` (what `tools/list` advertises) and `~standard.validate` (what `tools/call` enforces) in separate fields, so enforcement can be skipped while the schema stays fully visible to clients.

## Why that validation default matters

The review's concern was verified rather than assumed, by reading tool schemas off a live SOAT deployment and running them through the real `@modelcontextprotocol/server` validator. Every one of these is a documented affordance that works against the REST API today and would have been rejected at the MCP layer:

| Live tool + argument | Documented as | Under validation |
| --- | --- | --- |
| `patch-agent.tool_choice: {type,name}` | its own description says an object is valid | rejected — must be string |
| `patch-agent.max_context_messages: null` | "Null means no limit" | rejected — must be number |
| `patch-agent.tool_bindings: null` | "set to `null` to clear" | rejected — must be array |
| `update-actor.memory_id: null` | "Set to null to unlink" | rejected — must be string |
| `update-memory-entry.metadata: null` | "Pass null to clear" | rejected — must be object |
| `update-memory-entry.tags: null` | "Pass null or an empty array to clear" | rejected — must be array |

"Pass `null` to clear" is a pervasive idiom in these APIs rather than an edge case, and `patch-agent.tool_choice` contradicts its own description in a single schema. The two shapes the review flagged as untested — `{ type: 'object' }` with no `properties`, and required-field-only calls — both pass, and are now asserted.

## Also in this PR

**`@ttoss/http-server-mcp-openapi` schema generation.** `buildInputSchema` collapsed every body property to one guessed primitive, dropping `nullable` and property-level `oneOf`/`anyOf`. It now emits `type: [t, 'null']` for nullable properties and forwards `oneOf`/`anyOf` verbatim, so a generated schema describes what the API actually accepts. This matters independently of the default above: it is what makes `validateArguments: true` safe to turn on for OpenAPI-derived tools.

SOAT carries a vendored copy of the same generator (`packages/server/src/lib/soatToolsHelpers.ts`) that needs the identical fix. It is no longer a blocker now that validation is opt-in, but it is still worth doing before anyone enables it there.

**A new [Breaking Changes](https://ttoss.dev/docs/engineering/guidelines/breaking-changes) engineering guideline.** The repo documented how to *declare* a breaking change and nothing about whether one is warranted — and this PR is the evidence that the gap matters, since it followed the existing note correctly and still shipped four unnecessary breaks. The guideline covers separating a goal from its implementation side effects, classifying breaks by how loudly they fail (an install or compile error is cheap; a runtime failure on *some* inputs warrants opt-in), preferring an additive dual path, keeping advertisement separate from enforcement, verifying against real consumers instead of inferring, and treating divergence from best practice as evidence of an unstated invariant rather than cruft to delete. The root `README.md`'s mechanical section now links it.

## Verification

- `@ttoss/http-server-mcp`: 111 tests passing, 100% statements/functions/lines
- `@ttoss/http-server-mcp-openapi`: 58 tests passing, 100% across all metrics
- New tests cover both serving paths, the plain-JSON framing, stateful mode, and both validation modes
- `tsc --noEmit` clean in `examples/http-server-mcp-calculator`
- Architectural claims — Koa bridge compatibility, concurrency, response framing, `fromJsonSchema` semantics — verified against the real published packages before implementation, not inferred

One of those checks is worth calling out, because it changed the implementation: the stateless path's serialization queue looked like obsolete SDK-1.x cruft, but the constraint it works around still exists. Closing a transport while another is mid-flight on the same `McpServer` deadlocks — a test hung for two minutes rather than failing. The queue stays, now documented with the real reason.

## Not verified

No live `tools/call` against a staging deployment. Worth noting that the review's suggestion of one wouldn't have settled the validation question anyway: a live server runs the *published* package, so it can only establish today's baseline, not exercise the new validator. The offline run against verbatim production schemas above is the stronger check.