### PR TITLE
feat(http-server-mcp): warn when auth is configured without explicit publicMethods

### DIFF
--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -360,7 +360,7 @@ The `WWW-Authenticate: Bearer resource_metadata="…"` header is how MCP clients
 
 The two behaviors the [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) requires for client bootstrapping are built into the `auth` option, so you no longer need the hand-rolled middleware shown above:
 
-- **`publicMethods`** — JSON-RPC methods that bypass verification, read from the request body's `method` field. Defaults to `['initialize', 'tools/list']` so clients can discover the server before authenticating. Pass `[]` to require a token for every method, or a custom list to change the exempt set.
+- **`publicMethods`** — JSON-RPC methods that bypass verification, read from the request body's `method` field. Defaults to `['initialize', 'tools/list']` so clients can discover the server before authenticating. Pass `[]` to require a token for every method, or a custom list to change the exempt set. Leaving it unset serves the full tool catalogue — every tool name, description, and input schema — to unauthenticated callers, and logs a one-time warning explaining that and how to close it. Set `publicMethods` explicitly (even to the same default) to silence the warning.
 - **`resourceMetadataUrl`** — when set, a `401` responds with `WWW-Authenticate: Bearer resource_metadata="<resourceMetadataUrl>"` (RFC 9728) instead of a bare `Bearer`, pointing MCP clients at the protected-resource metadata document. When omitted, the header falls back to `Bearer`.
 
 ```typescript
@@ -870,6 +870,8 @@ expect(call.status).toBe(200);
 - Setting `publicMethods: []` makes `initialize` return `401` + `WWW-Authenticate`, which triggers the client's OAuth discovery and PKCE flow.
 
 Use the default when token auth is handled outside the OAuth flow (Cognito, API keys, Bearer tokens). Set `publicMethods: []` only when you want OAuth clients to self-discover and authenticate before anything else.
+
+Leaving `publicMethods` unset also exposes the full tool catalogue (`tools/list`) to unauthenticated callers — a tool's name, description, and input schema can leak internal resource names and, for an OpenAPI-derived server, the shape of the whole underlying API. A one-time warning is logged when `auth` is configured without an explicit `publicMethods`, naming the exposure and how to close it. This default is a candidate to tighten to `['initialize']` in a future major; track the decision in [ttoss/ttoss#1176](https://github.com/ttoss/ttoss/issues/1176).
 
 ## AWS Lambda Deployment
 

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -44,6 +44,10 @@ export interface McpAuthOptions {
   requiredScopes?: string[];
   /**
    * JSON-RPC methods (read from `body.method`) that bypass verification.
+   * Leaving this unset serves `tools/list` — the full tool catalogue —
+   * to unauthenticated callers, and logs a one-time warning explaining how
+   * to close it. Set explicitly (even to the same default) to silence the
+   * warning; set to `['initialize']` to require a token for `tools/list` too.
    * @default ['initialize', 'tools/list']
    */
   publicMethods?: string[];
@@ -506,6 +510,27 @@ export const createMcpRouter = (
 
   if (auth) {
     const verifyToken = buildVerifyToken(auth);
+
+    if (auth.publicMethods === undefined) {
+      // `tools/list` exposing the full tool catalogue to unauthenticated
+      // callers is a surprising default for anyone who configured `auth`
+      // without considering `publicMethods`. Warn once so operators find out
+      // from their own logs rather than from an unauthenticated tool listing
+      // in production. This default is a candidate to tighten to
+      // `['initialize']` in a future major — see
+      // https://github.com/ttoss/ttoss/issues/1176.
+      // eslint-disable-next-line no-console -- one-time operator-facing warning
+      console.warn(
+        `[@ttoss/http-server-mcp] "auth" is configured but "publicMethods" was not set, ` +
+          `so it defaults to ${JSON.stringify(DEFAULT_PUBLIC_METHODS)}. This means ` +
+          `"tools/list" — the full tool catalogue, including names, descriptions, and ` +
+          `input schemas — is served to unauthenticated callers. ` +
+          `To require a token for "tools/list" too, set publicMethods: ['initialize']. ` +
+          `To keep the current behaviour and silence this warning, set ` +
+          `publicMethods: ${JSON.stringify(DEFAULT_PUBLIC_METHODS)} explicitly.`
+      );
+    }
+
     const publicMethods = new Set(auth.publicMethods ?? DEFAULT_PUBLIC_METHODS);
 
     const verify = authMiddleware({

--- a/packages/http-server-mcp/tests/unit/tests/auth.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/auth.test.ts
@@ -572,6 +572,42 @@ describe('auth — public methods and RFC 9728 discovery', () => {
     expect(res.status).toBe(401);
   });
 
+  test('warns once when auth is configured without an explicit publicMethods', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    buildApp({});
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toEqual(
+      expect.stringContaining('publicMethods')
+    );
+    expect(warnSpy.mock.calls[0][0]).toEqual(
+      expect.stringContaining('tools/list')
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test('does not warn when publicMethods is set explicitly, even to the default', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    buildApp({ publicMethods: ['initialize', 'tools/list'] });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test('does not warn when publicMethods is set to an empty array', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    buildApp({ publicMethods: [] });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   test('a request without a method is treated as protected', async () => {
     const res = await request(buildApp({}).callback())
       .post('/mcp')


### PR DESCRIPTION
## Summary

Closes the one remaining Phase 1 item from #1168, tracked separately in #1176: whether `tools/list` should stay in `DEFAULT_PUBLIC_METHODS`.

Ships #1176's recommended option **3 ("warn now, flip later")**:

- `tools/list` stays public by default — no breaking change here.
- When `auth` is configured and `publicMethods` is left unset, `createMcpRouter` now logs a one-time warning naming the exposure (the full tool catalogue — names, descriptions, input schemas — served unauthenticated) and how to close it (`publicMethods: ['initialize']`), or how to silence the warning by setting `publicMethods` explicitly to the same default.
- Documents the tradeoff in the `publicMethods` JSDoc and in the README's "Public methods and discovery" and "`publicMethods` and OAuth clients" sections, linking to #1176 for the eventual major-version flip.

## Test plan

- [x] `pnpm run test` in `packages/http-server-mcp` — 114/114 tests pass, including 3 new tests covering: warning fires once when `publicMethods` is unset, no warning when set explicitly to the default, no warning when set to `[]`.
- [x] Coverage unchanged (branches 95.16% vs. 95% threshold, no decrease).
- [x] `git add <files> && pnpm run -w lint` — passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjDnEeP6w7edzQYB59DuX3)_