### PR TITLE
fix(http-server-mcp-openapi): resolve unresolvable $refs to an empty schema

### DIFF
--- a/packages/http-server-mcp-openapi/package.json
+++ b/packages/http-server-mcp-openapi/package.json
@@ -38,6 +38,7 @@
     "@ttoss/http-server-mcp": "workspace:^"
   },
   "devDependencies": {
+    "@modelcontextprotocol/server": "^2.0.0",
     "@ttoss/config": "workspace:^",
     "@ttoss/http-server": "workspace:^",
     "jest": "^30.4.2",

--- a/packages/http-server-mcp-openapi/src/schema.ts
+++ b/packages/http-server-mcp-openapi/src/schema.ts
@@ -79,6 +79,14 @@ const dereferenceValue = (args: {
       // recursing and return an empty schema rather than looping forever.
       if (seenRefs.has(refName)) return {};
       const resolved = spec.components?.schemas?.[refName];
+      // A ref with no target in this document — most often one pointing into
+      // another file, e.g. `./tools.yaml#/components/schemas/X`. Resolve it the
+      // same way as a circular ref: an empty schema, which accepts any value.
+      // Returning `undefined` instead would put an undefined value inside
+      // `properties`, and while JSON serialisation silently drops it, the
+      // in-memory schema is what a JSON Schema validator compiles — and it
+      // throws on `Object.keys(undefined)` while walking `properties`.
+      if (resolved === undefined) return {};
       return dereferenceValue({
         value: resolved,
         spec,

--- a/packages/http-server-mcp-openapi/src/toolDefinitions.ts
+++ b/packages/http-server-mcp-openapi/src/toolDefinitions.ts
@@ -151,10 +151,14 @@ export const buildInputSchema = (
         : { type: 'string', description: '' }; // path param
   }
 
+  // `required` is omitted rather than set to `undefined`: JSON has no
+  // `undefined`, so the key was never visible to clients anyway, and leaving an
+  // explicit `undefined` on the in-memory schema only risks tripping the
+  // validator that compiles it when the tool is registered.
   return {
     type: 'object',
     properties,
-    required: requiredFields.length > 0 ? requiredFields : undefined,
+    ...(requiredFields.length > 0 ? { required: requiredFields } : {}),
   };
 };
 

--- a/packages/http-server-mcp-openapi/tests/unit/tests/schemaIntegrity.test.ts
+++ b/packages/http-server-mcp-openapi/tests/unit/tests/schemaIntegrity.test.ts
@@ -1,0 +1,164 @@
+import { fromJsonSchema, McpServer } from '@modelcontextprotocol/server';
+import { openApiToToolDefinitions } from 'src/index';
+
+/**
+ * Collects every path in `node` whose value is `undefined`.
+ *
+ * JSON has no `undefined`, so such a key is invisible once the schema is
+ * serialised — which is what makes it dangerous. The value survives on the
+ * in-memory object handed to the JSON Schema validator when a tool is
+ * registered, and that validator throws while compiling `properties`.
+ */
+const findUndefinedPaths = (
+  node: unknown,
+  path: string,
+  found: string[]
+): void => {
+  if (node === null || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (const [index, entry] of node.entries()) {
+      if (entry === undefined) found.push(`${path}[${index}]`);
+      findUndefinedPaths(entry, `${path}[${index}]`, found);
+    }
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (value === undefined) found.push(`${path}.${key}`);
+    findUndefinedPaths(value, `${path}.${key}`, found);
+  }
+};
+
+/**
+ * A `$ref` this generator cannot resolve. Only same-document
+ * `#/components/schemas/...` refs are followed, so a ref into another file has
+ * no target here — the shape real multi-file OpenAPI documents produce.
+ */
+const specWithUnresolvableRef = {
+  paths: {
+    '/agents/{agent_id}': {
+      patch: {
+        operationId: 'patchAgent',
+        parameters: [
+          {
+            name: 'agent_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  tool_bindings: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        tool_id: { type: 'string' },
+                        tool: {
+                          $ref: './tools.yaml#/components/schemas/CreateTool',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('generated schema integrity', () => {
+  const tools = openApiToToolDefinitions({ spec: specWithUnresolvableRef });
+
+  test('an unresolvable $ref leaves no undefined value behind', () => {
+    const found: string[] = [];
+    for (const tool of tools) {
+      findUndefinedPaths(tool.inputSchema, tool.name, found);
+    }
+
+    expect(found).toEqual([]);
+  });
+
+  test('the unresolvable ref becomes an empty schema, keeping the property visible', () => {
+    // Resolved the same way as a circular ref: `{}` accepts any value, so the
+    // property stays discoverable and no valid call is rejected. Dropping it
+    // would hide a field the API does accept.
+    const props = tools[0].inputSchema.properties as Record<string, never>;
+    expect(props.toolBindings).toEqual({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { tool_id: { type: 'string' }, tool: {} },
+      },
+      description: '',
+    });
+  });
+
+  test('every inputSchema survives a JSON round-trip unchanged', () => {
+    for (const tool of tools) {
+      expect(JSON.parse(JSON.stringify(tool.inputSchema))).toEqual(
+        tool.inputSchema
+      );
+    }
+  });
+
+  test('every generated schema compiles in the real MCP SDK, on live objects', () => {
+    // Deliberately not JSON round-tripped: serialising drops `undefined` and
+    // would hide the very class of bug this suite exists to catch.
+    const server = new McpServer({ name: 'integrity', version: '1.0.0' });
+
+    for (const tool of tools) {
+      expect(() => {
+        server.registerTool(
+          tool.name,
+          {
+            description: tool.description,
+            inputSchema: fromJsonSchema(tool.inputSchema as never),
+          },
+          async () => {
+            return { content: [{ type: 'text' as const, text: 'ok' }] };
+          }
+        );
+      }).not.toThrow();
+    }
+  });
+
+  test('a zero-parameter operation omits `required` rather than setting it undefined', () => {
+    const [tool] = openApiToToolDefinitions({
+      spec: { paths: { '/ping': { get: { operationId: 'ping' } } } },
+    });
+    expect('required' in tool.inputSchema).toBe(false);
+  });
+
+  test('an operation with only optional params omits `required`', () => {
+    const [tool] = openApiToToolDefinitions({
+      spec: {
+        paths: {
+          '/things': {
+            get: {
+              operationId: 'listThings',
+              parameters: [
+                {
+                  name: 'limit',
+                  in: 'query',
+                  required: false,
+                  schema: { type: 'integer' },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect('required' in tool.inputSchema).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1610,6 +1610,9 @@ importers:
         specifier: workspace:^
         version: link:../http-server-mcp
     devDependencies:
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ttoss/config':
         specifier: workspace:^
         version: link:../config


### PR DESCRIPTION
`@ttoss/http-server-mcp-openapi` had the same latent bug that crashed SOAT's server on boot in [ttoss/soat#769](https://github.com/ttoss/soat/pull/769). Found by fixing it there, then checking whether this package shared it — it does.

## The bug

`dereferenceSchema` follows only same-document `#/components/schemas/...` refs. A `$ref` with no target here — most often one pointing into another file, e.g. `./tools.yaml#/components/schemas/CreateTool` — dereferenced to `undefined`, which then sat inside `properties` on the generated tool schema.

Nothing observable was wrong, which is exactly why it went unnoticed. JSON has no `undefined`, so the key was already absent from every schema a client actually received. What breaks is the **in-memory object**: `@ttoss/http-server-mcp` now hands it to a real JSON Schema validator when the tool is registered, and that validator throws on `Object.keys(undefined)` while walking `properties`:

```
ajv/compile/util.js:17  TypeError: Cannot convert undefined or null to object
    at alwaysValidSchema → properties.js:23
```

That's a startup crash, not a failed call — the server never finishes booting. It reproduces regardless of `validateArguments`, because `fromJsonSchema` compiles the schema in order to *advertise* it.

## The fix

Such a ref now resolves to `{}`, exactly as a circular ref already did a few lines above. An empty schema accepts any value, so the property stays discoverable and no valid call is rejected. Dropping the key instead would hide a field the API does accept.

`required` is likewise omitted rather than set to `undefined`.

## Verification

`tests/unit/tests/schemaIntegrity.test.ts` asserts, for a spec containing an unresolvable cross-file `$ref`, that generated schemas:

- carry no `undefined` value anywhere
- survive a JSON round-trip unchanged — the same failure stated structurally: a schema that changes shape when serialised is carrying something JSON cannot express
- **compile in the real MCP SDK, against the live objects** — deliberately not serialised first

That last point is the one that matters. My original audit for #1171 serialised the schemas before validating them and reported a clean pass, because `JSON.stringify` silently drops `undefined`. Serialising is precisely what hides this bug, so the guard has to work on live objects. `@modelcontextprotocol/server` becomes a devDependency so the check imports a declared dependency rather than relying on hoisting.

All 6 new tests fail before the fix (including the SDK compile, with the ajv trace above) and pass after.

- `@ttoss/http-server-mcp-openapi`: 64 tests passing, 100% across all metrics
- `@ttoss/http-server-mcp`: 111 tests passing, unaffected
- `tsc --noEmit` clean in `examples/http-server-mcp-calculator`, lint clean

`pnpm turbo run build` fails in my environment on the pre-existing `babel-plugin-formatjs` / `@babel/helper-plugin-utils` linking error, which reproduces on untouched packages — not from this change.

## Note on the two implementations

SOAT's vendored copy prunes `undefined` values generically as a defensive pass, because it has other paths that can produce them. This package fixes it at the source, in the dereferencer, which is cleaner and consistent with the existing circular-ref handling. Worth aligning if the vendored copy is ever de-duplicated against this package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee7RAe7MxUgfg54qA19gRG)_