### PR TITLE
fix(auth-core): use absolute docs URL for the http-server-auth cross-link

### DIFF
--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -178,7 +178,8 @@ const handlers = createEmailAuthHandlers({
 
 Each handler takes a normalized request and resolves to a status and a body, so
 it is mountable on any runner. For Koa, `emailAuth()` from
-[`@ttoss/http-server-auth`](../http-server-auth) does it for you.
+[`@ttoss/http-server-auth`](https://ttoss.dev/docs/modules/packages/http-server-auth)
+does it for you.
 
 Every handler returns expected outcomes as responses — `invalid_credentials`,
 `invalid_token`, `expired_token`, `too_many_attempts` and friends, under a


### PR DESCRIPTION
## What

One-line README fix. `main` is currently red and no packages published from
#1172 because of a broken link I introduced in `packages/auth-core/README.md`.

## Why it broke

The README is rendered as a docs page at `/docs/modules/packages/auth-core/`, so
the relative link resolved against that page rather than the repo tree:

```
- Broken link on source page path = /docs/modules/packages/auth-core/:
   -> linking to _media/http-server-auth (resolved as: /docs/modules/packages/auth-core/_media/http-server-auth)
```

That failed `@docs/website#build` (121 of 122 turbo tasks passed), which runs
before publish in the `main` workflow — so the release never got to npm.

The PR check on #1172 passed because it does not build the docs site; only the
`main` workflow does.

## Fix

Switched to the absolute `ttoss.dev` URL that the same file already uses for the
same package further down, which is external and therefore not link-checked:

```md
[`@ttoss/http-server-auth`](https://ttoss.dev/docs/modules/packages/http-server-auth)
```

Also grepped both touched READMEs and `CONTRIBUTING.md` for any other relative
markdown links — this was the only one.

Once this lands, the `main` workflow should get past the docs build and publish
the new `@ttoss/auth-core` and `@ttoss/http-server-auth` versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R9AuEg77dBpG1LEstmovh

---
_Generated by [Claude Code](https://claude.ai/code/session_014R9AuEg77dBpG1LEstmovh)_