### PR TITLE
feat(auth-core): cap how often one address can be mailed

### DIFF
--- a/packages/auth-core/CONTRIBUTING.md
+++ b/packages/auth-core/CONTRIBUTING.md
@@ -106,3 +106,20 @@ Re-litigation answers:
 - "Why does a wrong code look up by email rather than by its hash?" → so the failure can be charged to the outstanding record; a hash lookup of a wrong guess finds nothing and can count nothing.
 - "Why destroy the code at `maxAttempts` instead of just refusing?" → refusing while the record lives lets an attacker keep guessing until expiry; destroying it forces a fresh code with a fresh keyspace.
 - "Why a different default TTL for `numeric`?" → the smaller keyspace makes a long window a guessing window; 24 hours is safe for 32 random bytes and not for 6 digits.
+
+### ADR-004: The send cap counts requests, not deliveries
+
+Status: accepted (2026-07-29)
+Tags: email-auth, rate-limit, enumeration, mail-bombing
+
+Decision: `requestRateLimit` gates the "mail me something" handlers before the user lookup and records every request that passes validation, whether or not a message followed.
+Rejected: recording only actual sends — an unknown address would never accumulate records and so never hit the limit, making `429` vs `200` a reliable account-existence oracle and undoing the enumeration safety the same handlers are built around; silently dropping over-limit requests and still answering `200` — indistinguishable from success, so a legitimate user who resends twice gets no explanation and no retry signal; limiting by IP instead of address — the abuse this prevents is aimed at one victim's mailbox and an attacker rotates IPs more easily than the victim changes address.
+Cost: requests that send nothing still consume a record and a store write, so a hostile caller can exhaust a stranger's allowance and briefly deny them a code they never asked for — a far cheaper failure than mailing them repeatedly, but a real one.
+Anchors: `src/emailAuthTypes.ts` (`RequestRateLimit`, `RequestRateLimitStore`), `src/emailAuthRuntime.ts` (`createCheckRequestRate`), `src/emailAuthLink.ts` (`createSendHandler`), `src/emailAuthCode.ts` (`sendEmailCode`).
+
+Re-litigation answers:
+
+- "Why is the limiter optional if it matters this much?" → it needs a store the engine cannot supply, and a package that has no I/O cannot invent shared state; the README and the option's JSDoc both say to configure it.
+- "Why not reuse the `emailCode` attempt ceiling?" → that bounds guesses against one issued code; this bounds how many codes get mailed at all. Different resource, different attacker.
+- "Why gate before the lookup rather than after?" → after the lookup the verdict depends on whether the account exists, which is exactly the leak.
+- "Why a `429` rather than a silent 200?" → the response is uniform across known and unknown addresses, so it leaks nothing, and the caller learns to wait instead of retrying immediately.

--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -193,6 +193,31 @@ same acknowledgement whether or not the address is on file, so the response
 cannot be used to enumerate accounts; and sign-in runs a decoy PBKDF2 compare
 for an unknown address, so response time cannot either.
 
+### Capping how often an address is mailed
+
+Pass `requestRateLimit` and the send endpoints stop being a way to mail a
+stranger repeatedly. Without it they will send as fast as they are called —
+issuing a new token invalidates the previous one, which limits how many tokens
+are _redeemable_ rather than how many messages go out.
+
+```ts
+requestRateLimit: {
+  store: myRateLimitStore, // { recent, record }
+  cooldownSeconds: 60,     // default
+  maxPerWindow: 10,        // default
+  windowSeconds: 60 * 60 * 24, // default
+}
+```
+
+The cap is applied to the request, before the engine looks the address up, and
+**every** request is recorded whether or not mail followed. Counting only the
+requests that produced mail would make a `429` mean "this address has an
+account" — reintroducing the enumeration oracle the rest of the flow avoids.
+
+`createMemoryRequestRateLimitStore` is a reference implementation. Back it with
+something shared in production: a per-process limiter caps each replica
+separately, so a fleet of N sends N times the intended rate.
+
 ## API tokens
 
 Personal access tokens in the form `<prefix>_<hex>`, recognizable in logs and

--- a/packages/auth-core/src/emailAuthCode.ts
+++ b/packages/auth-core/src/emailAuthCode.ts
@@ -103,6 +103,19 @@ export const createEmailCodeHandlers = (
       return error(400, 'invalid_request', 'A valid email is required.');
     }
 
+    /**
+     * Before the lookup, so the verdict depends only on the address — see
+     * `createCheckRequestRate`.
+     */
+    const limited = await runtime.checkRequestRate({
+      email,
+      purpose: 'emailCode',
+    });
+
+    if (limited) {
+      return limited;
+    }
+
     const user = await userStore.findByEmail(email);
 
     if (user || createUserOnVerify) {

--- a/packages/auth-core/src/emailAuthLink.ts
+++ b/packages/auth-core/src/emailAuthLink.ts
@@ -32,6 +32,20 @@ const createSendHandler = (args: {
       return error(400, 'invalid_request', 'A valid email is required.');
     }
 
+    /**
+     * Before the lookup, so the verdict cannot depend on whether an account
+     * exists — a limiter that only counted real sends would answer `429` for a
+     * registered address and `200` for an unknown one.
+     */
+    const limited = await args.runtime.checkRequestRate({
+      email,
+      purpose: args.purpose,
+    });
+
+    if (limited) {
+      return limited;
+    }
+
     const user = await args.runtime.options.userStore.findByEmail(email);
 
     if (user) {

--- a/packages/auth-core/src/emailAuthRuntime.ts
+++ b/packages/auth-core/src/emailAuthRuntime.ts
@@ -53,6 +53,12 @@ const DEFAULT_CODE_DIGITS = 6;
 
 const DEFAULT_MAX_ATTEMPTS = 5;
 
+const DEFAULT_COOLDOWN_SECONDS = 60;
+
+const DEFAULT_MAX_PER_WINDOW = 10;
+
+const DEFAULT_WINDOW_SECONDS = 60 * 60 * 24;
+
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /** Purposes whose token travels inside a link rather than as a typed code. */
@@ -69,6 +75,7 @@ export const emailAuthErrorCodes = [
   'invalid_token',
   'expired_token',
   'too_many_attempts',
+  'too_many_requests',
   'email_not_verified',
   'password_too_weak',
 ] as const;
@@ -155,6 +162,19 @@ export const compareAgainstDecoy = async (
 export type RedeemedToken =
   { response: AuthHttpResponse } | { user: EmailAuthUser; email: string };
 
+/**
+ * Applies the send cap for one address, recording the request as it goes.
+ *
+ * Returns a response to hand straight back when the address is over its limit,
+ * or `null` to proceed. Every request is recorded, including the ones that go on
+ * to send nothing, so the verdict depends only on the address and never on
+ * whether an account exists behind it.
+ */
+export type CheckRequestRate = (args: {
+  email: string;
+  purpose: OneTimeTokenPurpose;
+}) => Promise<AuthHttpResponse | null>;
+
 export type EmailAuthRuntime = {
   options: EmailAuthOptions;
   paths: Required<EmailAuthPaths>;
@@ -176,6 +196,8 @@ export type EmailAuthRuntime = {
     request: AuthHttpRequest;
     purpose: LinkPurpose;
   }) => Promise<RedeemedToken>;
+  /** Applies the send cap. Resolves `null` when the request may proceed. */
+  checkRequestRate: CheckRequestRate;
 };
 
 const validateOptions = (options: EmailAuthOptions): void => {
@@ -275,6 +297,49 @@ const createIssueToken = (args: {
     };
 
     await options.sendEmail(delivery);
+  };
+};
+
+const TOO_MANY_REQUESTS =
+  'Too many requests for this address. Wait a moment and try again.';
+
+const createCheckRequestRate = (
+  options: EmailAuthOptions
+): CheckRequestRate => {
+  const limit = options.requestRateLimit;
+
+  if (!limit) {
+    return () => {
+      return Promise.resolve(null);
+    };
+  }
+
+  const cooldownMs = (limit.cooldownSeconds ?? DEFAULT_COOLDOWN_SECONDS) * 1000;
+  const windowMs = (limit.windowSeconds ?? DEFAULT_WINDOW_SECONDS) * 1000;
+  const maxPerWindow = limit.maxPerWindow ?? DEFAULT_MAX_PER_WINDOW;
+
+  return async ({ email, purpose }) => {
+    const now = Date.now();
+    const since = new Date(now - windowMs);
+    const recent = await limit.store.recent({ email, purpose, since });
+
+    const withinWindow = recent.filter((at) => {
+      return at.getTime() >= since.getTime();
+    });
+
+    const newest = withinWindow.reduce((max, at) => {
+      return at.getTime() > max ? at.getTime() : max;
+    }, 0);
+
+    const tooSoon = newest > 0 && now - newest < cooldownMs;
+
+    if (tooSoon || withinWindow.length >= maxPerWindow) {
+      return error(429, 'too_many_requests', TOO_MANY_REQUESTS);
+    }
+
+    await limit.store.record({ email, purpose, requestedAt: new Date(now) });
+
+    return null;
   };
 };
 
@@ -408,5 +473,6 @@ export const createEmailAuthRuntime = (
     }),
     buildSession: createBuildSession(options),
     redeemLinkToken: createRedeemLinkToken(options),
+    checkRequestRate: createCheckRequestRate(options),
   };
 };

--- a/packages/auth-core/src/emailAuthTypes.ts
+++ b/packages/auth-core/src/emailAuthTypes.ts
@@ -146,6 +146,49 @@ export type OneTimeTokenStore = {
 };
 
 // ---------------------------------------------------------------------------
+// Send rate limiting
+// ---------------------------------------------------------------------------
+
+/**
+ * App-provided record of how often each address has asked for mail.
+ *
+ * Without this, anyone can point the "mail me something" endpoints at a
+ * stranger's address and make the application send to it repeatedly. Capping how
+ * many codes are *valid* does not help — that limits redemptions, not messages.
+ */
+export type RequestRateLimitStore = {
+  /**
+   * Timestamps of the requests recorded for this address and purpose at or
+   * after `since`, in any order.
+   */
+  recent: (args: {
+    email: string;
+    purpose: OneTimeTokenPurpose;
+    since: Date;
+  }) => Promise<Date[]> | Date[];
+  /** Record one request. */
+  record: (args: {
+    email: string;
+    purpose: OneTimeTokenPurpose;
+    requestedAt: Date;
+  }) => Promise<void> | void;
+};
+
+export type RequestRateLimit = {
+  store: RequestRateLimitStore;
+  /**
+   * Minimum seconds between two requests for the same address and purpose.
+   * Defaults to 60 — long enough to stop a hammering loop, short enough that a
+   * user who mistypes their address is not stuck waiting.
+   */
+  cooldownSeconds?: number;
+  /** Requests allowed per address per window. Defaults to 10. */
+  maxPerWindow?: number;
+  /** Window the ceiling applies over. Defaults to 24 hours. */
+  windowSeconds?: number;
+};
+
+// ---------------------------------------------------------------------------
 // Delivery and session contracts
 // ---------------------------------------------------------------------------
 
@@ -299,6 +342,17 @@ export type EmailAuthOptions = {
   password?: PasswordOptions;
   paths?: EmailAuthPaths;
   hooks?: EmailAuthHooks;
+  /**
+   * Caps how often one address can be mailed. Strongly recommended: without it
+   * the send endpoints will mail any address as fast as they are called.
+   *
+   * The cap is applied to the request, before the engine looks the address up,
+   * and every request is recorded whether or not mail followed. That is
+   * deliberate — counting only the requests that produced mail would make a
+   * `429` mean "this address has an account", turning the limiter into the
+   * enumeration oracle the rest of the flow is careful to avoid.
+   */
+  requestRateLimit?: RequestRateLimit;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -31,6 +31,8 @@ export type {
   OneTimeTokenPurpose,
   OneTimeTokenStore,
   PasswordOptions,
+  RequestRateLimit,
+  RequestRateLimitStore,
   StoredOneTimeToken,
 } from './emailAuthTypes';
 export { decode, encode } from './encodeDecode';
@@ -47,6 +49,7 @@ export {
   createMemoryClientStore,
   createMemoryOneTimeTokenStore,
   createMemoryRefreshTokenStore,
+  createMemoryRequestRateLimitStore,
   createMemoryUserStore,
 } from './memoryStores';
 export {

--- a/packages/auth-core/src/memoryStores.ts
+++ b/packages/auth-core/src/memoryStores.ts
@@ -2,6 +2,7 @@ import type {
   EmailAuthUser,
   EmailAuthUserStore,
   OneTimeTokenStore,
+  RequestRateLimitStore,
   StoredOneTimeToken,
 } from './emailAuthTypes';
 import type {
@@ -227,6 +228,41 @@ export const createMemoryOneTimeTokenStore = (): OneTimeTokenStore => {
       if (token) {
         tokens.set(entry, { ...token, attempts: (token.attempts ?? 0) + 1 });
       }
+    },
+  };
+};
+
+/**
+ * In-memory reference {@link RequestRateLimitStore}, keyed by address and
+ * purpose. Records are pruned on read, so the map does not grow without bound.
+ *
+ * For tests and local development. A production deployment wants this shared
+ * across instances — a table with an index on `(email, purpose, requested_at)`,
+ * or a Redis counter — because a per-process limiter caps each replica
+ * separately and so lets the fleet send N times the intended rate.
+ */
+export const createMemoryRequestRateLimitStore = (): RequestRateLimitStore => {
+  const requests = new Map<string, Date[]>();
+
+  const key = (args: { email: string; purpose: string }): string => {
+    return `${args.purpose}:${args.email}`;
+  };
+
+  return {
+    recent: ({ email, purpose, since }) => {
+      const entry = key({ email, purpose });
+
+      const kept = (requests.get(entry) ?? []).filter((at) => {
+        return at.getTime() >= since.getTime();
+      });
+
+      requests.set(entry, kept);
+
+      return kept;
+    },
+    record: ({ email, purpose, requestedAt }) => {
+      const entry = key({ email, purpose });
+      requests.set(entry, [...(requests.get(entry) ?? []), requestedAt]);
     },
   };
 };

--- a/packages/auth-core/tests/unit/jest.config.ts
+++ b/packages/auth-core/tests/unit/jest.config.ts
@@ -4,7 +4,7 @@ export default jestUnitConfig({
   coverageThreshold: {
     global: {
       statements: 99,
-      branches: 97.5,
+      branches: 97.9,
       functions: 100,
       lines: 99,
     },

--- a/packages/auth-core/tests/unit/tests/emailAuth.test.ts
+++ b/packages/auth-core/tests/unit/tests/emailAuth.test.ts
@@ -7,6 +7,7 @@ import type {
 import { hashPassword } from 'src/hash';
 import {
   createMemoryOneTimeTokenStore,
+  createMemoryRequestRateLimitStore,
   createMemoryUserStore,
 } from 'src/memoryStores';
 import type { AuthHttpRequest } from 'src/oauthServerTypes';
@@ -1209,4 +1210,178 @@ test('it should propagate a delivery failure rather than swallowing it', async (
   await expect(
     handlers.sendMagicLink?.(request({ email: 'user@example.com' }))
   ).rejects.toThrow('SES is down');
+});
+
+// ---------------------------------------------------------------------------
+// request rate limiting
+// ---------------------------------------------------------------------------
+
+describe('request rate limiting', () => {
+  const limited = (overrides: Partial<EmailAuthOptions> = {}) => {
+    return setup({
+      modes: ['emailCode'],
+      requestRateLimit: {
+        store: createMemoryRequestRateLimitStore(),
+        cooldownSeconds: 60,
+        maxPerWindow: 3,
+      },
+      ...overrides,
+    });
+  };
+
+  test('it should refuse a second request inside the cooldown', async () => {
+    const { handlers, sent } = limited();
+
+    const first = await handlers.sendEmailCode?.(
+      request({ email: 'user@example.com' })
+    );
+    const second = await handlers.sendEmailCode?.(
+      request({ email: 'user@example.com' })
+    );
+
+    expect(first?.status).toBe(200);
+    expect(second?.status).toBe(429);
+    expect(second?.body).toMatchObject({
+      error: { code: 'too_many_requests' },
+    });
+    // The refused request must not have sent anything.
+    expect(sent).toHaveLength(1);
+  });
+
+  test('it should limit each address independently', async () => {
+    const { handlers, sent } = limited();
+
+    await handlers.sendEmailCode?.(request({ email: 'one@example.com' }));
+    const other = await handlers.sendEmailCode?.(
+      request({ email: 'two@example.com' })
+    );
+
+    expect(other?.status).toBe(200);
+    expect(sent).toHaveLength(2);
+  });
+
+  test('it should allow another request once the cooldown has passed', async () => {
+    const { handlers } = limited({
+      requestRateLimit: {
+        store: createMemoryRequestRateLimitStore(),
+        cooldownSeconds: 0,
+        maxPerWindow: 3,
+      },
+    });
+
+    expect(
+      await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+    ).toMatchObject({ status: 200 });
+    expect(
+      await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+    ).toMatchObject({ status: 200 });
+  });
+
+  test('it should enforce the window ceiling even with no cooldown', async () => {
+    const { handlers, sent } = limited({
+      requestRateLimit: {
+        store: createMemoryRequestRateLimitStore(),
+        cooldownSeconds: 0,
+        maxPerWindow: 3,
+      },
+    });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect(
+        await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+      ).toMatchObject({ status: 200 });
+    }
+
+    expect(
+      await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+    ).toMatchObject({ status: 429 });
+    expect(sent).toHaveLength(3);
+  });
+
+  test('it should drop requests that fall outside the window', async () => {
+    const store = createMemoryRequestRateLimitStore();
+
+    await store.record({
+      email: 'user@example.com',
+      purpose: 'emailCode',
+      // Older than the window below, so it must not count.
+      requestedAt: new Date(Date.now() - 10_000),
+    });
+
+    const { handlers } = setup({
+      modes: ['emailCode'],
+      requestRateLimit: {
+        store,
+        cooldownSeconds: 0,
+        maxPerWindow: 1,
+        windowSeconds: 1,
+      },
+    });
+
+    expect(
+      await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+    ).toMatchObject({ status: 200 });
+  });
+
+  /**
+   * The whole point of counting requests rather than sends: an unknown address
+   * and a registered one must be rate-limited identically, or `429` becomes an
+   * account-existence oracle.
+   */
+  test('it should limit an unknown address exactly like a registered one', async () => {
+    const { handlers } = setup({
+      modes: ['magicLink'],
+      users: [{ email: 'known@example.com' }],
+      requestRateLimit: {
+        store: createMemoryRequestRateLimitStore(),
+        cooldownSeconds: 60,
+        maxPerWindow: 3,
+      },
+    });
+
+    const knownFirst = await handlers.sendMagicLink?.(
+      request({ email: 'known@example.com' })
+    );
+    const knownSecond = await handlers.sendMagicLink?.(
+      request({ email: 'known@example.com' })
+    );
+    const unknownFirst = await handlers.sendMagicLink?.(
+      request({ email: 'nobody@example.com' })
+    );
+    const unknownSecond = await handlers.sendMagicLink?.(
+      request({ email: 'nobody@example.com' })
+    );
+
+    expect(knownFirst).toEqual(unknownFirst);
+    expect(knownSecond).toEqual(unknownSecond);
+    expect(knownSecond?.status).toBe(429);
+  });
+
+  test('it should apply sensible defaults when only a store is given', async () => {
+    const { handlers, sent } = setup({
+      modes: ['emailCode'],
+      requestRateLimit: { store: createMemoryRequestRateLimitStore() },
+    });
+
+    expect(
+      await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+    ).toMatchObject({ status: 200 });
+    // The default cooldown is a minute, so an immediate retry is refused.
+    expect(
+      await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+    ).toMatchObject({ status: 429 });
+    expect(sent).toHaveLength(1);
+  });
+
+  test('it should not limit anything when no limiter is configured', async () => {
+    const { handlers, sent } = setup({ modes: ['emailCode'] });
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      expect(
+        await handlers.sendEmailCode?.(request({ email: 'user@example.com' }))
+      ).toMatchObject({ status: 200 });
+    }
+
+    expect(sent).toHaveLength(4);
+  });
 });

--- a/packages/http-server-auth/src/emailAuth.ts
+++ b/packages/http-server-auth/src/emailAuth.ts
@@ -32,6 +32,8 @@ export {
   type OneTimeTokenPurpose,
   type OneTimeTokenStore,
   type PasswordOptions,
+  type RequestRateLimit,
+  type RequestRateLimitStore,
   type StoredOneTimeToken,
 } from '@ttoss/auth-core';
 

--- a/packages/http-server-auth/src/index.ts
+++ b/packages/http-server-auth/src/index.ts
@@ -20,6 +20,8 @@ export {
   type OneTimeTokenPurpose,
   type OneTimeTokenStore,
   type PasswordOptions,
+  type RequestRateLimit,
+  type RequestRateLimitStore,
   type StoredOneTimeToken,
 } from './emailAuth';
 export {


### PR DESCRIPTION
## The gap

The send handlers shipped in #1172 will mail any address as fast as they are
called. Issuing a new token deletes its predecessor, which bounds how many tokens
are **redeemable** — not how many messages go out. So `POST /auth/code` or
`/auth/magic-link` in a loop is a way to keep mailing a stranger's inbox, at the
cost of the sender's own domain reputation.

I missed this in the original design. It surfaced while preparing an AWS SES
production-access request, where "how do you prevent abuse" is the question being
asked.

## Fix

```ts
requestRateLimit: {
  store: myRateLimitStore,     // { recent, record }
  cooldownSeconds: 60,         // default
  maxPerWindow: 10,            // default
  windowSeconds: 60 * 60 * 24, // default
}
```

Over-limit requests get `429 too_many_requests` and send nothing.

## The part worth reviewing

The gate runs **before the user lookup**, and records **every** request that
passes validation — including the ones that go on to send nothing.

That is deliberate and slightly counter-intuitive. The obvious implementation
counts deliveries, but then an unknown address never accumulates records and
never hits the limit, so `429` vs `200` becomes a reliable account-existence
oracle — undoing the enumeration safety the rest of these handlers are built
around. Counting requests keeps the verdict a function of the address alone.

There is a test that asserts exactly this: the known and unknown address must
produce byte-identical responses on both the first and second request.

Recorded as **ADR-004**, along with why IP-based limiting was rejected (the abuse
targets one victim's mailbox, and an attacker rotates IPs more easily than the
victim changes address) and the cost accepted (a hostile caller can exhaust a
stranger's allowance and briefly deny them a code — much cheaper than mailing
them repeatedly, but real).

## Why optional

The limiter needs state shared across replicas, which a package with no I/O
cannot invent. `createMemoryRequestRateLimitStore` ships as a reference, and both
its JSDoc and the README warn that a per-process store caps each replica
separately, so a fleet of N sends N times the intended rate.

## Testing

8 new specs: cooldown, per-address independence, the window ceiling, records
ageing out of the window, defaults applied from a bare `{ store }`, the
enumeration-equivalence assertion, and the unconfigured case staying unlimited.

`@ttoss/auth-core` 249 tests, `@ttoss/http-server-auth` 63. The new code is at
100% statements/branches/functions/lines; the package branch threshold rises
97.5 → 97.9.

## Follow-up

naturali will configure this against a Postgres-backed store in the same change
that adds SNS bounce/complaint handling. myhold picks it up whenever it migrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014R9AuEg77dBpG1LEstmovh

---
_Generated by [Claude Code](https://claude.ai/code/session_014R9AuEg77dBpG1LEstmovh)_