### PR TITLE
feat(auth-core): add configurable email and password auth flows

### DIFF
--- a/packages/auth-core/CONTRIBUTING.md
+++ b/packages/auth-core/CONTRIBUTING.md
@@ -73,3 +73,36 @@ Re-litigation answers:
 - "Why `deleteBySubject`, not `deleteByOwner({ clientId, subject })`?" → "revoke all of a user's access" is the security-critical operation; per-client revocation is a local addition when a consumer needs it.
 - "Why doesn't the verifier sweep expired tokens?" → keeps the verify path read-only for read-replica deployments; expiry cleanup is a separate concern (DB TTL / cron).
 - "Why allow `expiresAt: null`?" → explicit opt-in for long-lived personal API keys; OAuth access-token issuance should always set a TTL.
+
+### ADR-002: Email delivery is a `sendEmail` callback, not a mail-transport dependency
+
+Status: accepted (2026-07-29)
+Tags: email-auth, magic-link, email-code, delivery, dependencies
+
+Decision: `createEmailAuthHandlers` mints and persists the token, then hands the plaintext to an app-provided `sendEmail(delivery)` exactly once, so the package composes the flows without depending on any mail SDK.
+Rejected: a `@ttoss/mailer` package wrapping Resend/SES — a thin re-export of provider SDKs that adds a dependency and a version to maintain while every consumer already has a configured client; templates shipped from this package — brand, copy, and i18n are application concerns and each consumer would immediately override them; `nodemailer` as a universal transport — pulls SMTP into a package whose whole point is having no I/O.
+Cost: two consumers each write their own template and send call, so a bug in one is not fixed in the other, and the package cannot verify that delivery actually happened.
+Anchors: `src/emailAuthTypes.ts` (`EmailAuthDelivery`, `EmailAuthOptions.sendEmail`), `src/emailAuth.ts` (`issueToken`).
+
+Re-litigation answers:
+
+- "Why not just ship a Resend and an SES transport?" → the flows are the reusable part; the transports are one `await client.send(...)` line each in an app that already configures the client.
+- "How does the app know what to put in the email?" → `EmailAuthDelivery` carries `purpose`, `token`, `url`, `expires`, and the user, which is everything a template needs.
+- "Why does the engine not catch a delivery failure?" → the token stays persisted and the throw reaches the app's existing error reporting, so a retry is safe and an outage is visible rather than swallowed into a 200.
+
+### ADR-003: Short numeric codes are a token format, gated on a bounded attempt count
+
+Status: accepted (2026-07-29)
+Tags: email-code, one-time-token, brute-force, rejection-sampling
+
+Decision: `generateOneTimeToken({ format: 'numeric', digits })` produces a rejection-sampled decimal code defaulting to 6 digits and a 10-minute lifetime, and `createEmailAuthHandlers` refuses to start in `emailCode` mode unless the store implements `findByEmail` and `incrementAttempts`.
+Rejected: a separate `generateNumericCode` primitive — the hash-at-rest and expiry mechanics are identical, so a second surface would duplicate them; treating a code like any other one-time token — ~20 bits is guessable within a long TTL, so shipping it without attempt counting would be insecure by default; counting attempts by token hash alone — a wrong guess hashes to nothing on record, so there is no row to charge the attempt to.
+Cost: the store contract carries an `attempts` column and an email-keyed lookup that the link flows never use, and the `numeric` format defaults to a different TTL than `hex`, which is a documented asymmetry rather than an obvious one.
+Anchors: `src/oneTimeToken.ts` (`randomDigits`, `NUMERIC_REJECTION_CEILING`), `src/emailAuthTypes.ts` (`OneTimeTokenStore.findByEmail`, `incrementAttempts`), `src/emailAuth.ts` (`verifyEmailCode`).
+
+Re-litigation answers:
+
+- "Why reject bytes ≥ 250 instead of `byte % 10`?" → plain modulo over `0-255` over-produces `0-5` by about 20%, which measurably shrinks the keyspace.
+- "Why does a wrong code look up by email rather than by its hash?" → so the failure can be charged to the outstanding record; a hash lookup of a wrong guess finds nothing and can count nothing.
+- "Why destroy the code at `maxAttempts` instead of just refusing?" → refusing while the record lives lets an attacker keep guessing until expiry; destroying it forces a fresh code with a fresh keyspace.
+- "Why a different default TTL for `numeric`?" → the smaller keyspace makes a long window a guessing window; 24 hours is safe for 32 random bytes and not for 6 digits.

--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -110,6 +110,88 @@ const { token, tokenHash, expires } = generateOneTimeToken({
 const isValid = verifyOneTimeToken({ token: received, tokenHash, expires });
 ```
 
+Pass `format: 'numeric'` for a short code the user retypes from their email
+instead of a link they click. Digits are drawn by rejection sampling so the
+keyspace stays uniform, and the lifetime defaults to 10 minutes rather than 24
+hours because ~20 bits of entropy makes a long window a guessing window.
+
+```ts
+const { token, tokenHash, expires } = generateOneTimeToken({
+  format: 'numeric',
+  digits: 6, // default; 4 to 12 supported
+});
+```
+
+A short code is only safe with a bounded attempt count, which
+`createEmailAuthHandlers` below enforces. Rolling your own means bounding the
+guesses yourself.
+
+## Email and password flows
+
+`createEmailAuthHandlers` composes the primitives above into the credential
+flows an application actually mounts — password sign-up and sign-in, magic
+links, mailed numeric codes, address confirmation, and password reset. It stays
+true to the package's contract: no database and no mail transport. Persistence
+arrives as stores, session minting as `issueSession`, and delivery as
+`sendEmail`, which receives the plaintext token exactly once and sends it with
+whichever provider the application already uses.
+
+`modes` decides which flows exist, so an application that only signs users in
+with a mailed code never exposes a password endpoint.
+
+```ts
+import { createEmailAuthHandlers } from '@ttoss/auth-core';
+
+const handlers = createEmailAuthHandlers({
+  modes: ['emailCode'],
+
+  userStore: {
+    findByEmail: (email) => db.User.findOne({ where: { email } }),
+    create: ({ email, passwordHash, emailVerified }) =>
+      db.User.create({ email, passwordHash, emailVerified }),
+    update: ({ id, ...changes }) => db.User.update(changes, { where: { id } }),
+  },
+
+  oneTimeTokenStore: {
+    /* save, find, findByEmail, delete, deleteFor, incrementAttempts */
+  },
+
+  issueSession: (user) => issueSession(user),
+
+  sendEmail: async ({ to, purpose, token, url, expires }) => {
+    await ses.send(buildAuthEmail({ to, purpose, token, url, expires }));
+  },
+
+  baseUrl: process.env.APP_URL,
+  ttl: { emailCode: 60 * 10 },
+  emailCode: { digits: 6, maxAttempts: 5 },
+
+  hooks: {
+    onUserCreated: (user) => createDefaultWorkspace(user),
+    enrichSession: ({ session, user }) => ({
+      ...session,
+      plan: planFor(user),
+    }),
+  },
+});
+```
+
+Each handler takes a normalized request and resolves to a status and a body, so
+it is mountable on any runner. For Koa, `emailAuth()` from
+[`@ttoss/http-server-auth`](../http-server-auth) does it for you.
+
+Every handler returns expected outcomes as responses — `invalid_credentials`,
+`invalid_token`, `expired_token`, `too_many_attempts` and friends, under a
+stable `error.code`. Only genuinely unexpected failures throw, `sendEmail`
+included, so a delivery outage reaches the application's error reporting rather
+than being folded into a 200.
+
+Two behaviours are deliberate and worth knowing before you diff them against
+your own implementation. The endpoints that mail something always return the
+same acknowledgement whether or not the address is on file, so the response
+cannot be used to enumerate accounts; and sign-in runs a decoy PBKDF2 compare
+for an unknown address, so response time cannot either.
+
 ## API tokens
 
 Personal access tokens in the form `<prefix>_<hex>`, recognizable in logs and
@@ -291,3 +373,5 @@ const onAuthorize = createRedirectConsentOnAuthorize({
 `createMemoryClientStore`, `createMemoryAuthCodeStore`, `createMemoryRefreshTokenStore`, and `createMemoryAccessTokenStore` are `Map`-backed implementations of the store contracts — for tests, local development, and examples. Production swaps in a durable backend behind the same interfaces.
 
 `createMemoryAccessTokenStore` implements `listBySubject` and round-trips `displayPrefix`/`createdAt` for tests and local development.
+
+`createMemoryUserStore` and `createMemoryOneTimeTokenStore` do the same for the email and password flows, including the attempt counting the `emailCode` mode requires — useful as a reference when implementing the contracts against a real database.

--- a/packages/auth-core/src/emailAuth.ts
+++ b/packages/auth-core/src/emailAuth.ts
@@ -1,0 +1,86 @@
+import { createEmailCodeHandlers } from './emailAuthCode';
+import {
+  createEmailVerificationHandler,
+  createMagicLinkHandlers,
+  createPasswordResetHandlers,
+} from './emailAuthLink';
+import { createPasswordHandlers } from './emailAuthPassword';
+import { createEmailAuthRuntime } from './emailAuthRuntime';
+import type { EmailAuthHandlers, EmailAuthOptions } from './emailAuthTypes';
+
+export {
+  type EmailAuthErrorCode,
+  emailAuthErrorCodes,
+  normalizeEmail,
+} from './emailAuthRuntime';
+
+/**
+ * Runner-agnostic engine for the email and password credential flows —
+ * password sign-up and sign-in, magic links, mailed numeric codes, address
+ * confirmation and password reset.
+ *
+ * It owns the security mechanics and nothing else: persistence arrives as
+ * stores, session minting as `issueSession`, and mail delivery as `sendEmail`,
+ * so the package carries no database and no mail-transport dependency. Mount it
+ * with an adapter — `emailAuth()` from `@ttoss/http-server-auth` for Koa.
+ *
+ * `modes` decides which handlers exist, so an application that only signs users
+ * in with a mailed code never exposes a password endpoint. A configuration that
+ * cannot be served safely throws here, at startup, rather than on a request.
+ *
+ * @example
+ * ```typescript
+ * const handlers = createEmailAuthHandlers({
+ *   modes: ['emailCode'],
+ *   userStore,
+ *   oneTimeTokenStore,
+ *   issueSession: (user) => issueSession(user),
+ *   sendEmail: async ({ to, token }) => ses.send(buildCodeEmail(to, token)),
+ * });
+ * ```
+ */
+export const createEmailAuthHandlers = (
+  options: EmailAuthOptions
+): EmailAuthHandlers => {
+  const runtime = createEmailAuthRuntime(options);
+
+  const handlers: EmailAuthHandlers = {
+    paths: runtime.paths,
+    modes: [...options.modes],
+  };
+
+  if (options.modes.includes('password')) {
+    const { signUp, signIn } = createPasswordHandlers(runtime);
+
+    handlers.signUp = signUp;
+    handlers.signIn = signIn;
+  }
+
+  if (options.modes.includes('magicLink')) {
+    const { sendMagicLink, verifyMagicLink } = createMagicLinkHandlers(runtime);
+
+    handlers.sendMagicLink = sendMagicLink;
+    handlers.verifyMagicLink = verifyMagicLink;
+  }
+
+  if (options.modes.includes('emailCode')) {
+    const { sendEmailCode, verifyEmailCode } = createEmailCodeHandlers(runtime);
+
+    handlers.sendEmailCode = sendEmailCode;
+    handlers.verifyEmailCode = verifyEmailCode;
+  }
+
+  if (options.modes.includes('emailVerification')) {
+    handlers.verifyEmail = createEmailVerificationHandler(runtime);
+  }
+
+  if (options.modes.includes('passwordReset')) {
+    const { requestPasswordReset, resetPassword } =
+      createPasswordResetHandlers(runtime);
+
+    handlers.requestPasswordReset = requestPasswordReset;
+    handlers.resetPassword = resetPassword;
+  }
+
+  return handlers;
+};

--- a/packages/auth-core/src/emailAuthCode.ts
+++ b/packages/auth-core/src/emailAuthCode.ts
@@ -1,0 +1,170 @@
+import {
+  ACCEPTED,
+  type EmailAuthRuntime,
+  error,
+  ok,
+  readEmail,
+  readString,
+} from './emailAuthRuntime';
+import type {
+  EmailAuthHandler,
+  EmailAuthUser,
+  StoredOneTimeToken,
+} from './emailAuthTypes';
+import type { AuthHttpResponse } from './oauthServerTypes';
+import { verifyOneTimeToken } from './oneTimeToken';
+
+/**
+ * The `emailCode` mode: a short numeric code mailed to the user, who types it
+ * back. Unlike the link flows, the code is looked up by address rather than by
+ * its own hash — a wrong guess hashes to nothing on record, so there would
+ * otherwise be no row to charge the failed attempt to, and the bounded attempt
+ * count is the only thing standing between ~20 bits of entropy and a
+ * brute-force.
+ */
+
+const INVALID_CODE = 'This code is not valid.';
+
+/**
+ * Charges a wrong guess to the stored code, destroying it once the allowance is
+ * spent — refusing while the record lives would let an attacker keep guessing
+ * until it expired.
+ */
+const chargeFailedAttempt = async (args: {
+  runtime: EmailAuthRuntime;
+  stored: StoredOneTimeToken;
+}): Promise<AuthHttpResponse> => {
+  const tokenStore = args.runtime.options.oneTimeTokenStore;
+  const { tokenHash } = args.stored;
+
+  if ((args.stored.attempts ?? 0) + 1 >= args.runtime.maxAttempts) {
+    await tokenStore.delete({ tokenHash, purpose: 'emailCode' });
+
+    return error(
+      429,
+      'too_many_attempts',
+      'Too many incorrect attempts. Request a new code.'
+    );
+  }
+
+  await tokenStore.incrementAttempts?.({ tokenHash, purpose: 'emailCode' });
+
+  return error(401, 'invalid_token', INVALID_CODE);
+};
+
+/**
+ * Resolves the account behind a redeemed code, creating it when the mode
+ * doubles as sign-up. A code that outlived its user row must not silently
+ * recreate the account when sign-up is disabled.
+ */
+const resolveUser = async (args: {
+  runtime: EmailAuthRuntime;
+  email: string;
+}): Promise<EmailAuthUser | undefined> => {
+  const { userStore, hooks } = args.runtime.options;
+
+  const existing = await userStore.findByEmail(args.email);
+
+  if (existing) {
+    return existing.emailVerified
+      ? existing
+      : await userStore.update({ id: existing.id, emailVerified: true });
+  }
+
+  if (!args.runtime.createUserOnVerify) {
+    return undefined;
+  }
+
+  /**
+   * A code-only account has no password to store; the address itself, proven by
+   * the code, is the credential.
+   */
+  const created = await userStore.create({
+    email: args.email,
+    passwordHash: null,
+    emailVerified: true,
+  });
+
+  await hooks?.onUserCreated?.(created);
+
+  return created;
+};
+
+export const createEmailCodeHandlers = (
+  runtime: EmailAuthRuntime
+): { sendEmailCode: EmailAuthHandler; verifyEmailCode: EmailAuthHandler } => {
+  const { options, createUserOnVerify } = runtime;
+  const { userStore, oneTimeTokenStore: tokenStore } = options;
+
+  const sendEmailCode: EmailAuthHandler = async (request) => {
+    const email = readEmail(request);
+
+    if (email === undefined) {
+      return error(400, 'invalid_request', 'A valid email is required.');
+    }
+
+    const user = await userStore.findByEmail(email);
+
+    if (user || createUserOnVerify) {
+      await runtime.issueToken({
+        purpose: 'emailCode',
+        email,
+        user: user ?? null,
+      });
+    }
+
+    return ACCEPTED;
+  };
+
+  const verifyEmailCode: EmailAuthHandler = async (request) => {
+    const email = readEmail(request);
+    const code = readString(request, 'code');
+
+    if (email === undefined || code === undefined) {
+      return error(400, 'invalid_request', 'email and code are required.');
+    }
+
+    const stored = await tokenStore.findByEmail?.({
+      email,
+      purpose: 'emailCode',
+    });
+
+    if (!stored) {
+      return error(401, 'invalid_token', INVALID_CODE);
+    }
+
+    if (stored.expires.getTime() <= Date.now()) {
+      await tokenStore.delete({
+        tokenHash: stored.tokenHash,
+        purpose: 'emailCode',
+      });
+
+      return error(401, 'expired_token', 'This code has expired.');
+    }
+
+    if (
+      !verifyOneTimeToken({
+        token: code,
+        tokenHash: stored.tokenHash,
+        expires: stored.expires,
+      })
+    ) {
+      return chargeFailedAttempt({ runtime, stored });
+    }
+
+    await tokenStore.delete({
+      tokenHash: stored.tokenHash,
+      purpose: 'emailCode',
+    });
+
+    const user = await resolveUser({ runtime, email });
+
+    if (!user) {
+      return error(401, 'invalid_token', INVALID_CODE);
+    }
+
+    return ok(await runtime.buildSession(user));
+  };
+
+  return { sendEmailCode, verifyEmailCode };
+};

--- a/packages/auth-core/src/emailAuthLink.ts
+++ b/packages/auth-core/src/emailAuthLink.ts
@@ -1,0 +1,154 @@
+import {
+  ACCEPTED,
+  type EmailAuthRuntime,
+  error,
+  type LinkPurpose,
+  ok,
+  readEmail,
+  readString,
+} from './emailAuthRuntime';
+import type { EmailAuthHandler } from './emailAuthTypes';
+import { hashPassword } from './hash';
+
+/**
+ * The three link-carrying modes — `magicLink`, `emailVerification` and
+ * `passwordReset`. All of them mint a high-entropy token, mail it inside a URL,
+ * and redeem it by hash, which is why a wrong token matches no record at all.
+ */
+
+/**
+ * Builds the "mail me a link" half of a flow. The acknowledgement is identical
+ * whether or not the address is on file, so it cannot be used to enumerate
+ * accounts.
+ */
+const createSendHandler = (args: {
+  runtime: EmailAuthRuntime;
+  purpose: LinkPurpose;
+}): EmailAuthHandler => {
+  return async (request) => {
+    const email = readEmail(request);
+
+    if (email === undefined) {
+      return error(400, 'invalid_request', 'A valid email is required.');
+    }
+
+    const user = await args.runtime.options.userStore.findByEmail(email);
+
+    if (user) {
+      await args.runtime.issueToken({ purpose: args.purpose, email, user });
+    }
+
+    return ACCEPTED;
+  };
+};
+
+export const createMagicLinkHandlers = (
+  runtime: EmailAuthRuntime
+): { sendMagicLink: EmailAuthHandler; verifyMagicLink: EmailAuthHandler } => {
+  const { userStore } = runtime.options;
+
+  const verifyMagicLink: EmailAuthHandler = async (request) => {
+    const result = await runtime.redeemLinkToken({
+      request,
+      purpose: 'magicLink',
+    });
+
+    if ('response' in result) {
+      return result.response;
+    }
+
+    /**
+     * Holding the mailed token proves control of the address, so a previously
+     * unconfirmed user is confirmed by redeeming it.
+     */
+    const user = result.user.emailVerified
+      ? result.user
+      : await userStore.update({ id: result.user.id, emailVerified: true });
+
+    return ok(await runtime.buildSession(user));
+  };
+
+  return {
+    sendMagicLink: createSendHandler({ runtime, purpose: 'magicLink' }),
+    verifyMagicLink,
+  };
+};
+
+export const createEmailVerificationHandler = (
+  runtime: EmailAuthRuntime
+): EmailAuthHandler => {
+  return async (request) => {
+    const result = await runtime.redeemLinkToken({
+      request,
+      purpose: 'emailVerification',
+    });
+
+    if ('response' in result) {
+      return result.response;
+    }
+
+    const user = await runtime.options.userStore.update({
+      id: result.user.id,
+      emailVerified: true,
+    });
+
+    return ok(await runtime.buildSession(user));
+  };
+};
+
+export const createPasswordResetHandlers = (
+  runtime: EmailAuthRuntime
+): {
+  requestPasswordReset: EmailAuthHandler;
+  resetPassword: EmailAuthHandler;
+} => {
+  const resetPassword: EmailAuthHandler = async (request) => {
+    const password = readString(request, 'password');
+
+    if (password === undefined) {
+      return error(400, 'invalid_request', 'password is required.');
+    }
+
+    if (password.length < runtime.passwordMinLength) {
+      return error(
+        400,
+        'password_too_weak',
+        `password must be at least ${runtime.passwordMinLength} characters.`
+      );
+    }
+
+    /**
+     * The new password is validated first, so a rejected one leaves the token
+     * unspent and the user can simply try again.
+     */
+    const result = await runtime.redeemLinkToken({
+      request,
+      purpose: 'passwordReset',
+    });
+
+    if ('response' in result) {
+      return result.response;
+    }
+
+    /**
+     * Completing a reset proves control of the address, so it confirms an
+     * unverified one too — otherwise a user who never clicked the original
+     * confirmation link could reset their password and still not sign in.
+     */
+    await runtime.options.userStore.update({
+      id: result.user.id,
+      passwordHash: await hashPassword(password),
+      emailVerified: true,
+    });
+
+    return ok({ message: 'Password has been reset.' });
+  };
+
+  return {
+    requestPasswordReset: createSendHandler({
+      runtime,
+      purpose: 'passwordReset',
+    }),
+    resetPassword,
+  };
+};

--- a/packages/auth-core/src/emailAuthPassword.ts
+++ b/packages/auth-core/src/emailAuthPassword.ts
@@ -1,0 +1,121 @@
+import {
+  compareAgainstDecoy,
+  type EmailAuthRuntime,
+  error,
+  ok,
+  readEmail,
+  readString,
+} from './emailAuthRuntime';
+import type { EmailAuthHandler } from './emailAuthTypes';
+import { comparePassword, hashPassword, needsRehash } from './hash';
+
+/**
+ * The `password` mode: sign-up and sign-in with a stored password hash.
+ */
+
+const INVALID_CREDENTIALS = 'Invalid email or password.';
+
+export const createPasswordHandlers = (
+  runtime: EmailAuthRuntime
+): { signUp: EmailAuthHandler; signIn: EmailAuthHandler } => {
+  const { options, passwordMinLength, signInOnSignUp } = runtime;
+  const { userStore, hooks } = options;
+
+  const signUp: EmailAuthHandler = async (request) => {
+    const email = readEmail(request);
+    const password = readString(request, 'password');
+
+    if (email === undefined) {
+      return error(400, 'invalid_request', 'A valid email is required.');
+    }
+
+    if (password === undefined) {
+      return error(400, 'invalid_request', 'password is required.');
+    }
+
+    if (password.length < passwordMinLength) {
+      return error(
+        400,
+        'password_too_weak',
+        `password must be at least ${passwordMinLength} characters.`
+      );
+    }
+
+    if (await userStore.findByEmail(email)) {
+      return error(
+        409,
+        'email_exists',
+        'An account with this email already exists.'
+      );
+    }
+
+    const user = await userStore.create({
+      email,
+      passwordHash: await hashPassword(password),
+      emailVerified: false,
+    });
+
+    await hooks?.onUserCreated?.(user);
+
+    if (options.modes.includes('emailVerification')) {
+      await runtime.issueToken({ purpose: 'emailVerification', email, user });
+    }
+
+    if (!signInOnSignUp) {
+      return {
+        status: 201,
+        body: { message: 'Account created. Check your email to confirm it.' },
+      };
+    }
+
+    return { status: 201, body: await runtime.buildSession(user) };
+  };
+
+  const signIn: EmailAuthHandler = async (request) => {
+    const email = readEmail(request);
+    const password = readString(request, 'password');
+
+    if (email === undefined || password === undefined) {
+      return error(400, 'invalid_request', 'email and password are required.');
+    }
+
+    const user = await userStore.findByEmail(email);
+
+    /**
+     * The unknown-address and no-password cases both do the decoy compare, so
+     * neither is distinguishable from a wrong password by response time.
+     */
+    if (!user?.passwordHash) {
+      await compareAgainstDecoy(password);
+
+      return error(401, 'invalid_credentials', INVALID_CREDENTIALS);
+    }
+
+    if (!(await comparePassword(password, user.passwordHash))) {
+      return error(401, 'invalid_credentials', INVALID_CREDENTIALS);
+    }
+
+    /**
+     * Checked after the password so an unconfirmed address is never disclosed
+     * to someone who does not hold the credential.
+     */
+    if (options.password?.requireVerifiedEmail && !user.emailVerified) {
+      return error(
+        403,
+        'email_not_verified',
+        'Confirm your email address before signing in.'
+      );
+    }
+
+    if (needsRehash(user.passwordHash)) {
+      await userStore.update({
+        id: user.id,
+        passwordHash: await hashPassword(password),
+      });
+    }
+
+    return ok(await runtime.buildSession(user));
+  };
+
+  return { signUp, signIn };
+};

--- a/packages/auth-core/src/emailAuthRuntime.ts
+++ b/packages/auth-core/src/emailAuthRuntime.ts
@@ -1,0 +1,412 @@
+import type {
+  EmailAuthDelivery,
+  EmailAuthOptions,
+  EmailAuthPaths,
+  EmailAuthSession,
+  EmailAuthUser,
+  OneTimeTokenPurpose,
+} from './emailAuthTypes';
+import { comparePassword, hashPassword } from './hash';
+import type { AuthHttpRequest, AuthHttpResponse } from './oauthServerTypes';
+import {
+  generateOneTimeToken,
+  hashOneTimeToken,
+  verifyOneTimeToken,
+} from './oneTimeToken';
+
+/**
+ * Shared plumbing behind the credential flows: option resolution, request
+ * parsing, response shaping, and the one-time token lifecycle. The per-mode
+ * handler factories (`./emailAuthPassword`, `./emailAuthLink`,
+ * `./emailAuthCode`) build on the {@link EmailAuthRuntime} assembled here, so
+ * each mode file holds only its own flow logic.
+ */
+
+const DEFAULT_PATHS: Required<EmailAuthPaths> = {
+  signUp: '/auth/signup',
+  signIn: '/auth/login',
+  sendMagicLink: '/auth/magic-link',
+  verifyMagicLink: '/auth/magic-link/verify',
+  sendEmailCode: '/auth/code',
+  verifyEmailCode: '/auth/code/verify',
+  verifyEmail: '/auth/verify-email',
+  requestPasswordReset: '/auth/password/reset-request',
+  resetPassword: '/auth/password/reset',
+};
+
+const DEFAULT_LINK_PATHS = {
+  magicLink: '/auth/callback',
+  emailVerification: '/auth/verify-email',
+  passwordReset: '/auth/reset-password',
+};
+
+const DEFAULT_TTL = {
+  magicLink: 60 * 60 * 24,
+  emailCode: 60 * 10,
+  emailVerification: 60 * 60 * 24,
+  passwordReset: 60 * 60,
+} satisfies Record<OneTimeTokenPurpose, number>;
+
+const DEFAULT_PASSWORD_MIN_LENGTH = 8;
+
+const DEFAULT_CODE_DIGITS = 6;
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Purposes whose token travels inside a link rather than as a typed code. */
+export type LinkPurpose = Exclude<OneTimeTokenPurpose, 'emailCode'>;
+
+/**
+ * Error codes a handler can return. Stable strings, so a client can branch on
+ * them without parsing prose.
+ */
+export const emailAuthErrorCodes = [
+  'invalid_request',
+  'invalid_credentials',
+  'email_exists',
+  'invalid_token',
+  'expired_token',
+  'too_many_attempts',
+  'email_not_verified',
+  'password_too_weak',
+] as const;
+
+export type EmailAuthErrorCode = (typeof emailAuthErrorCodes)[number];
+
+export const error = (
+  status: number,
+  code: EmailAuthErrorCode,
+  message: string
+): AuthHttpResponse => {
+  return { status, body: { error: { code, message } } };
+};
+
+export const ok = (body: unknown): AuthHttpResponse => {
+  return { status: 200, body };
+};
+
+/**
+ * Enumeration-safe acknowledgement. Every "mail me something" endpoint returns
+ * this whether or not the address is on file, so the response cannot be used to
+ * discover who has an account.
+ */
+export const ACCEPTED: AuthHttpResponse = {
+  status: 200,
+  body: { message: 'If the address is registered, an email has been sent.' },
+};
+
+export const normalizeEmail = (email: string): string => {
+  return email.trim().toLowerCase();
+};
+
+/**
+ * Reads a field from the body, falling back to the query string so a link
+ * redemption works whether the token arrives in either.
+ */
+export const readString = (
+  request: AuthHttpRequest,
+  field: string
+): string | undefined => {
+  const fromBody = request.body?.[field];
+
+  if (typeof fromBody === 'string' && fromBody.length > 0) {
+    return fromBody;
+  }
+
+  const fromQuery = request.query?.[field];
+
+  return typeof fromQuery === 'string' && fromQuery.length > 0
+    ? fromQuery
+    : undefined;
+};
+
+/** Reads and normalizes an email, returning `undefined` when it is malformed. */
+export const readEmail = (request: AuthHttpRequest): string | undefined => {
+  const email = readString(request, 'email');
+
+  if (email === undefined) {
+    return undefined;
+  }
+
+  const normalized = normalizeEmail(email);
+
+  return EMAIL_PATTERN.test(normalized) ? normalized : undefined;
+};
+
+/**
+ * A real hash to compare against when there is no stored credential, so the
+ * unknown-address and no-password paths cost the same PBKDF2 work as a wrong
+ * password and cannot be told apart by response time. Derived once per process
+ * and never used to authenticate anything.
+ */
+let decoyHash: Promise<string> | undefined;
+
+export const compareAgainstDecoy = async (
+  plainPassword: string
+): Promise<void> => {
+  decoyHash ??= hashPassword('decoy');
+
+  await comparePassword(plainPassword, await decoyHash);
+};
+
+/** The outcome of redeeming a link token: a response to return, or the user. */
+export type RedeemedToken =
+  { response: AuthHttpResponse } | { user: EmailAuthUser; email: string };
+
+export type EmailAuthRuntime = {
+  options: EmailAuthOptions;
+  paths: Required<EmailAuthPaths>;
+  passwordMinLength: number;
+  signInOnSignUp: boolean;
+  codeDigits: number;
+  maxAttempts: number;
+  createUserOnVerify: boolean;
+  /** Mints, persists and mails a token, invalidating any it supersedes. */
+  issueToken: (args: {
+    purpose: OneTimeTokenPurpose;
+    email: string;
+    user: EmailAuthUser | null;
+  }) => Promise<void>;
+  /** Issues a session and folds `enrichSession` into it. */
+  buildSession: (user: EmailAuthUser) => Promise<EmailAuthSession>;
+  /** Redeems a token the request carries in full — the link flows. */
+  redeemLinkToken: (args: {
+    request: AuthHttpRequest;
+    purpose: LinkPurpose;
+  }) => Promise<RedeemedToken>;
+};
+
+const validateOptions = (options: EmailAuthOptions): void => {
+  if (options.modes.length === 0) {
+    throw new Error('createEmailAuthHandlers requires at least one mode.');
+  }
+
+  const needsLinks = options.modes.some((mode) => {
+    return mode !== 'password' && mode !== 'emailCode';
+  });
+
+  if (needsLinks && options.baseUrl === undefined) {
+    throw new Error(
+      'createEmailAuthHandlers requires baseUrl when a mode sends a link (magicLink, emailVerification, passwordReset).'
+    );
+  }
+
+  if (!options.modes.includes('emailCode')) {
+    return;
+  }
+
+  if (options.oneTimeTokenStore.findByEmail === undefined) {
+    throw new Error(
+      'createEmailAuthHandlers requires oneTimeTokenStore.findByEmail when the emailCode mode is enabled.'
+    );
+  }
+
+  if (options.oneTimeTokenStore.incrementAttempts === undefined) {
+    throw new Error(
+      'createEmailAuthHandlers requires oneTimeTokenStore.incrementAttempts when the emailCode mode is enabled, so a short code cannot be brute-forced.'
+    );
+  }
+};
+
+const INVALID_LINK = 'This link is not valid.';
+
+const buildUrl = (args: {
+  purpose: LinkPurpose;
+  token: string;
+  baseUrl: string | undefined;
+  linkPaths: typeof DEFAULT_LINK_PATHS;
+}): string => {
+  const url = new URL(args.linkPaths[args.purpose], args.baseUrl);
+  url.searchParams.set('token', args.token);
+
+  return url.toString();
+};
+
+const createIssueToken = (args: {
+  options: EmailAuthOptions;
+  codeDigits: number;
+  ttl: Record<OneTimeTokenPurpose, number>;
+  linkPaths: typeof DEFAULT_LINK_PATHS;
+}): EmailAuthRuntime['issueToken'] => {
+  const { options, codeDigits, ttl, linkPaths } = args;
+
+  return async ({ purpose, email, user }) => {
+    const isCode = purpose === 'emailCode';
+
+    const { token, tokenHash, expires } = generateOneTimeToken(
+      isCode
+        ? {
+            format: 'numeric',
+            digits: codeDigits,
+            expiresInSeconds: ttl[purpose],
+          }
+        : { expiresInSeconds: ttl[purpose] }
+    );
+
+    await options.oneTimeTokenStore.deleteFor({ email, purpose });
+
+    await options.oneTimeTokenStore.save({
+      tokenHash,
+      email,
+      userId: user?.id ?? null,
+      purpose,
+      expires,
+      attempts: 0,
+    });
+
+    const delivery: EmailAuthDelivery = {
+      to: email,
+      purpose,
+      token,
+      expires,
+      user,
+      ...(isCode
+        ? {}
+        : {
+            url: buildUrl({
+              purpose: purpose as LinkPurpose,
+              token,
+              baseUrl: options.baseUrl,
+              linkPaths,
+            }),
+          }),
+    };
+
+    await options.sendEmail(delivery);
+  };
+};
+
+const createBuildSession = (
+  options: EmailAuthOptions
+): EmailAuthRuntime['buildSession'] => {
+  return async (user) => {
+    const session = await options.issueSession(user);
+
+    return options.hooks?.enrichSession
+      ? await options.hooks.enrichSession({ session, user })
+      : session;
+  };
+};
+
+const createRedeemLinkToken = (
+  options: EmailAuthOptions
+): EmailAuthRuntime['redeemLinkToken'] => {
+  const tokenStore = options.oneTimeTokenStore;
+
+  return async ({ request, purpose }) => {
+    const token = readString(request, 'token');
+
+    if (token === undefined) {
+      return { response: error(400, 'invalid_request', 'token is required.') };
+    }
+
+    const tokenHash = hashOneTimeToken(token);
+    const stored = await tokenStore.find({ tokenHash, purpose });
+
+    if (!stored) {
+      return { response: error(401, 'invalid_token', INVALID_LINK) };
+    }
+
+    await tokenStore.delete({ tokenHash, purpose });
+
+    if (
+      !verifyOneTimeToken({
+        token,
+        tokenHash: stored.tokenHash,
+        expires: stored.expires,
+      })
+    ) {
+      return {
+        response: error(401, 'expired_token', 'This link has expired.'),
+      };
+    }
+
+    /**
+     * Looked up fresh rather than trusted from the token, so a token that
+     * outlived the account it points at fails instead of resolving to a user
+     * who no longer exists.
+     */
+    const user = await options.userStore.findByEmail(stored.email);
+
+    if (!user) {
+      return { response: error(401, 'invalid_token', INVALID_LINK) };
+    }
+
+    return { user, email: stored.email };
+  };
+};
+
+/** The scalar knobs, with every default applied. */
+type ResolvedSettings = Pick<
+  EmailAuthRuntime,
+  | 'codeDigits'
+  | 'createUserOnVerify'
+  | 'maxAttempts'
+  | 'passwordMinLength'
+  | 'signInOnSignUp'
+>;
+
+const resolvePasswordSettings = (
+  options: EmailAuthOptions
+): Pick<ResolvedSettings, 'passwordMinLength' | 'signInOnSignUp'> => {
+  return {
+    passwordMinLength:
+      options.password?.minLength ?? DEFAULT_PASSWORD_MIN_LENGTH,
+    /**
+     * Withholding the session until the address is confirmed is only meaningful
+     * when there is a confirmation flow to complete it.
+     */
+    signInOnSignUp:
+      options.password?.signInOnSignUp ??
+      !options.modes.includes('emailVerification'),
+  };
+};
+
+const resolveCodeSettings = (
+  options: EmailAuthOptions
+): Pick<
+  ResolvedSettings,
+  'codeDigits' | 'createUserOnVerify' | 'maxAttempts'
+> => {
+  return {
+    codeDigits: options.emailCode?.digits ?? DEFAULT_CODE_DIGITS,
+    maxAttempts: options.emailCode?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    createUserOnVerify: options.emailCode?.createUserOnVerify ?? true,
+  };
+};
+
+const resolveSettings = (options: EmailAuthOptions): ResolvedSettings => {
+  return {
+    ...resolvePasswordSettings(options),
+    ...resolveCodeSettings(options),
+  };
+};
+
+/**
+ * Resolves options into the runtime the handler factories share. Throws on a
+ * configuration that cannot be served safely, so a misconfiguration fails at
+ * startup rather than on a request.
+ */
+export const createEmailAuthRuntime = (
+  options: EmailAuthOptions
+): EmailAuthRuntime => {
+  validateOptions(options);
+
+  const settings = resolveSettings(options);
+
+  return {
+    ...settings,
+    options,
+    paths: { ...DEFAULT_PATHS, ...options.paths },
+    issueToken: createIssueToken({
+      options,
+      codeDigits: settings.codeDigits,
+      ttl: { ...DEFAULT_TTL, ...options.ttl },
+      linkPaths: { ...DEFAULT_LINK_PATHS, ...options.linkPaths },
+    }),
+    buildSession: createBuildSession(options),
+    redeemLinkToken: createRedeemLinkToken(options),
+  };
+};

--- a/packages/auth-core/src/emailAuthTypes.ts
+++ b/packages/auth-core/src/emailAuthTypes.ts
@@ -1,0 +1,330 @@
+import type { AuthHttpRequest, AuthHttpResponse } from './oauthServerTypes';
+
+// ---------------------------------------------------------------------------
+// Modes
+// ---------------------------------------------------------------------------
+
+/**
+ * The credential flows an application turns on. Each mode mounts its own
+ * handlers and requires its own options, so an application that only signs
+ * users in with a mailed code never exposes a password endpoint.
+ */
+export type EmailAuthMode =
+  /** `signUp` + `signIn` with an email and a password. */
+  | 'password'
+  /** A mailed link carrying a high-entropy token that signs the user in. */
+  | 'magicLink'
+  /** A mailed short numeric code the user retypes to sign in. */
+  | 'emailCode'
+  /** A mailed link confirming the address after a password sign-up. */
+  | 'emailVerification'
+  /** The mailed forgot-password / reset-password pair. */
+  | 'passwordReset';
+
+/**
+ * Why a one-time token was issued. Persisted alongside the hash so a token
+ * minted for one flow can never be redeemed by another.
+ */
+export type OneTimeTokenPurpose =
+  'magicLink' | 'emailCode' | 'emailVerification' | 'passwordReset';
+
+// ---------------------------------------------------------------------------
+// Store contracts (app-provided persistence)
+// ---------------------------------------------------------------------------
+
+/**
+ * The application's user record, as far as this engine is concerned. Anything
+ * else on the row (name, locale, …) is the application's business and is
+ * carried through untouched by `hooks` and `issueSession`.
+ */
+export type EmailAuthUser = {
+  id: string;
+  email: string;
+  /**
+   * The stored password hash, or `null` for a user who has only ever signed in
+   * with a link or a code. Never the plain password.
+   */
+  passwordHash?: string | null;
+  emailVerified?: boolean;
+  [key: string]: unknown;
+};
+
+/**
+ * App-provided user persistence. The engine owns the flow mechanics; the app
+ * owns the table (Sequelize via `@ttoss/postgresdb`, DynamoDB, …).
+ *
+ * `findByEmail` receives an already-normalized address, so the app must store
+ * and query addresses in the same normalized form.
+ */
+export type EmailAuthUserStore = {
+  findByEmail: (
+    email: string
+  ) => Promise<EmailAuthUser | null> | EmailAuthUser | null;
+  create: (args: {
+    email: string;
+    passwordHash: string | null;
+    emailVerified: boolean;
+  }) => Promise<EmailAuthUser> | EmailAuthUser;
+  update: (args: {
+    id: string;
+    passwordHash?: string;
+    emailVerified?: boolean;
+  }) => Promise<EmailAuthUser> | EmailAuthUser;
+};
+
+/**
+ * A persisted one-time token. Only the hash is stored, so a store dump yields
+ * nothing redeemable.
+ *
+ * `email` is carried alongside `userId` because the code flow can mint a token
+ * for an address that has no user row yet, and because a wrong code has to be
+ * counted against a record found by address rather than by its own hash.
+ */
+export type StoredOneTimeToken = {
+  tokenHash: string;
+  /** Normalized address the token was mailed to. */
+  email: string;
+  /** `null` when the token was minted before the user row existed. */
+  userId: string | null;
+  purpose: OneTimeTokenPurpose;
+  expires: Date;
+  /**
+   * Wrong guesses recorded so far. Only meaningful for `emailCode`, whose
+   * short keyspace has to be defended by a bounded attempt count.
+   */
+  attempts?: number;
+};
+
+/**
+ * App-provided one-time token persistence.
+ *
+ * Every method takes or returns a `tokenHash`, never a redeemable token, which
+ * makes storing a usable secret impossible rather than merely discouraged.
+ */
+export type OneTimeTokenStore = {
+  save: (token: StoredOneTimeToken) => Promise<void> | void;
+  /**
+   * Look up by hash **and** purpose, so a token minted for one flow cannot be
+   * redeemed by another. This is the lookup for the link flows, where the
+   * token itself is the only thing the request carries.
+   */
+  find: (args: {
+    tokenHash: string;
+    purpose: OneTimeTokenPurpose;
+  }) => Promise<StoredOneTimeToken | null> | StoredOneTimeToken | null;
+  /**
+   * Look up the outstanding token for an address. Required when `emailCode` is
+   * enabled: a wrong code hashes to nothing on record, so the engine has to
+   * find the record by address before it can compare and count the attempt.
+   */
+  findByEmail?: (args: {
+    email: string;
+    purpose: OneTimeTokenPurpose;
+  }) => Promise<StoredOneTimeToken | null> | StoredOneTimeToken | null;
+  /** Delete a token, enforcing single use. */
+  delete: (args: {
+    tokenHash: string;
+    purpose: OneTimeTokenPurpose;
+  }) => Promise<void> | void;
+  /**
+   * Delete every outstanding token of this purpose for this address, so
+   * issuing a new one invalidates whatever preceded it.
+   */
+  deleteFor: (args: {
+    email: string;
+    purpose: OneTimeTokenPurpose;
+  }) => Promise<void> | void;
+  /**
+   * Record a failed attempt. Required when `emailCode` is enabled; the engine
+   * calls it on every wrong guess and destroys the token once `maxAttempts` is
+   * reached.
+   */
+  incrementAttempts?: (args: {
+    tokenHash: string;
+    purpose: OneTimeTokenPurpose;
+  }) => Promise<void> | void;
+};
+
+// ---------------------------------------------------------------------------
+// Delivery and session contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything the application needs to compose and send one auth email. The
+ * engine mints and persists the token, then hands the plaintext here exactly
+ * once — there is no transport dependency in this package, so the application
+ * sends it with whichever provider it already uses (Resend, SES, SMTP, …).
+ */
+export type EmailAuthDelivery = {
+  /** Normalized recipient address. */
+  to: string;
+  purpose: OneTimeTokenPurpose;
+  /**
+   * The plain token. For `emailCode` this is the digit code to show the user;
+   * for the link flows it is already embedded in `url`.
+   */
+  token: string;
+  /**
+   * The absolute URL to put behind the call to action, present for every
+   * purpose except `emailCode`. Built from `baseUrl` and the flow's `paths`.
+   */
+  url?: string;
+  expires: Date;
+  /**
+   * The user the token was issued for, or `null` when a code was mailed to an
+   * address that has no user row yet.
+   */
+  user: EmailAuthUser | null;
+};
+
+/**
+ * Whatever the application hands back to the client on a successful
+ * authentication. The engine never inspects it, which is what lets one
+ * application return a bare JWT and another an access token plus a rotating
+ * refresh token.
+ */
+export type EmailAuthSession = Record<string, unknown>;
+
+export type EmailAuthHooks = {
+  /**
+   * Called after a user row is created, before a session is issued. The place
+   * for application-specific bootstrapping (a default workspace, a free-plan
+   * subscription, an analytics identify call).
+   */
+  onUserCreated?: (user: EmailAuthUser) => Promise<void> | void;
+  /**
+   * Called after `issueSession`, to fold application state into the response
+   * body without the engine knowing about it.
+   */
+  enrichSession?: (args: {
+    session: EmailAuthSession;
+    user: EmailAuthUser;
+  }) => Promise<EmailAuthSession> | EmailAuthSession;
+};
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Lifetime in seconds for each purpose's token. */
+export type EmailAuthTtl = {
+  /** Defaults to 24 hours. */
+  magicLink?: number;
+  /** Defaults to 10 minutes — a short code needs a short window. */
+  emailCode?: number;
+  /** Defaults to 24 hours. */
+  emailVerification?: number;
+  /** Defaults to 1 hour. */
+  passwordReset?: number;
+};
+
+export type EmailCodeOptions = {
+  /** Number of digits. Defaults to 6. */
+  digits?: number;
+  /**
+   * Wrong guesses a single code tolerates before it is destroyed. Defaults
+   * to 5. Requires `oneTimeTokenStore.incrementAttempts`.
+   */
+  maxAttempts?: number;
+  /**
+   * Whether verifying a code for an unknown address creates the user, making
+   * the code flow a combined sign-up and sign-in. Defaults to `true`.
+   */
+  createUserOnVerify?: boolean;
+};
+
+export type PasswordOptions = {
+  /** Minimum plain-password length. Defaults to 8. */
+  minLength?: number;
+  /**
+   * Whether `signUp` issues a session immediately, or withholds it until the
+   * address is confirmed. Defaults to `false` when `emailVerification` is
+   * enabled and `true` otherwise.
+   */
+  signInOnSignUp?: boolean;
+  /** Whether `signIn` rejects a user whose address is unconfirmed. */
+  requireVerifiedEmail?: boolean;
+};
+
+/** Route paths, so an application can mount the flows under its own scheme. */
+export type EmailAuthPaths = {
+  signUp?: string;
+  signIn?: string;
+  sendMagicLink?: string;
+  verifyMagicLink?: string;
+  sendEmailCode?: string;
+  verifyEmailCode?: string;
+  verifyEmail?: string;
+  requestPasswordReset?: string;
+  resetPassword?: string;
+};
+
+export type EmailAuthOptions = {
+  /** The flows to enable. At least one is required. */
+  modes: EmailAuthMode[];
+  userStore: EmailAuthUserStore;
+  oneTimeTokenStore: OneTimeTokenStore;
+  /**
+   * Mints whatever the application calls a session. Kept as a hook rather than
+   * a built-in because session topology is the one thing consumers genuinely
+   * disagree on — a long-lived JWT and a short access token with a rotating
+   * refresh family are both valid, and neither belongs in this engine.
+   */
+  issueSession: (
+    user: EmailAuthUser
+  ) => Promise<EmailAuthSession> | EmailAuthSession;
+  /**
+   * Sends one auth email. Anything it throws propagates out of the handler to
+   * the adapter's error handling rather than being folded into a response, so
+   * a delivery outage surfaces as an error the application already reports.
+   */
+  sendEmail: (delivery: EmailAuthDelivery) => Promise<void> | void;
+  /**
+   * Absolute base URL of the application the emailed links point at, e.g.
+   * `https://app.example.com`. Required by every mode except `emailCode`.
+   */
+  baseUrl?: string;
+  /**
+   * Client-side paths the emailed links land on, appended to `baseUrl` with
+   * `?token=`. Default to `/auth/callback`, `/auth/verify-email` and
+   * `/auth/reset-password`.
+   */
+  linkPaths?: {
+    magicLink?: string;
+    emailVerification?: string;
+    passwordReset?: string;
+  };
+  ttl?: EmailAuthTtl;
+  emailCode?: EmailCodeOptions;
+  password?: PasswordOptions;
+  paths?: EmailAuthPaths;
+  hooks?: EmailAuthHooks;
+};
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export type EmailAuthHandler = (
+  request: AuthHttpRequest
+) => Promise<AuthHttpResponse>;
+
+/**
+ * The mounted flows. A handler is present only when its mode is enabled, so an
+ * adapter can mount exactly what the application configured.
+ */
+export type EmailAuthHandlers = {
+  /** Resolved paths for every mounted handler. */
+  paths: Required<EmailAuthPaths>;
+  /** The modes that were enabled. */
+  modes: EmailAuthMode[];
+  signUp?: EmailAuthHandler;
+  signIn?: EmailAuthHandler;
+  sendMagicLink?: EmailAuthHandler;
+  verifyMagicLink?: EmailAuthHandler;
+  sendEmailCode?: EmailAuthHandler;
+  verifyEmailCode?: EmailAuthHandler;
+  verifyEmail?: EmailAuthHandler;
+  requestPasswordReset?: EmailAuthHandler;
+  resetPassword?: EmailAuthHandler;
+};

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -9,6 +9,30 @@ export {
   createAccessTokenVerifier,
   type VerifiedAccessToken,
 } from './createAccessTokenVerifier';
+export {
+  createEmailAuthHandlers,
+  type EmailAuthErrorCode,
+  emailAuthErrorCodes,
+  normalizeEmail,
+} from './emailAuth';
+export type {
+  EmailAuthDelivery,
+  EmailAuthHandler,
+  EmailAuthHandlers,
+  EmailAuthHooks,
+  EmailAuthMode,
+  EmailAuthOptions,
+  EmailAuthPaths,
+  EmailAuthSession,
+  EmailAuthTtl,
+  EmailAuthUser,
+  EmailAuthUserStore,
+  EmailCodeOptions,
+  OneTimeTokenPurpose,
+  OneTimeTokenStore,
+  PasswordOptions,
+  StoredOneTimeToken,
+} from './emailAuthTypes';
 export { decode, encode } from './encodeDecode';
 export {
   decryptValue,
@@ -21,7 +45,9 @@ export {
   createMemoryAccessTokenStore,
   createMemoryAuthCodeStore,
   createMemoryClientStore,
+  createMemoryOneTimeTokenStore,
   createMemoryRefreshTokenStore,
+  createMemoryUserStore,
 } from './memoryStores';
 export {
   buildAuthorizationServerMetadata,
@@ -40,6 +66,8 @@ export {
 export {
   type AccessTokenStore,
   type AuthCodeStore,
+  type AuthHttpRequest,
+  type AuthHttpResponse,
   type AuthorizeRequest,
   type ClientStore,
   createOAuthHandlers,
@@ -64,7 +92,10 @@ export {
 export {
   generateOneTimeToken,
   hashOneTimeToken,
+  MAX_NUMERIC_DIGITS,
+  MIN_NUMERIC_DIGITS,
   type OneTimeToken,
+  type OneTimeTokenFormat,
   verifyOneTimeToken,
 } from './oneTimeToken';
 export {

--- a/packages/auth-core/src/memoryStores.ts
+++ b/packages/auth-core/src/memoryStores.ts
@@ -1,4 +1,10 @@
 import type {
+  EmailAuthUser,
+  EmailAuthUserStore,
+  OneTimeTokenStore,
+  StoredOneTimeToken,
+} from './emailAuthTypes';
+import type {
   AccessTokenStore,
   AuthCodeStore,
   ClientStore,
@@ -113,6 +119,114 @@ export const createMemoryAccessTokenStore = (): AccessTokenStore => {
       return [...tokens.values()].filter((token) => {
         return token.subject === subject;
       });
+    },
+  };
+};
+
+/**
+ * In-memory reference {@link EmailAuthUserStore}, keyed by normalized email.
+ * Ids are sequential, so they are stable within a run but meaningless across
+ * runs. For tests, local development, and examples only.
+ */
+export const createMemoryUserStore = (
+  initial: EmailAuthUser[] = []
+): EmailAuthUserStore => {
+  const users = new Map<string, EmailAuthUser>(
+    initial.map((user) => {
+      return [user.email, user];
+    })
+  );
+
+  let nextId = initial.length + 1;
+
+  const findById = (id: string): EmailAuthUser => {
+    for (const user of users.values()) {
+      if (user.id === id) {
+        return user;
+      }
+    }
+
+    throw new Error(`No user with id ${id}.`);
+  };
+
+  return {
+    findByEmail: (email) => {
+      return users.get(email) ?? null;
+    },
+    create: ({ email, passwordHash, emailVerified }) => {
+      const user: EmailAuthUser = {
+        id: `user_${nextId}`,
+        email,
+        passwordHash,
+        emailVerified,
+      };
+
+      nextId += 1;
+      users.set(email, user);
+
+      return user;
+    },
+    update: ({ id, passwordHash, emailVerified }) => {
+      const current = findById(id);
+
+      const updated: EmailAuthUser = {
+        ...current,
+        ...(passwordHash === undefined ? {} : { passwordHash }),
+        ...(emailVerified === undefined ? {} : { emailVerified }),
+      };
+
+      users.set(updated.email, updated);
+
+      return updated;
+    },
+  };
+};
+
+/**
+ * In-memory reference {@link OneTimeTokenStore}, keyed by `tokenHash` and
+ * purpose. Implements the full surface, including the attempt counting the
+ * `emailCode` mode requires. For tests and local development only.
+ */
+export const createMemoryOneTimeTokenStore = (): OneTimeTokenStore => {
+  const tokens = new Map<string, StoredOneTimeToken>();
+
+  const key = (args: { tokenHash: string; purpose: string }): string => {
+    return `${args.purpose}:${args.tokenHash}`;
+  };
+
+  return {
+    save: (token) => {
+      tokens.set(key(token), token);
+    },
+    find: ({ tokenHash, purpose }) => {
+      return tokens.get(key({ tokenHash, purpose })) ?? null;
+    },
+    findByEmail: ({ email, purpose }) => {
+      for (const token of tokens.values()) {
+        if (token.email === email && token.purpose === purpose) {
+          return token;
+        }
+      }
+
+      return null;
+    },
+    delete: ({ tokenHash, purpose }) => {
+      tokens.delete(key({ tokenHash, purpose }));
+    },
+    deleteFor: ({ email, purpose }) => {
+      for (const [entry, token] of tokens) {
+        if (token.email === email && token.purpose === purpose) {
+          tokens.delete(entry);
+        }
+      }
+    },
+    incrementAttempts: ({ tokenHash, purpose }) => {
+      const entry = key({ tokenHash, purpose });
+      const token = tokens.get(entry);
+
+      if (token) {
+        tokens.set(entry, { ...token, attempts: (token.attempts ?? 0) + 1 });
+      }
     },
   };
 };

--- a/packages/auth-core/src/oauthServerTypes.ts
+++ b/packages/auth-core/src/oauthServerTypes.ts
@@ -6,6 +6,16 @@
 // translates its own request/response objects to and from these plain shapes.
 // ---------------------------------------------------------------------------
 
+/**
+ * Neutral aliases for the two shapes below. They predate the email/password
+ * flows in `./emailAuth`, which reuse them verbatim, so the `OAuth`-prefixed
+ * names are kept as the originals and these read correctly at the newer call
+ * sites.
+ */
+export type AuthHttpRequest = OAuthRequest;
+
+export type AuthHttpResponse = OAuthResponse;
+
 /** A normalized inbound HTTP request, framework-agnostic. */
 export interface OAuthRequest {
   /** Query-string parameters (e.g. from `/authorize?client_id=...`). */
@@ -323,8 +333,7 @@ export interface OnRefreshTokenArgs {
 
 /** Result of validating a refresh token. Return `undefined` to reject. */
 export type OnRefreshTokenResult =
-  | { subject: string; scopes: string[] }
-  | undefined;
+  { subject: string; scopes: string[] } | undefined;
 
 /** Configuration for {@link createOAuthHandlers}. */
 export interface OAuthServerOptions {

--- a/packages/auth-core/src/oneTimeToken.ts
+++ b/packages/auth-core/src/oneTimeToken.ts
@@ -9,6 +9,46 @@ import crypto from 'node:crypto';
  * successful verification.
  */
 
+/**
+ * How the plain token is encoded.
+ *
+ * `hex` produces a high-entropy string for tokens that travel inside a link
+ * the user clicks. `numeric` produces a short digit code the user retypes from
+ * their email or SMS — human-transcribable, and therefore low-entropy enough
+ * that it is only safe with a short lifetime and a bounded attempt count.
+ */
+export type OneTimeTokenFormat = 'hex' | 'numeric';
+
+export const MIN_NUMERIC_DIGITS = 4;
+
+export const MAX_NUMERIC_DIGITS = 12;
+
+/**
+ * Largest multiple of 10 that fits in a byte. Bytes at or above it are
+ * discarded so that `byte % 10` stays uniform over `0-9`.
+ */
+const NUMERIC_REJECTION_CEILING = 250;
+
+const DEFAULT_NUMERIC_DIGITS = 6;
+
+const DEFAULT_NUMERIC_TTL = 60 * 10;
+
+const DEFAULT_HEX_TTL = 60 * 60 * 24;
+
+const assertDigits = (digits: number): number => {
+  if (
+    !Number.isInteger(digits) ||
+    digits < MIN_NUMERIC_DIGITS ||
+    digits > MAX_NUMERIC_DIGITS
+  ) {
+    throw new Error(
+      `digits must be an integer between ${MIN_NUMERIC_DIGITS} and ${MAX_NUMERIC_DIGITS}, received ${digits}.`
+    );
+  }
+
+  return digits;
+};
+
 export type OneTimeToken = {
   /**
    * The plain token to deliver to the user (e.g., in a link sent by email).
@@ -26,32 +66,102 @@ export const hashOneTimeToken = (token: string): string => {
   return crypto.createHash('sha256').update(token).digest('hex');
 };
 
+/**
+ * Uniformly random decimal string via rejection sampling.
+ *
+ * `crypto.randomInt` would also be unbiased, but drawing the whole code from a
+ * single integer caps the length at the safe-integer range; sampling per digit
+ * keeps every supported length uniform.
+ */
+const randomDigits = (digits: number): string => {
+  let code = '';
+
+  while (code.length < digits) {
+    /**
+     * Over-draw so that the expected number of rejections (a little under 2%
+     * of bytes) rarely costs a second pass.
+     */
+    const bytes = crypto.randomBytes(digits - code.length + 8);
+
+    for (const byte of bytes) {
+      if (code.length === digits) {
+        break;
+      }
+
+      if (byte >= NUMERIC_REJECTION_CEILING) {
+        continue;
+      }
+
+      code += String(byte % 10);
+    }
+  }
+
+  return code;
+};
+
+const defaultTtl = (format: OneTimeTokenFormat): number => {
+  return format === 'numeric' ? DEFAULT_NUMERIC_TTL : DEFAULT_HEX_TTL;
+};
+
+const randomToken = (args: {
+  format: OneTimeTokenFormat;
+  bytes?: number;
+  digits?: number;
+}): string => {
+  if (args.format === 'numeric') {
+    return randomDigits(assertDigits(args.digits ?? DEFAULT_NUMERIC_DIGITS));
+  }
+
+  return crypto.randomBytes(args.bytes ?? 32).toString('hex');
+};
+
 export const generateOneTimeToken = (args?: {
   /**
+   * Token encoding. Defaults to `hex`.
+   */
+  format?: OneTimeTokenFormat;
+  /**
    * Number of random bytes. The token is the hex encoding, so the string
-   * length is twice this value. Defaults to 32.
+   * length is twice this value. Defaults to 32. Ignored when `format` is
+   * `numeric`.
    */
   bytes?: number;
   /**
-   * Token lifetime in seconds. Defaults to 24 hours.
+   * Number of digits when `format` is `numeric`. Defaults to 6, and must be
+   * between {@link MIN_NUMERIC_DIGITS} and {@link MAX_NUMERIC_DIGITS}.
+   * Ignored when `format` is `hex`.
+   */
+  digits?: number;
+  /**
+   * Token lifetime in seconds. Defaults to 24 hours for `hex` and 10 minutes
+   * for `numeric`, whose smaller keyspace makes a long window a guessing
+   * window.
    */
   expiresInSeconds?: number;
 }): OneTimeToken => {
-  const bytes = args?.bytes ?? 32;
-  const expiresInSeconds = args?.expiresInSeconds ?? 60 * 60 * 24;
+  const format = args?.format ?? 'hex';
 
-  const token = crypto.randomBytes(bytes).toString('hex');
+  const expiresInSeconds = args?.expiresInSeconds ?? defaultTtl(format);
 
-  return {
-    token,
-    tokenHash: hashOneTimeToken(token),
-    expires: new Date(Date.now() + expiresInSeconds * 1000),
-  };
+  const expires = new Date(Date.now() + expiresInSeconds * 1000);
+
+  const token = randomToken({
+    format,
+    bytes: args?.bytes,
+    digits: args?.digits,
+  });
+
+  return { token, tokenHash: hashOneTimeToken(token), expires };
 };
 
 /**
  * Constant-time check of a plain token against a stored hash, also validating
  * the expiration date.
+ *
+ * This is a single-guess check and deliberately keeps no state, so a `numeric`
+ * token needs the caller to bound how many guesses a stored record accepts —
+ * `createEmailAuthHandlers` does that through
+ * `OneTimeTokenStore.incrementAttempts`.
  */
 export const verifyOneTimeToken = (args: {
   token: string;

--- a/packages/auth-core/tests/unit/jest.config.ts
+++ b/packages/auth-core/tests/unit/jest.config.ts
@@ -1,3 +1,12 @@
 import { jestUnitConfig } from '@ttoss/config';
 
-export default jestUnitConfig();
+export default jestUnitConfig({
+  coverageThreshold: {
+    global: {
+      statements: 99,
+      branches: 97.5,
+      functions: 100,
+      lines: 99,
+    },
+  },
+});

--- a/packages/auth-core/tests/unit/tests/emailAuth.test.ts
+++ b/packages/auth-core/tests/unit/tests/emailAuth.test.ts
@@ -1,0 +1,1212 @@
+import { createEmailAuthHandlers, normalizeEmail } from 'src/emailAuth';
+import type {
+  EmailAuthDelivery,
+  EmailAuthMode,
+  EmailAuthOptions,
+} from 'src/emailAuthTypes';
+import { hashPassword } from 'src/hash';
+import {
+  createMemoryOneTimeTokenStore,
+  createMemoryUserStore,
+} from 'src/memoryStores';
+import type { AuthHttpRequest } from 'src/oauthServerTypes';
+
+const BASE_URL = 'https://app.example.com';
+
+const request = (body: Record<string, unknown>): AuthHttpRequest => {
+  return { body, query: {}, headers: {} };
+};
+
+/**
+ * Builds an engine over the in-memory reference stores, capturing every
+ * delivery so a test can read the token the user would have received.
+ */
+const setup = (
+  args: {
+    modes?: EmailAuthMode[];
+    users?: Array<{
+      email: string;
+      passwordHash?: string | null;
+      emailVerified?: boolean;
+    }>;
+  } & Partial<EmailAuthOptions> = {}
+) => {
+  const { modes = ['password'], users = [], ...overrides } = args;
+
+  const sent: EmailAuthDelivery[] = [];
+
+  const userStore = createMemoryUserStore(
+    users.map((user, index) => {
+      return {
+        id: `user_${index + 1}`,
+        email: user.email,
+        passwordHash: user.passwordHash ?? null,
+        emailVerified: user.emailVerified ?? false,
+      };
+    })
+  );
+
+  const oneTimeTokenStore = createMemoryOneTimeTokenStore();
+
+  const handlers = createEmailAuthHandlers({
+    modes,
+    userStore,
+    oneTimeTokenStore,
+    baseUrl: BASE_URL,
+    issueSession: (user) => {
+      return { accessToken: `token-for-${user.id}`, userId: user.id };
+    },
+    sendEmail: (delivery) => {
+      sent.push(delivery);
+    },
+    ...overrides,
+  });
+
+  return { handlers, userStore, oneTimeTokenStore, sent };
+};
+
+const lastDelivery = (sent: EmailAuthDelivery[]): EmailAuthDelivery => {
+  const delivery = sent.at(-1);
+
+  if (!delivery) {
+    throw new Error('No email was sent.');
+  }
+
+  return delivery;
+};
+
+// ---------------------------------------------------------------------------
+// configuration
+// ---------------------------------------------------------------------------
+
+test('it should normalize an email by trimming and lower-casing', () => {
+  expect(normalizeEmail('  User@Example.COM ')).toBe('user@example.com');
+});
+
+test('it should only mount the handlers for the enabled modes', () => {
+  const { handlers } = setup({ modes: ['magicLink'] });
+
+  expect(handlers.sendMagicLink).toBeDefined();
+  expect(handlers.verifyMagicLink).toBeDefined();
+  expect(handlers.signUp).toBeUndefined();
+  expect(handlers.signIn).toBeUndefined();
+  expect(handlers.resetPassword).toBeUndefined();
+  expect(handlers.modes).toEqual(['magicLink']);
+});
+
+test('it should expose resolved paths and allow overriding them', () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    paths: { signIn: '/v1/auth/sessions' },
+  });
+
+  expect(handlers.paths.signIn).toBe('/v1/auth/sessions');
+  expect(handlers.paths.signUp).toBe('/auth/signup');
+});
+
+test('it should require at least one mode', () => {
+  expect(() => {
+    return setup({ modes: [] });
+  }).toThrow('at least one mode');
+});
+
+test('it should require baseUrl when a mode sends a link', () => {
+  expect(() => {
+    return setup({ modes: ['magicLink'], baseUrl: undefined });
+  }).toThrow('requires baseUrl');
+});
+
+test('it should not require baseUrl when only mailing codes', () => {
+  expect(() => {
+    return setup({ modes: ['emailCode'], baseUrl: undefined });
+  }).not.toThrow();
+});
+
+/**
+ * A short code without attempt counting is brute-forceable, so the engine
+ * refuses to start rather than silently running unprotected.
+ */
+test('it should require attempt counting when the emailCode mode is enabled', () => {
+  const store = createMemoryOneTimeTokenStore();
+
+  expect(() => {
+    return setup({
+      modes: ['emailCode'],
+      oneTimeTokenStore: { ...store, incrementAttempts: undefined },
+    });
+  }).toThrow('incrementAttempts');
+
+  expect(() => {
+    return setup({
+      modes: ['emailCode'],
+      oneTimeTokenStore: { ...store, findByEmail: undefined },
+    });
+  }).toThrow('findByEmail');
+});
+
+// ---------------------------------------------------------------------------
+// password
+// ---------------------------------------------------------------------------
+
+test('it should sign a user up and issue a session', async () => {
+  const { handlers, sent } = setup({ modes: ['password'] });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'New@Example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.status).toBe(201);
+  expect(response?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+  // No emailVerification mode, so nothing to confirm and nothing to send.
+  expect(sent).toHaveLength(0);
+});
+
+test('it should store the sign-up email normalized', async () => {
+  const { handlers, userStore } = setup({ modes: ['password'] });
+
+  await handlers.signUp?.(
+    request({ email: '  Mixed@Example.COM ', password: 'a-good-password' })
+  );
+
+  expect(await userStore.findByEmail('mixed@example.com')).toMatchObject({
+    email: 'mixed@example.com',
+  });
+});
+
+test('it should never store the plain password', async () => {
+  const { handlers, userStore } = setup({ modes: ['password'] });
+
+  await handlers.signUp?.(
+    request({ email: 'new@example.com', password: 'a-good-password' })
+  );
+
+  const user = await userStore.findByEmail('new@example.com');
+
+  expect(user?.passwordHash).not.toContain('a-good-password');
+  expect(user?.passwordHash).toMatch(/^pbkdf2-sha256\$/);
+});
+
+test('it should reject a sign-up for an existing email', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    users: [{ email: 'taken@example.com' }],
+  });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'taken@example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.status).toBe(409);
+  expect(response?.body).toMatchObject({ error: { code: 'email_exists' } });
+});
+
+test('it should reject a malformed email', async () => {
+  const { handlers } = setup({ modes: ['password'] });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'not-an-email', password: 'a-good-password' })
+  );
+
+  expect(response?.status).toBe(400);
+  expect(response?.body).toMatchObject({ error: { code: 'invalid_request' } });
+});
+
+test('it should reject a password below the minimum length', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    password: { minLength: 10 },
+  });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'new@example.com', password: 'short' })
+  );
+
+  expect(response?.status).toBe(400);
+  expect(response?.body).toMatchObject({
+    error: {
+      code: 'password_too_weak',
+      message: 'password must be at least 10 characters.',
+    },
+  });
+});
+
+test('it should require a password on sign-up', async () => {
+  const { handlers } = setup({ modes: ['password'] });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'new@example.com' })
+  );
+
+  expect(response?.status).toBe(400);
+});
+
+test('it should sign an existing user in', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    users: [
+      {
+        email: 'user@example.com',
+        passwordHash: await hashPassword('a-good-password'),
+        emailVerified: true,
+      },
+    ],
+  });
+
+  const response = await handlers.signIn?.(
+    request({ email: 'user@example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.status).toBe(200);
+  expect(response?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+test('it should reject a wrong password', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    users: [
+      {
+        email: 'user@example.com',
+        passwordHash: await hashPassword('a-good-password'),
+      },
+    ],
+  });
+
+  const response = await handlers.signIn?.(
+    request({ email: 'user@example.com', password: 'wrong-password' })
+  );
+
+  expect(response?.status).toBe(401);
+  expect(response?.body).toMatchObject({
+    error: { code: 'invalid_credentials' },
+  });
+});
+
+/**
+ * An unknown address and a user who has no password must be indistinguishable
+ * from a wrong password, or the response becomes an account-enumeration oracle.
+ */
+test('it should not distinguish an unknown address from a wrong password', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    users: [{ email: 'codeonly@example.com', passwordHash: null }],
+  });
+
+  const unknown = await handlers.signIn?.(
+    request({ email: 'nobody@example.com', password: 'a-good-password' })
+  );
+  const noPassword = await handlers.signIn?.(
+    request({ email: 'codeonly@example.com', password: 'a-good-password' })
+  );
+
+  expect(unknown).toEqual(noPassword);
+  expect(unknown?.status).toBe(401);
+});
+
+test('it should require both email and password to sign in', async () => {
+  const { handlers } = setup({ modes: ['password'] });
+
+  const response = await handlers.signIn?.(
+    request({ email: 'user@example.com' })
+  );
+
+  expect(response?.status).toBe(400);
+});
+
+test('it should reject an unverified user when requireVerifiedEmail is set', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    password: { requireVerifiedEmail: true },
+    users: [
+      {
+        email: 'user@example.com',
+        passwordHash: await hashPassword('a-good-password'),
+        emailVerified: false,
+      },
+    ],
+  });
+
+  const response = await handlers.signIn?.(
+    request({ email: 'user@example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.status).toBe(403);
+  expect(response?.body).toMatchObject({
+    error: { code: 'email_not_verified' },
+  });
+});
+
+test('it should rehash a legacy password hash on a successful sign-in', async () => {
+  const { handlers, userStore } = setup({
+    modes: ['password'],
+    users: [
+      {
+        email: 'user@example.com',
+        passwordHash: await hashPassword('a-good-password', {
+          iterations: 1000,
+        }),
+      },
+    ],
+  });
+
+  await handlers.signIn?.(
+    request({ email: 'user@example.com', password: 'a-good-password' })
+  );
+
+  const user = await userStore.findByEmail('user@example.com');
+
+  expect(user?.passwordHash).toMatch(/^pbkdf2-sha256\$600000\$/);
+});
+
+test('it should withhold the session on sign-up when email verification is enabled', async () => {
+  const { handlers, sent } = setup({
+    modes: ['password', 'emailVerification'],
+  });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'new@example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.status).toBe(201);
+  expect(response?.body).not.toHaveProperty('accessToken');
+  expect(lastDelivery(sent).purpose).toBe('emailVerification');
+});
+
+test('it should issue a session on sign-up when signInOnSignUp overrides verification', async () => {
+  const { handlers } = setup({
+    modes: ['password', 'emailVerification'],
+    password: { signInOnSignUp: true },
+  });
+
+  const response = await handlers.signUp?.(
+    request({ email: 'new@example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+// ---------------------------------------------------------------------------
+// magicLink
+// ---------------------------------------------------------------------------
+
+test('it should mail a magic link and sign the user in when it is redeemed', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  const send = await handlers.sendMagicLink?.(
+    request({ email: 'user@example.com' })
+  );
+
+  expect(send?.status).toBe(200);
+
+  const delivery = lastDelivery(sent);
+
+  expect(delivery.purpose).toBe('magicLink');
+  expect(delivery.token).toHaveLength(64);
+  expect(delivery.url).toBe(
+    `${BASE_URL}/auth/callback?token=${delivery.token}`
+  );
+
+  const verify = await handlers.verifyMagicLink?.(
+    request({ token: delivery.token })
+  );
+
+  expect(verify?.status).toBe(200);
+  expect(verify?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+test('it should confirm the address when a magic link is redeemed', async () => {
+  const { handlers, sent, userStore } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com', emailVerified: false }],
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+  await handlers.verifyMagicLink?.(
+    request({ token: lastDelivery(sent).token })
+  );
+
+  expect(await userStore.findByEmail('user@example.com')).toMatchObject({
+    emailVerified: true,
+  });
+});
+
+test('it should leave an already-confirmed address untouched on redemption', async () => {
+  const { handlers, sent, userStore } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com', emailVerified: true }],
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.verifyMagicLink?.(
+    request({ token: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(200);
+  expect(await userStore.findByEmail('user@example.com')).toMatchObject({
+    emailVerified: true,
+  });
+});
+
+test('it should accept a link token from the query string', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.verifyMagicLink?.({
+    body: {},
+    query: { token: lastDelivery(sent).token },
+    headers: {},
+  });
+
+  expect(response?.status).toBe(200);
+});
+
+test('it should honour a custom link path', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+    linkPaths: { magicLink: '/enter' },
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  expect(lastDelivery(sent).url).toContain(`${BASE_URL}/enter?token=`);
+});
+
+test('it should let a magic link be redeemed only once', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  const { token } = lastDelivery(sent);
+
+  await handlers.verifyMagicLink?.(request({ token }));
+  const replay = await handlers.verifyMagicLink?.(request({ token }));
+
+  expect(replay?.status).toBe(401);
+  expect(replay?.body).toMatchObject({ error: { code: 'invalid_token' } });
+});
+
+test('it should invalidate the previous magic link when a new one is issued', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+  const first = lastDelivery(sent).token;
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+  const second = lastDelivery(sent).token;
+
+  expect(
+    await handlers.verifyMagicLink?.(request({ token: first }))
+  ).toMatchObject({ status: 401 });
+  expect(
+    await handlers.verifyMagicLink?.(request({ token: second }))
+  ).toMatchObject({ status: 200 });
+});
+
+test('it should reject an expired magic link', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+    ttl: { magicLink: -1 },
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.verifyMagicLink?.(
+    request({ token: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(401);
+  expect(response?.body).toMatchObject({ error: { code: 'expired_token' } });
+});
+
+test('it should require a token to redeem a magic link', async () => {
+  const { handlers } = setup({ modes: ['magicLink'] });
+
+  const response = await handlers.verifyMagicLink?.(request({}));
+
+  expect(response?.status).toBe(400);
+});
+
+/**
+ * The acknowledgement must not reveal whether the address is on file, so an
+ * unknown address gets the same body as a known one and no email at all.
+ */
+test('it should acknowledge a magic link for an unknown address without sending mail', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  const known = await handlers.sendMagicLink?.(
+    request({ email: 'user@example.com' })
+  );
+  const unknown = await handlers.sendMagicLink?.(
+    request({ email: 'nobody@example.com' })
+  );
+
+  expect(unknown).toEqual(known);
+  expect(sent).toHaveLength(1);
+});
+
+test('it should reject a malformed address when mailing a magic link', async () => {
+  const { handlers } = setup({ modes: ['magicLink'] });
+
+  const response = await handlers.sendMagicLink?.(request({ email: 'nope' }));
+
+  expect(response?.status).toBe(400);
+});
+
+test('it should reject a missing address when mailing a magic link', async () => {
+  const { handlers } = setup({ modes: ['magicLink'] });
+
+  const response = await handlers.sendMagicLink?.(request({}));
+
+  expect(response?.status).toBe(400);
+  expect(response?.body).toMatchObject({ error: { code: 'invalid_request' } });
+});
+
+/**
+ * A token outlives the row it points at if the account is deleted mid-flight.
+ * Redeeming it must fail rather than resolve to a missing user.
+ */
+test('it should refuse a link token whose user no longer exists', async () => {
+  const users = createMemoryUserStore([
+    { id: 'user_1', email: 'user@example.com', passwordHash: null },
+  ]);
+
+  const sent: EmailAuthDelivery[] = [];
+  let deleted = false;
+
+  const handlers = createEmailAuthHandlers({
+    modes: ['magicLink'],
+    baseUrl: BASE_URL,
+    oneTimeTokenStore: createMemoryOneTimeTokenStore(),
+    userStore: {
+      ...users,
+      findByEmail: (email) => {
+        return deleted ? null : users.findByEmail(email);
+      },
+    },
+    issueSession: (user) => {
+      return { accessToken: `token-for-${user.id}` };
+    },
+    sendEmail: (delivery) => {
+      sent.push(delivery);
+    },
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  deleted = true;
+
+  const response = await handlers.verifyMagicLink?.(
+    request({ token: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(401);
+  expect(response?.body).toMatchObject({ error: { code: 'invalid_token' } });
+});
+
+// ---------------------------------------------------------------------------
+// emailCode
+// ---------------------------------------------------------------------------
+
+test('it should mail a six-digit code carrying no link', async () => {
+  const { handlers, sent } = setup({ modes: ['emailCode'] });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const delivery = lastDelivery(sent);
+
+  expect(delivery.purpose).toBe('emailCode');
+  expect(delivery.token).toMatch(/^\d{6}$/);
+  expect(delivery.url).toBeUndefined();
+});
+
+test('it should honour the digits option', async () => {
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    emailCode: { digits: 8 },
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  expect(lastDelivery(sent).token).toMatch(/^\d{8}$/);
+});
+
+test('it should create the user when an unknown address verifies a code', async () => {
+  const { handlers, sent, userStore } = setup({ modes: ['emailCode'] });
+
+  await handlers.sendEmailCode?.(request({ email: 'new@example.com' }));
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'new@example.com', code: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(200);
+  expect(response?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+
+  const user = await userStore.findByEmail('new@example.com');
+
+  expect(user).toMatchObject({ emailVerified: true, passwordHash: null });
+});
+
+test('it should sign an existing user in with a code', async () => {
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    users: [{ email: 'user@example.com', emailVerified: true }],
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: lastDelivery(sent).token })
+  );
+
+  expect(response?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+test('it should not send a code to an unknown address when createUserOnVerify is off', async () => {
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    emailCode: { createUserOnVerify: false },
+  });
+
+  const response = await handlers.sendEmailCode?.(
+    request({ email: 'nobody@example.com' })
+  );
+
+  expect(response?.status).toBe(200);
+  expect(sent).toHaveLength(0);
+});
+
+test('it should reject a missing address when mailing a code', async () => {
+  const { handlers } = setup({ modes: ['emailCode'] });
+
+  const response = await handlers.sendEmailCode?.(request({}));
+
+  expect(response?.status).toBe(400);
+});
+
+test('it should confirm an unverified address when a code is redeemed', async () => {
+  const { handlers, sent, userStore } = setup({
+    modes: ['emailCode'],
+    users: [{ email: 'user@example.com', emailVerified: false }],
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+  await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: lastDelivery(sent).token })
+  );
+
+  expect(await userStore.findByEmail('user@example.com')).toMatchObject({
+    emailVerified: true,
+  });
+});
+
+/**
+ * With sign-up disabled, a code that outlived its user row must not quietly
+ * recreate the account.
+ */
+test('it should refuse a code whose user disappeared when createUserOnVerify is off', async () => {
+  const users = createMemoryUserStore([
+    { id: 'user_1', email: 'user@example.com', passwordHash: null },
+  ]);
+
+  const sent: EmailAuthDelivery[] = [];
+  let deleted = false;
+
+  const handlers = createEmailAuthHandlers({
+    modes: ['emailCode'],
+    emailCode: { createUserOnVerify: false },
+    oneTimeTokenStore: createMemoryOneTimeTokenStore(),
+    userStore: {
+      ...users,
+      findByEmail: (email) => {
+        return deleted ? null : users.findByEmail(email);
+      },
+    },
+    issueSession: (user) => {
+      return { accessToken: `token-for-${user.id}` };
+    },
+    sendEmail: (delivery) => {
+      sent.push(delivery);
+    },
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  deleted = true;
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(401);
+});
+
+test('it should reject a wrong code', async () => {
+  const { handlers, sent } = setup({ modes: ['emailCode'] });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const wrong = lastDelivery(sent).token === '000000' ? '111111' : '000000';
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+
+  expect(response?.status).toBe(401);
+  expect(response?.body).toMatchObject({ error: { code: 'invalid_token' } });
+});
+
+test('it should require both email and code to verify', async () => {
+  const { handlers } = setup({ modes: ['emailCode'] });
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com' })
+  );
+
+  expect(response?.status).toBe(400);
+});
+
+test('it should reject a code for an address with none outstanding', async () => {
+  const { handlers } = setup({ modes: ['emailCode'] });
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: '123456' })
+  );
+
+  expect(response?.status).toBe(401);
+  expect(response?.body).toMatchObject({ error: { code: 'invalid_token' } });
+});
+
+test('it should reject an expired code', async () => {
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    ttl: { emailCode: -1 },
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(401);
+  expect(response?.body).toMatchObject({ error: { code: 'expired_token' } });
+});
+
+test('it should let a code be redeemed only once', async () => {
+  const { handlers, sent } = setup({ modes: ['emailCode'] });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const { token } = lastDelivery(sent);
+
+  await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: token })
+  );
+
+  const replay = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: token })
+  );
+
+  expect(replay?.status).toBe(401);
+});
+
+/**
+ * A six-digit code is only ~20 bits, so the bounded attempt count is what makes
+ * the flow safe. Once it is spent the code must be destroyed, not merely
+ * refused, or an attacker can keep guessing until it expires.
+ */
+test('it should destroy a code after too many wrong attempts', async () => {
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    emailCode: { maxAttempts: 3 },
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const { token } = lastDelivery(sent);
+  const wrong = token === '000000' ? '111111' : '000000';
+
+  const first = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+  const second = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+  const third = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+
+  expect(first?.status).toBe(401);
+  expect(second?.status).toBe(401);
+  expect(third?.status).toBe(429);
+  expect(third?.body).toMatchObject({ error: { code: 'too_many_attempts' } });
+
+  // The correct code is gone too, so the user has to request a new one.
+  const afterLockout = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: token })
+  );
+
+  expect(afterLockout?.status).toBe(401);
+});
+
+/**
+ * `attempts` is optional on the stored record, so a store that has never
+ * written it must still charge the first wrong guess.
+ */
+test('it should charge an attempt against a record with no attempt count', async () => {
+  const store = createMemoryOneTimeTokenStore();
+
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    emailCode: { maxAttempts: 2 },
+    oneTimeTokenStore: {
+      ...store,
+      save: (token) => {
+        return store.save({ ...token, attempts: undefined });
+      },
+    },
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const wrong = lastDelivery(sent).token === '000000' ? '111111' : '000000';
+
+  const first = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+  const second = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+
+  expect(first?.status).toBe(401);
+  expect(second?.status).toBe(429);
+});
+
+test('it should reset the attempt count when a new code is issued', async () => {
+  const { handlers, sent } = setup({
+    modes: ['emailCode'],
+    emailCode: { maxAttempts: 2 },
+  });
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const wrong = lastDelivery(sent).token === '000000' ? '111111' : '000000';
+
+  await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: wrong })
+  );
+
+  await handlers.sendEmailCode?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.verifyEmailCode?.(
+    request({ email: 'user@example.com', code: lastDelivery(sent).token })
+  );
+
+  expect(response?.status).toBe(200);
+});
+
+// ---------------------------------------------------------------------------
+// emailVerification
+// ---------------------------------------------------------------------------
+
+test('it should confirm an address and sign the user in', async () => {
+  const { handlers, sent, userStore } = setup({
+    modes: ['password', 'emailVerification'],
+  });
+
+  await handlers.signUp?.(
+    request({ email: 'new@example.com', password: 'a-good-password' })
+  );
+
+  const delivery = lastDelivery(sent);
+
+  expect(delivery.url).toBe(
+    `${BASE_URL}/auth/verify-email?token=${delivery.token}`
+  );
+
+  const response = await handlers.verifyEmail?.(
+    request({ token: delivery.token })
+  );
+
+  expect(response?.status).toBe(200);
+  expect(response?.body).toMatchObject({ accessToken: 'token-for-user_1' });
+  expect(await userStore.findByEmail('new@example.com')).toMatchObject({
+    emailVerified: true,
+  });
+});
+
+/**
+ * Purpose is stored with the token so one flow's token cannot be spent on
+ * another's endpoint.
+ */
+test('it should refuse a token minted for a different purpose', async () => {
+  const { handlers, sent } = setup({
+    modes: ['magicLink', 'emailVerification', 'passwordReset'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  await handlers.sendMagicLink?.(request({ email: 'user@example.com' }));
+
+  const { token } = lastDelivery(sent);
+
+  expect(await handlers.verifyEmail?.(request({ token }))).toMatchObject({
+    status: 401,
+  });
+  expect(
+    await handlers.resetPassword?.(
+      request({ token, password: 'a-good-password' })
+    )
+  ).toMatchObject({ status: 401 });
+});
+
+// ---------------------------------------------------------------------------
+// passwordReset
+// ---------------------------------------------------------------------------
+
+test('it should reset a password and let the new one sign in', async () => {
+  const { handlers, sent } = setup({
+    modes: ['password', 'passwordReset'],
+    users: [
+      {
+        email: 'user@example.com',
+        passwordHash: await hashPassword('old-password'),
+        emailVerified: true,
+      },
+    ],
+  });
+
+  await handlers.requestPasswordReset?.(request({ email: 'user@example.com' }));
+
+  const delivery = lastDelivery(sent);
+
+  expect(delivery.purpose).toBe('passwordReset');
+  expect(delivery.url).toBe(
+    `${BASE_URL}/auth/reset-password?token=${delivery.token}`
+  );
+
+  const reset = await handlers.resetPassword?.(
+    request({ token: delivery.token, password: 'new-password' })
+  );
+
+  expect(reset?.status).toBe(200);
+  expect(reset?.body).toMatchObject({ message: 'Password has been reset.' });
+
+  expect(
+    await handlers.signIn?.(
+      request({ email: 'user@example.com', password: 'new-password' })
+    )
+  ).toMatchObject({ status: 200 });
+
+  expect(
+    await handlers.signIn?.(
+      request({ email: 'user@example.com', password: 'old-password' })
+    )
+  ).toMatchObject({ status: 401 });
+});
+
+test('it should confirm the address when a reset completes', async () => {
+  const { handlers, sent, userStore } = setup({
+    modes: ['passwordReset'],
+    users: [{ email: 'user@example.com', emailVerified: false }],
+  });
+
+  await handlers.requestPasswordReset?.(request({ email: 'user@example.com' }));
+  await handlers.resetPassword?.(
+    request({ token: lastDelivery(sent).token, password: 'new-password' })
+  );
+
+  expect(await userStore.findByEmail('user@example.com')).toMatchObject({
+    emailVerified: true,
+  });
+});
+
+test('it should acknowledge a reset request for an unknown address without sending mail', async () => {
+  const { handlers, sent } = setup({
+    modes: ['passwordReset'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  const known = await handlers.requestPasswordReset?.(
+    request({ email: 'user@example.com' })
+  );
+  const unknown = await handlers.requestPasswordReset?.(
+    request({ email: 'nobody@example.com' })
+  );
+
+  expect(unknown).toEqual(known);
+  expect(sent).toHaveLength(1);
+});
+
+test('it should reject a malformed address on a reset request', async () => {
+  const { handlers } = setup({ modes: ['passwordReset'] });
+
+  const response = await handlers.requestPasswordReset?.(
+    request({ email: 'nope' })
+  );
+
+  expect(response?.status).toBe(400);
+});
+
+test('it should validate the new password before spending the reset token', async () => {
+  const { handlers, sent } = setup({
+    modes: ['passwordReset'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  await handlers.requestPasswordReset?.(request({ email: 'user@example.com' }));
+
+  const { token } = lastDelivery(sent);
+
+  expect(
+    await handlers.resetPassword?.(request({ token, password: 'short' }))
+  ).toMatchObject({ status: 400 });
+
+  expect(
+    await handlers.resetPassword?.(request({ password: 'a-good-password' }))
+  ).toMatchObject({ status: 400 });
+
+  expect(await handlers.resetPassword?.(request({ token }))).toMatchObject({
+    status: 400,
+  });
+
+  // The token survived both rejections, so the user can still finish.
+  expect(
+    await handlers.resetPassword?.(
+      request({ token, password: 'a-good-password' })
+    )
+  ).toMatchObject({ status: 200 });
+});
+
+test('it should let a reset token be spent only once', async () => {
+  const { handlers, sent } = setup({
+    modes: ['passwordReset'],
+    users: [{ email: 'user@example.com' }],
+  });
+
+  await handlers.requestPasswordReset?.(request({ email: 'user@example.com' }));
+
+  const { token } = lastDelivery(sent);
+
+  await handlers.resetPassword?.(
+    request({ token, password: 'a-good-password' })
+  );
+
+  expect(
+    await handlers.resetPassword?.(
+      request({ token, password: 'another-password' })
+    )
+  ).toMatchObject({ status: 401 });
+});
+
+test('it should reject an expired reset token', async () => {
+  const { handlers, sent } = setup({
+    modes: ['passwordReset'],
+    users: [{ email: 'user@example.com' }],
+    ttl: { passwordReset: -1 },
+  });
+
+  await handlers.requestPasswordReset?.(request({ email: 'user@example.com' }));
+
+  const response = await handlers.resetPassword?.(
+    request({ token: lastDelivery(sent).token, password: 'a-good-password' })
+  );
+
+  expect(response?.body).toMatchObject({ error: { code: 'expired_token' } });
+});
+
+// ---------------------------------------------------------------------------
+// hooks
+// ---------------------------------------------------------------------------
+
+test('it should call onUserCreated for both sign-up and code-created users', async () => {
+  const created: string[] = [];
+
+  const password = setup({
+    modes: ['password'],
+    hooks: {
+      onUserCreated: (user) => {
+        created.push(user.email);
+      },
+    },
+  });
+
+  await password.handlers.signUp?.(
+    request({ email: 'signup@example.com', password: 'a-good-password' })
+  );
+
+  const code = setup({
+    modes: ['emailCode'],
+    hooks: {
+      onUserCreated: (user) => {
+        created.push(user.email);
+      },
+    },
+  });
+
+  await code.handlers.sendEmailCode?.(request({ email: 'code@example.com' }));
+  await code.handlers.verifyEmailCode?.(
+    request({ email: 'code@example.com', code: lastDelivery(code.sent).token })
+  );
+
+  expect(created).toEqual(['signup@example.com', 'code@example.com']);
+});
+
+test('it should fold enrichSession into every issued session', async () => {
+  const { handlers } = setup({
+    modes: ['password'],
+    users: [
+      {
+        email: 'user@example.com',
+        passwordHash: await hashPassword('a-good-password'),
+      },
+    ],
+    hooks: {
+      enrichSession: ({ session, user }) => {
+        return { ...session, plan: 'free', email: user.email };
+      },
+    },
+  });
+
+  const response = await handlers.signIn?.(
+    request({ email: 'user@example.com', password: 'a-good-password' })
+  );
+
+  expect(response?.body).toMatchObject({
+    accessToken: 'token-for-user_1',
+    plan: 'free',
+    email: 'user@example.com',
+  });
+});
+
+test('it should propagate a delivery failure rather than swallowing it', async () => {
+  const { handlers } = setup({
+    modes: ['magicLink'],
+    users: [{ email: 'user@example.com' }],
+    sendEmail: () => {
+      throw new Error('SES is down');
+    },
+  });
+
+  await expect(
+    handlers.sendMagicLink?.(request({ email: 'user@example.com' }))
+  ).rejects.toThrow('SES is down');
+});

--- a/packages/auth-core/tests/unit/tests/oneTimeToken.test.ts
+++ b/packages/auth-core/tests/unit/tests/oneTimeToken.test.ts
@@ -1,6 +1,8 @@
 import {
   generateOneTimeToken,
   hashOneTimeToken,
+  MAX_NUMERIC_DIGITS,
+  MIN_NUMERIC_DIGITS,
   verifyOneTimeToken,
 } from 'src/oneTimeToken';
 
@@ -43,4 +45,73 @@ test('it should respect bytes and expiresInSeconds options', () => {
 
   expect(token).toHaveLength(32);
   expect(expires.getTime()).toBeLessThanOrEqual(Date.now() + 61 * 1000);
+});
+
+test('it should generate a six-digit numeric code by default', () => {
+  const { token, tokenHash, expires } = generateOneTimeToken({
+    format: 'numeric',
+  });
+
+  expect(token).toMatch(/^\d{6}$/);
+  expect(tokenHash).toBe(hashOneTimeToken(token));
+  expect(verifyOneTimeToken({ token, tokenHash, expires })).toBe(true);
+});
+
+test('it should default a numeric code to a ten-minute lifetime', () => {
+  const { expires } = generateOneTimeToken({ format: 'numeric' });
+
+  expect(expires.getTime()).toBeGreaterThan(Date.now() + 9 * 60 * 1000);
+  expect(expires.getTime()).toBeLessThanOrEqual(Date.now() + 10 * 60 * 1000);
+});
+
+test('it should respect the digits option', () => {
+  for (const digits of [MIN_NUMERIC_DIGITS, 8, MAX_NUMERIC_DIGITS]) {
+    const { token } = generateOneTimeToken({ format: 'numeric', digits });
+
+    expect(token).toHaveLength(digits);
+    expect(token).toMatch(/^\d+$/);
+  }
+});
+
+test('it should reject a digits option outside the supported range', () => {
+  for (const digits of [MIN_NUMERIC_DIGITS - 1, MAX_NUMERIC_DIGITS + 1, 6.5]) {
+    expect(() => {
+      return generateOneTimeToken({ format: 'numeric', digits });
+    }).toThrow('digits must be an integer');
+  }
+});
+
+test('it should reject a wrong numeric code', () => {
+  const { token, tokenHash, expires } = generateOneTimeToken({
+    format: 'numeric',
+  });
+
+  const wrong = token === '000000' ? '111111' : '000000';
+
+  expect(verifyOneTimeToken({ token: wrong, tokenHash, expires })).toBe(false);
+});
+
+/**
+ * Rejection sampling exists so that `byte % 10` stays uniform. A biased
+ * implementation (plain modulo over 0-255) over-produces `0-5` by ~20%, which
+ * this margin catches while staying far enough from the mean that a fair
+ * generator effectively never trips it.
+ */
+test('it should distribute numeric digits without modulo bias', () => {
+  const counts = new Array<number>(10).fill(0);
+  const draws = 4000;
+
+  for (let index = 0; index < draws; index += 1) {
+    for (const digit of generateOneTimeToken({ format: 'numeric', digits: 6 })
+      .token) {
+      counts[Number(digit)] += 1;
+    }
+  }
+
+  const expected = (draws * 6) / 10;
+
+  for (const count of counts) {
+    expect(count).toBeGreaterThan(expected * 0.88);
+    expect(count).toBeLessThan(expected * 1.12);
+  }
 });

--- a/packages/http-server-auth/README.md
+++ b/packages/http-server-auth/README.md
@@ -125,6 +125,51 @@ type AuthenticatedUser = {
 
 Both `apiToken.lookup` and `jwt.mapPayload` receive the Koa `ctx` as a second argument, enabling request-scoped work (e.g. reading a per-request connection off `ctx.db` or updating `lastUsedAt`). The single-argument signatures keep working — `ctx` is purely additive.
 
+## Email and password flows
+
+`emailAuth()` mounts the credential flows — password sign-up and sign-in, magic
+links, mailed numeric codes, address confirmation and password reset — as a Koa
+`Router`. It is a thin adapter over `createEmailAuthHandlers` from
+[`@ttoss/auth-core`](https://ttoss.dev/docs/modules/packages/auth-core), which
+owns the mechanics; this package only maps `ctx` to and from it.
+
+`modes` decides which routes exist, so an app that signs users in with a mailed
+code alone never exposes a password endpoint.
+
+```ts
+import { App, bodyParser } from '@ttoss/http-server';
+import { authMiddleware, emailAuth } from '@ttoss/http-server-auth';
+
+const app = new App();
+app.use(bodyParser());
+
+app.use(
+  emailAuth({
+    modes: ['emailCode'],
+    prefix: '/v1',
+    userStore,
+    oneTimeTokenStore,
+    issueSession: (user) => issueSession(user),
+    sendEmail: async ({ to, token }) => {
+      await ses.send(buildCodeEmail({ to, code: token }));
+    },
+  }).routes()
+);
+
+// Mount after, so the sign-in routes stay reachable without a token.
+app.use(authMiddleware({ strategies: ['jwt'], jwt: { secret } }));
+```
+
+Every route is a `POST`, link redemptions included: the token arrives in the body
+from the page the user landed on, which keeps it out of server logs and out of
+the `Referer` header. The engine also reads a token from the query string, so a
+`GET` redemption is available to an app that wants one.
+
+Mount it before `authMiddleware` (or exempt its paths) — a client calls these
+routes precisely because it has no token yet. `prefix` applies to every mounted
+path when the app versions its API; individual paths are overridable through
+`paths`.
+
 ## OAuth authorization server
 
 The package also ships `oauthServer()` — a Koa `Router` that issues tokens (`/authorize`, `/token`, `/register`, discovery), a thin adapter over `createOAuthHandlers` from [`@ttoss/auth-core`](https://ttoss.dev/docs/modules/packages/auth-core). Pair it with the `oauth` verification strategy above when one deployment both issues and verifies. See the [OAuth Authorization Server](https://ttoss.dev/docs/engineering/guidelines/oauth-authorization-server) guideline.

--- a/packages/http-server-auth/src/emailAuth.ts
+++ b/packages/http-server-auth/src/emailAuth.ts
@@ -1,0 +1,107 @@
+import {
+  createEmailAuthHandlers,
+  type EmailAuthHandler,
+  type EmailAuthOptions,
+} from '@ttoss/auth-core';
+import { type Context, Router } from '@ttoss/http-server';
+
+import { applyResponse, toAuthRequest } from './koaAdapter';
+
+/**
+ * The credential-flow option types and the runner-agnostic engine live in
+ * `@ttoss/auth-core`; this is the Koa adapter that mounts it on an
+ * `@ttoss/http-server` app. Re-exported so a consumer needs a single import.
+ */
+export {
+  createEmailAuthHandlers,
+  type EmailAuthDelivery,
+  type EmailAuthErrorCode,
+  emailAuthErrorCodes,
+  type EmailAuthHandler,
+  type EmailAuthHandlers,
+  type EmailAuthHooks,
+  type EmailAuthMode,
+  type EmailAuthOptions,
+  type EmailAuthPaths,
+  type EmailAuthSession,
+  type EmailAuthTtl,
+  type EmailAuthUser,
+  type EmailAuthUserStore,
+  type EmailCodeOptions,
+  normalizeEmail,
+  type OneTimeTokenPurpose,
+  type OneTimeTokenStore,
+  type PasswordOptions,
+  type StoredOneTimeToken,
+} from '@ttoss/auth-core';
+
+/**
+ * Mounts the email and password credential flows as a Koa `Router`, adapting
+ * the runner-agnostic engine from `@ttoss/auth-core`. Which routes appear is
+ * decided by `modes`, so an app that only signs users in with a mailed code
+ * never exposes a password endpoint.
+ *
+ * Every route is a `POST`, including the link redemptions: the token arrives in
+ * the body from the page the user landed on, which keeps it out of server logs
+ * and out of the `Referer` header. The engine also reads a token from the query
+ * string, so a `GET` redemption can be added by an application that wants one.
+ *
+ * Mount it **before** `authMiddleware`, or exempt its paths — the sign-in
+ * routes are what a client calls precisely because it has no token yet.
+ *
+ * @example
+ * ```typescript
+ * import { App, bodyParser } from '@ttoss/http-server';
+ * import { emailAuth } from '@ttoss/http-server-auth';
+ *
+ * const app = new App();
+ * app.use(bodyParser());
+ * app.use(
+ *   emailAuth({
+ *     modes: ['emailCode'],
+ *     userStore,
+ *     oneTimeTokenStore,
+ *     issueSession: (user) => issueSession(user),
+ *     sendEmail: async ({ to, token }) => {
+ *       await ses.send(buildCodeEmail({ to, code: token }));
+ *     },
+ *   }).routes()
+ * );
+ * ```
+ */
+export const emailAuth = (
+  options: EmailAuthOptions & {
+    /**
+     * Prefix applied to every mounted path, e.g. `/v1`. Useful when the app
+     * versions its API and the engine's default paths are otherwise fine.
+     */
+    prefix?: string;
+  }
+): Router => {
+  const handlers = createEmailAuthHandlers(options);
+  const router = new Router();
+
+  const prefix = options.prefix ?? '';
+
+  const mount = (path: string, handler: EmailAuthHandler | undefined): void => {
+    if (!handler) {
+      return;
+    }
+
+    router.post(`${prefix}${path}`, async (ctx: Context) => {
+      applyResponse(ctx, await handler(toAuthRequest(ctx)));
+    });
+  };
+
+  mount(handlers.paths.signUp, handlers.signUp);
+  mount(handlers.paths.signIn, handlers.signIn);
+  mount(handlers.paths.sendMagicLink, handlers.sendMagicLink);
+  mount(handlers.paths.verifyMagicLink, handlers.verifyMagicLink);
+  mount(handlers.paths.sendEmailCode, handlers.sendEmailCode);
+  mount(handlers.paths.verifyEmailCode, handlers.verifyEmailCode);
+  mount(handlers.paths.verifyEmail, handlers.verifyEmail);
+  mount(handlers.paths.requestPasswordReset, handlers.requestPasswordReset);
+  mount(handlers.paths.resetPassword, handlers.resetPassword);
+
+  return router;
+};

--- a/packages/http-server-auth/src/index.ts
+++ b/packages/http-server-auth/src/index.ts
@@ -1,5 +1,28 @@
 export { authMiddleware } from './authMiddleware';
 export {
+  createEmailAuthHandlers,
+  emailAuth,
+  type EmailAuthDelivery,
+  type EmailAuthErrorCode,
+  emailAuthErrorCodes,
+  type EmailAuthHandler,
+  type EmailAuthHandlers,
+  type EmailAuthHooks,
+  type EmailAuthMode,
+  type EmailAuthOptions,
+  type EmailAuthPaths,
+  type EmailAuthSession,
+  type EmailAuthTtl,
+  type EmailAuthUser,
+  type EmailAuthUserStore,
+  type EmailCodeOptions,
+  normalizeEmail,
+  type OneTimeTokenPurpose,
+  type OneTimeTokenStore,
+  type PasswordOptions,
+  type StoredOneTimeToken,
+} from './emailAuth';
+export {
   type AuthCodeStore,
   type AuthorizeRequest,
   type ClientStore,

--- a/packages/http-server-auth/src/koaAdapter.ts
+++ b/packages/http-server-auth/src/koaAdapter.ts
@@ -1,0 +1,49 @@
+import type { AuthHttpRequest, AuthHttpResponse } from '@ttoss/auth-core';
+import type { Context } from '@ttoss/http-server';
+
+/**
+ * Translation between Koa's `ctx` and the framework-agnostic request/response
+ * shapes the `@ttoss/auth-core` engines speak. Shared by every adapter in this
+ * package so the mapping exists once.
+ */
+
+/** Normalizes a Koa query/header value (which may be an array) to a string. */
+export const firstValue = (
+  value: string | string[] | undefined
+): string | undefined => {
+  return Array.isArray(value) ? value[0] : value;
+};
+
+export const toAuthRequest = (ctx: Context): AuthHttpRequest => {
+  const query: Record<string, string | undefined> = {};
+
+  for (const [key, value] of Object.entries(ctx.query)) {
+    query[key] = firstValue(value);
+  }
+
+  const headers: Record<string, string | undefined> = {};
+
+  for (const [key, value] of Object.entries(ctx.headers)) {
+    headers[key] = firstValue(value);
+  }
+
+  return {
+    query,
+    body: (ctx.request.body ?? {}) as Record<string, unknown>,
+    headers,
+  };
+};
+
+/**
+ * Applies an engine response to `ctx`. A response carries either a JSON body
+ * with a status or a redirect, never both.
+ */
+export const applyResponse = (ctx: Context, res: AuthHttpResponse): void => {
+  if (res.redirect !== undefined) {
+    ctx.redirect(res.redirect);
+    return;
+  }
+
+  ctx.status = res.status;
+  ctx.body = res.body;
+};

--- a/packages/http-server-auth/src/oauthServer.ts
+++ b/packages/http-server-auth/src/oauthServer.ts
@@ -1,10 +1,7 @@
-import {
-  createOAuthHandlers,
-  type OAuthRequest,
-  type OAuthResponse,
-  type OAuthServerOptions,
-} from '@ttoss/auth-core';
+import { createOAuthHandlers, type OAuthServerOptions } from '@ttoss/auth-core';
 import { type Context, type Middleware, Router } from '@ttoss/http-server';
+
+import { applyResponse, toAuthRequest } from './koaAdapter';
 
 /**
  * The OAuth authorization-server option types and runner-agnostic engine live
@@ -29,38 +26,6 @@ export {
   type OnRefreshTokenResult,
   type StoredAuthorizationCode,
 } from '@ttoss/auth-core';
-
-/** Normalizes a Koa query/header value (which may be an array) to a string. */
-const firstValue = (
-  value: string | string[] | undefined
-): string | undefined => {
-  return Array.isArray(value) ? value[0] : value;
-};
-
-const toOAuthRequest = (ctx: Context): OAuthRequest => {
-  const query: Record<string, string | undefined> = {};
-  for (const [key, value] of Object.entries(ctx.query)) {
-    query[key] = firstValue(value);
-  }
-  const headers: Record<string, string | undefined> = {};
-  for (const [key, value] of Object.entries(ctx.headers)) {
-    headers[key] = firstValue(value);
-  }
-  return {
-    query,
-    body: (ctx.request.body ?? {}) as Record<string, unknown>,
-    headers,
-  };
-};
-
-const applyResponse = (ctx: Context, res: OAuthResponse): void => {
-  if (res.redirect !== undefined) {
-    ctx.redirect(res.redirect);
-    return;
-  }
-  ctx.status = res.status;
-  ctx.body = res.body;
-};
 
 /**
  * Mounts an OAuth 2.1 Authorization Server (issuing tokens) as a Koa `Router`,
@@ -97,15 +62,15 @@ export const oauthServer = (options: OAuthServerOptions): Router => {
   }
 
   router.get(engine.paths.authorize, async (ctx: Context) => {
-    applyResponse(ctx, await engine.authorize(toOAuthRequest(ctx)));
+    applyResponse(ctx, await engine.authorize(toAuthRequest(ctx)));
   });
 
   router.post(engine.paths.token, async (ctx: Context) => {
-    applyResponse(ctx, await engine.token(toOAuthRequest(ctx)));
+    applyResponse(ctx, await engine.token(toAuthRequest(ctx)));
   });
 
   router.post(engine.paths.register, async (ctx: Context) => {
-    applyResponse(ctx, await engine.register(toOAuthRequest(ctx)));
+    applyResponse(ctx, await engine.register(toAuthRequest(ctx)));
   });
 
   return router;

--- a/packages/http-server-auth/tests/unit/jest.config.ts
+++ b/packages/http-server-auth/tests/unit/jest.config.ts
@@ -3,7 +3,7 @@ import { jestUnitConfig } from '@ttoss/config';
 export default jestUnitConfig({
   coverageThreshold: {
     global: {
-      branches: 97.81,
+      branches: 97.9,
       functions: 100,
       lines: 100,
       statements: 100,

--- a/packages/http-server-auth/tests/unit/tests/emailAuth.test.ts
+++ b/packages/http-server-auth/tests/unit/tests/emailAuth.test.ts
@@ -1,0 +1,169 @@
+import {
+  createMemoryOneTimeTokenStore,
+  createMemoryUserStore,
+  type EmailAuthDelivery,
+  type EmailAuthMode,
+} from '@ttoss/auth-core';
+import { App, bodyParser } from '@ttoss/http-server';
+import { emailAuth } from 'src/index';
+import request from 'supertest';
+
+const BASE_URL = 'https://app.example.com';
+
+const createApp = (
+  args: {
+    modes?: EmailAuthMode[];
+    prefix?: string;
+  } = {}
+) => {
+  const { modes = ['emailCode'], prefix } = args;
+
+  const sent: EmailAuthDelivery[] = [];
+
+  const app = new App();
+  app.use(bodyParser());
+  app.use(
+    emailAuth({
+      modes,
+      prefix,
+      baseUrl: BASE_URL,
+      userStore: createMemoryUserStore(),
+      oneTimeTokenStore: createMemoryOneTimeTokenStore(),
+      issueSession: (user) => {
+        return { accessToken: `token-for-${user.id}` };
+      },
+      sendEmail: (delivery) => {
+        sent.push(delivery);
+      },
+    }).routes()
+  );
+
+  return { app, sent };
+};
+
+test('it should sign a user in end to end with a mailed code', async () => {
+  const { app, sent } = createApp({ modes: ['emailCode'] });
+
+  const send = await request(app.callback())
+    .post('/auth/code')
+    .send({ email: 'user@example.com' });
+
+  expect(send.status).toBe(200);
+  expect(sent).toHaveLength(1);
+  expect(sent[0].token).toMatch(/^\d{6}$/);
+
+  const verify = await request(app.callback())
+    .post('/auth/code/verify')
+    .send({ email: 'user@example.com', code: sent[0].token });
+
+  expect(verify.status).toBe(200);
+  expect(verify.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+test('it should sign a user up and in with a password end to end', async () => {
+  const { app } = createApp({ modes: ['password'] });
+
+  const signUp = await request(app.callback())
+    .post('/auth/signup')
+    .send({ email: 'user@example.com', password: 'a-good-password' });
+
+  expect(signUp.status).toBe(201);
+
+  const signIn = await request(app.callback())
+    .post('/auth/login')
+    .send({ email: 'user@example.com', password: 'a-good-password' });
+
+  expect(signIn.status).toBe(200);
+  expect(signIn.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+test('it should redeem a magic link end to end', async () => {
+  const { app, sent } = createApp({ modes: ['password', 'magicLink'] });
+
+  await request(app.callback())
+    .post('/auth/signup')
+    .send({ email: 'user@example.com', password: 'a-good-password' });
+
+  await request(app.callback())
+    .post('/auth/magic-link')
+    .send({ email: 'user@example.com' });
+
+  expect(sent[0].url).toBe(`${BASE_URL}/auth/callback?token=${sent[0].token}`);
+
+  const verify = await request(app.callback())
+    .post('/auth/magic-link/verify')
+    .send({ token: sent[0].token });
+
+  expect(verify.status).toBe(200);
+  expect(verify.body).toMatchObject({ accessToken: 'token-for-user_1' });
+});
+
+test('it should surface an engine error as its status and body', async () => {
+  const { app } = createApp({ modes: ['password'] });
+
+  const response = await request(app.callback())
+    .post('/auth/login')
+    .send({ email: 'nobody@example.com', password: 'a-good-password' });
+
+  expect(response.status).toBe(401);
+  expect(response.body).toMatchObject({
+    error: { code: 'invalid_credentials' },
+  });
+});
+
+test('it should read a token from the query string', async () => {
+  const { app, sent } = createApp({ modes: ['password', 'magicLink'] });
+
+  await request(app.callback())
+    .post('/auth/signup')
+    .send({ email: 'user@example.com', password: 'a-good-password' });
+
+  await request(app.callback())
+    .post('/auth/magic-link')
+    .send({ email: 'user@example.com' });
+
+  const verify = await request(app.callback()).post(
+    `/auth/magic-link/verify?token=${sent[0].token}`
+  );
+
+  expect(verify.status).toBe(200);
+});
+
+test('it should not mount routes for disabled modes', async () => {
+  const { app } = createApp({ modes: ['emailCode'] });
+
+  const response = await request(app.callback())
+    .post('/auth/login')
+    .send({ email: 'user@example.com', password: 'a-good-password' });
+
+  expect(response.status).toBe(404);
+});
+
+test('it should apply the prefix to every mounted path', async () => {
+  const { app } = createApp({ modes: ['emailCode'], prefix: '/v1' });
+
+  expect(
+    (
+      await request(app.callback())
+        .post('/v1/auth/code')
+        .send({ email: 'user@example.com' })
+    ).status
+  ).toBe(200);
+
+  expect(
+    (
+      await request(app.callback())
+        .post('/auth/code')
+        .send({ email: 'user@example.com' })
+    ).status
+  ).toBe(404);
+});
+
+test('it should tolerate a request with no body', async () => {
+  const { app } = createApp({ modes: ['emailCode'] });
+
+  const response = await request(app.callback()).post('/auth/code');
+
+  expect(response.status).toBe(400);
+  expect(response.body).toMatchObject({ error: { code: 'invalid_request' } });
+});


### PR DESCRIPTION
## What

Adds the missing **flows** layer to the auth stack. `@ttoss/auth-core` already
shipped the primitives (one-time tokens, PBKDF2 hashing, JWT) and
`@ttoss/http-server-auth` the Bearer middleware, but each application still
hand-rolled the endpoints in between. This adds:

- **`createEmailAuthHandlers`** (`@ttoss/auth-core`) — a runner-agnostic engine
  for password sign-up and sign-in, magic links, mailed numeric codes, address
  confirmation and password reset.
- **`emailAuth()`** (`@ttoss/http-server-auth`) — the Koa adapter that mounts it,
  mirroring the existing `oauthServer()` split exactly.

A `modes` array selects which flows exist, so one consumer can expose only a
mailed-code sign-in while another exposes the full password surface, from the
same package. No new package, and no dead endpoints in either consumer.

```ts
app.use(
  emailAuth({
    modes: ['emailCode'],
    prefix: '/v1',
    userStore,
    oneTimeTokenStore,
    issueSession: (user) => issueSession(user),
    sendEmail: async ({ to, token }) => ses.send(buildCodeEmail({ to, code: token })),
  }).routes()
);
```

## Why this shape

The engine keeps the package's existing contract — no database and no mail
transport. Persistence arrives as store contracts, session minting as
`issueSession`, and delivery as a `sendEmail` callback receiving the plaintext
token exactly once. A mailer package wrapping Resend/SES was considered and
rejected: it would be a thin re-export of provider SDKs while every consumer
already has a configured client. Recorded as **ADR-002**.

Session topology stays with the application deliberately, which is what lets a
consumer on a long-lived JWT and one on a short access token plus a rotating
refresh family share the same credential flows.

## Numeric codes

`generateOneTimeToken` gains `format: 'numeric'` for short codes the user
retypes. Digits are drawn by rejection sampling — plain `byte % 10` over-produces
`0-5` by ~20% and measurably shrinks the keyspace — and the lifetime defaults to
10 minutes rather than 24 hours.

A ~20-bit code is only safe with a bounded attempt count, so `emailCode` mode
**refuses to start** unless the store implements `findByEmail` and
`incrementAttempts`. A wrong guess hashes to nothing on record, which is why the
code flow looks up by address while the link flows look up by token hash.
Recorded as **ADR-003**.

## Also in here

- `createMemoryUserStore` / `createMemoryOneTimeTokenStore` as reference
  implementations of the new contracts.
- `AuthHttpRequest` / `AuthHttpResponse` aliases — the OAuth-prefixed HTTP shapes
  are no longer OAuth-specific. Additive, non-breaking.
- `firstValue` / `toAuthRequest` / `applyResponse` extracted from
  `oauthServer.ts` into a shared `koaAdapter.ts` rather than duplicated for the
  new router.

## Security properties worth reviewing

- Tokens are hash-at-rest only; the store interface never accepts a plaintext
  token, so persisting a redeemable secret is impossible by construction.
- Every "mail me something" endpoint returns the same acknowledgement whether or
  not the address is on file.
- Sign-in runs a decoy PBKDF2 compare for an unknown address or a
  password-less user, so response time does not enumerate accounts either.
- `purpose` is stored with each token, so one flow's token cannot be spent on
  another's endpoint.
- Reaching `maxAttempts` destroys the code rather than merely refusing it.

## Testing

72 new tests. `@ttoss/auth-core` 241 passing, `@ttoss/http-server-auth` 63
passing. All five new engine files at 100% statements, branches, functions and
lines; the adapter likewise. Coverage thresholds raised in both packages
(`http-server-auth` branches 97.81 → 97.9; `auth-core` gains a threshold where
it previously had none).

The adapter tests drive a real Koa app through supertest end to end for the code,
password and magic-link flows.

Note: `pnpm turbo run build` cannot be verified in this environment — a
pre-existing babel/formatjs linking failure breaks `@ttoss/i18n-cli#build-config`
on `main` too, before either of these packages is reached. Types were verified
with `tsc --noEmit` against both entry points instead, and both test suites and
`pnpm run -w lint` are green.

## Follow-ups (not in this PR)

- Wire naturali.ai's 6-digit login onto this, replacing the `console.info` token
  stub with SES (needs `ses:SendEmail` on the task role and DNS records at an
  external provider — there is no Route 53 zone for the domain).
- Migrate myhold, which needs a bcrypt → PBKDF2 path and switching its
  currently-plaintext `VerificationToken.token` to hash-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R9AuEg77dBpG1LEstmovh

---
_Generated by [Claude Code](https://claude.ai/code/session_014R9AuEg77dBpG1LEstmovh)_