### PR TITLE
feat(http-server): add toHttpError and applyHttpErrorHeaders

### DIFF
--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -151,6 +151,46 @@ app.use(async (ctx, next) => {
 });
 ```
 
+An app with its own error envelope usually recognizes only its own error class,
+so a deliberate `ctx.throw(401, 'Unauthorized', { headers })` from a library
+middleware — `authMiddleware`, `createMcpRouter`'s `auth` — becomes a `500` with
+the `WWW-Authenticate` header stripped. For MCP that header is the whole
+[RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) discovery chain: the client
+gets an opaque server error where it expected the pointer to the authorization
+server, so OAuth discovery never starts.
+
+`toHttpError` normalizes a thrown value into `{ status, message, headers }` when
+it is a deliberate, exposable 4xx, and `undefined` otherwise, so a genuine bug
+still becomes a `500` with nothing leaked. `applyHttpErrorHeaders` copies the
+headers the thrower attached onto the response — without it the status is right
+but discovery is still broken.
+
+```typescript
+import { App, applyHttpErrorHeaders, toHttpError } from '@ttoss/http-server';
+
+app.use(async (ctx, next) => {
+  try {
+    await next();
+  } catch (error) {
+    if (error instanceof ApiError) {
+      writeError(ctx, error);
+      return;
+    }
+
+    const httpError = toHttpError(error);
+
+    if (httpError) {
+      applyHttpErrorHeaders({ ctx, error });
+      writeError(ctx, new ApiError(httpError.status, httpError.message));
+      return;
+    }
+
+    console.error('Unhandled request error:', error);
+    writeError(ctx, new ApiError(500, 'internal_error'));
+  }
+});
+```
+
 ## OAuth
 
 Authentication lives in [`@ttoss/http-server-auth`](https://ttoss.dev/docs/modules/packages/http-server-auth) — `authMiddleware` (verify Bearer tokens, including an `oauth` strategy) and `oauthServer()` (issue tokens), a thin Koa layer over the runner-agnostic engine in [`@ttoss/auth-core`](https://ttoss.dev/docs/modules/packages/auth-core). This base runner stays auth-free. See the [OAuth Authorization Server](https://ttoss.dev/docs/engineering/guidelines/oauth-authorization-server) guideline.
@@ -166,5 +206,8 @@ All exports are re-exported from established Koa ecosystem packages:
 - **`multer`** - [Koa multer](https://github.com/koajs/multer) for file uploads
 - **`serve`** - [Koa static](https://github.com/koajs/static) for serving static files
 - **`addHealthCheck({ app, path? })`** - Adds a health endpoint (defaults to `/health`) returning `{ status: 'ok' }`
+- **`toHttpError(error)`** - Normalizes a deliberate, exposable 4xx into `{ status, message, headers }`; `undefined` for anything else
+- **`applyHttpErrorHeaders({ ctx, error })`** - Copies headers attached to a thrown error onto the response (e.g. `WWW-Authenticate`)
+- **`NormalizedHttpError`** (type) - Return shape of `toHttpError`
 - **`MulterFile`** (type) - File type for uploaded files
 - **`RouterContext<StateT, ContextT>`** (type) - Generic Koa router context for type-safe route handlers

--- a/packages/http-server/src/httpError.ts
+++ b/packages/http-server/src/httpError.ts
@@ -1,0 +1,155 @@
+import type { Context } from 'koa';
+
+/**
+ * A deliberate, client-facing HTTP error normalized out of an unknown thrown
+ * value — what `ctx.throw(401, 'Unauthorized', { headers })` produces.
+ */
+export interface NormalizedHttpError {
+  /** The 4xx status the thrower asked for. */
+  status: number;
+  /** The message the thrower attached, safe to expose to the client. */
+  message: string;
+  /**
+   * Headers the thrower attached to the error (a `401`'s `WWW-Authenticate`,
+   * for instance). Empty when the error carried none.
+   */
+  headers: Record<string, string>;
+}
+
+/**
+ * The shape `http-errors` (used by Koa's `ctx.throw`) puts on a thrown error.
+ * Every field is `unknown` because the value reaching a catch-all error
+ * middleware is genuinely untyped.
+ */
+interface HttpishError {
+  status?: unknown;
+  statusCode?: unknown;
+  expose?: unknown;
+  headers?: unknown;
+  message?: unknown;
+}
+
+const DEFAULT_MESSAGE = 'The request could not be completed.';
+
+const readStatus = (candidate: HttpishError): number | undefined => {
+  const raw = candidate.status ?? candidate.statusCode;
+  return typeof raw === 'number' ? raw : undefined;
+};
+
+const readHeaders = (candidate: HttpishError): Record<string, string> => {
+  const { headers } = candidate;
+
+  if (typeof headers !== 'object' || headers === null) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).filter(([, value]) => {
+      return typeof value === 'string';
+    })
+  ) as Record<string, string>;
+};
+
+/**
+ * Normalizes an error thrown by a library middleware — `authMiddleware`,
+ * `createMcpRouter`'s `auth`, or any `ctx.throw` — into the status, message,
+ * and headers a catch-all error middleware must preserve.
+ *
+ * An app with its own error envelope typically recognizes only its own error
+ * class and turns everything else into a `500`. That swallows a deliberate
+ * `401` **and its `WWW-Authenticate` header**, which is the whole RFC 9728
+ * discovery chain for MCP clients: the client gets an opaque server error where
+ * it expected the pointer to the authorization server, so OAuth discovery never
+ * starts. Run thrown values through this helper before falling back to `500`.
+ *
+ * Returns `undefined` for anything that is not a deliberate, exposable 4xx —
+ * a genuine bug still becomes a `500` with nothing leaked. Only errors that opt
+ * in via `expose === true` (which `http-errors` sets for 4xx) pass through.
+ *
+ * @example
+ * ```typescript
+ * import { applyHttpErrorHeaders, toHttpError } from '@ttoss/http-server';
+ *
+ * app.use(async (ctx, next) => {
+ *   try {
+ *     await next();
+ *   } catch (error) {
+ *     if (error instanceof ApiError) {
+ *       writeError(ctx, error);
+ *       return;
+ *     }
+ *
+ *     const httpError = toHttpError(error);
+ *
+ *     if (httpError) {
+ *       applyHttpErrorHeaders({ ctx, error });
+ *       writeError(ctx, new ApiError(httpError.status, httpError.message));
+ *       return;
+ *     }
+ *
+ *     console.error('Unhandled request error:', error);
+ *     writeError(ctx, new ApiError(500, 'internal_error'));
+ *   }
+ * });
+ * ```
+ */
+export const toHttpError = (
+  error: unknown
+): NormalizedHttpError | undefined => {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  const candidate = error as HttpishError;
+  const status = readStatus(candidate);
+
+  if (status === undefined || status < 400 || status >= 500) {
+    return undefined;
+  }
+
+  /**
+   * `http-errors` sets `expose: true` on 4xx and `false` on 5xx. Gating on it
+   * keeps internal failure details out of responses, even when an internal
+   * error happens to carry a 4xx-looking status.
+   */
+  if (candidate.expose !== true) {
+    return undefined;
+  }
+
+  const message =
+    typeof candidate.message === 'string' && candidate.message
+      ? candidate.message
+      : DEFAULT_MESSAGE;
+
+  return { status, message, headers: readHeaders(candidate) };
+};
+
+/**
+ * Copies the headers a thrower attached to an error onto the response — the
+ * `WWW-Authenticate` header of a `401`, above all.
+ *
+ * Call it from a catch-all error middleware alongside {@link toHttpError}:
+ * without this half the status is right but MCP discovery is still broken,
+ * because the header that names the authorization server never reaches the
+ * client. Non-string header values are ignored; a value that is not an error
+ * object, or an error without headers, is a no-op.
+ */
+export const applyHttpErrorHeaders = ({
+  ctx,
+  error,
+}: {
+  /** The Koa context whose response headers are being written. */
+  ctx: Context;
+  /** The caught value, of unknown shape. */
+  error: unknown;
+}): void => {
+  if (typeof error !== 'object' || error === null) {
+    return;
+  }
+
+  for (const [name, value] of Object.entries(
+    readHeaders(error as HttpishError)
+  )) {
+    ctx.set(name, value);
+  }
+};

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -7,6 +7,11 @@ import serve from 'koa-static';
 
 export { App, bodyParser, cors, multer, Router, serve };
 export * from './addHealthCheck';
+export {
+  applyHttpErrorHeaders,
+  type NormalizedHttpError,
+  toHttpError,
+} from './httpError';
 export type { File as MulterFile } from '@koa/multer';
 export type { Context, Middleware, Next } from 'koa';
 

--- a/packages/http-server/tests/unit/tests/httpError.test.ts
+++ b/packages/http-server/tests/unit/tests/httpError.test.ts
@@ -1,0 +1,147 @@
+import type { Context } from 'koa';
+import { App, applyHttpErrorHeaders, Router, toHttpError } from 'src/index';
+import request from 'supertest';
+
+describe('toHttpError', () => {
+  test('normalizes an exposable 4xx', () => {
+    const error = {
+      status: 401,
+      expose: true,
+      message: 'Unauthorized',
+      headers: { 'WWW-Authenticate': 'Bearer' },
+    };
+
+    expect(toHttpError(error)).toEqual({
+      status: 401,
+      message: 'Unauthorized',
+      headers: { 'WWW-Authenticate': 'Bearer' },
+    });
+  });
+
+  test('reads statusCode when status is absent', () => {
+    expect(
+      toHttpError({ statusCode: 403, expose: true, message: 'Forbidden' })
+    ).toEqual({ status: 403, message: 'Forbidden', headers: {} });
+  });
+
+  test('falls back to a generic message when the error has none', () => {
+    expect(toHttpError({ status: 400, expose: true, message: '' })).toEqual({
+      status: 400,
+      message: 'The request could not be completed.',
+      headers: {},
+    });
+
+    expect(toHttpError({ status: 400, expose: true, message: 42 })).toEqual({
+      status: 400,
+      message: 'The request could not be completed.',
+      headers: {},
+    });
+  });
+
+  test('drops non-string header values', () => {
+    const error = {
+      status: 401,
+      expose: true,
+      message: 'Unauthorized',
+      headers: { 'WWW-Authenticate': 'Bearer', 'Retry-After': 30 },
+    };
+
+    expect(toHttpError(error)?.headers).toEqual({
+      'WWW-Authenticate': 'Bearer',
+    });
+  });
+
+  test.each([
+    ['a non-object', 'boom'],
+    ['null', null],
+    ['a plain Error', new Error('boom')],
+    ['a status that is not a number', { status: '401', expose: true }],
+    ['a 5xx', { status: 500, expose: true }],
+    ['a 3xx', { status: 302, expose: true }],
+    ['an error that does not opt into exposure', { status: 401 }],
+    ['an internal error with a 4xx status', { status: 401, expose: false }],
+  ])('returns undefined for %s', (_, error) => {
+    expect(toHttpError(error)).toBeUndefined();
+  });
+
+  test('ignores non-object headers', () => {
+    expect(
+      toHttpError({
+        status: 401,
+        expose: true,
+        message: 'x',
+        headers: 'Bearer',
+      })?.headers
+    ).toEqual({});
+    expect(
+      toHttpError({ status: 401, expose: true, message: 'x', headers: null })
+        ?.headers
+    ).toEqual({});
+  });
+});
+
+describe('applyHttpErrorHeaders', () => {
+  test('is a no-op for values that cannot carry headers', () => {
+    const set = jest.fn();
+    const ctx = { set } as unknown as Context;
+
+    applyHttpErrorHeaders({ ctx, error: 'boom' });
+    applyHttpErrorHeaders({ ctx, error: null });
+    applyHttpErrorHeaders({ ctx, error: new Error('boom') });
+
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  test('preserves WWW-Authenticate through a catch-all error envelope', async () => {
+    const app = new App();
+
+    app.use(async (ctx, next) => {
+      try {
+        await next();
+      } catch (error) {
+        const httpError = toHttpError(error);
+
+        if (httpError) {
+          applyHttpErrorHeaders({ ctx, error });
+          ctx.status = httpError.status;
+          ctx.body = { error: httpError.message };
+          return;
+        }
+
+        ctx.status = 500;
+        ctx.body = { error: 'internal_error' };
+      }
+    });
+
+    const router = new Router();
+
+    router.get('/protected', (ctx) => {
+      ctx.throw(401, 'Unauthorized', {
+        headers: {
+          'WWW-Authenticate':
+            'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
+        },
+      });
+    });
+
+    router.get('/broken', () => {
+      throw new Error('boom');
+    });
+
+    app.use(router.routes());
+
+    const unauthorized = await request(app.callback()).get('/protected');
+
+    expect(unauthorized.status).toBe(401);
+    expect(unauthorized.body).toEqual({ error: 'Unauthorized' });
+    expect(unauthorized.headers['www-authenticate']).toBe(
+      'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"'
+    );
+
+    const broken = await request(app.callback()).get('/broken');
+
+    expect(broken.status).toBe(500);
+    expect(broken.body).toEqual({ error: 'internal_error' });
+    expect(broken.headers['www-authenticate']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part 2 of 3 from the "Three gaps found while building an MCP OAuth server on ttoss" report.

## Problem

`authMiddleware` (and therefore `createMcpRouter`'s `auth`) rejects with `ctx.throw(401, 'Unauthorized', { headers: { 'WWW-Authenticate': … } })`. Any app with its own error envelope has a catch-all error middleware, and the natural implementation only recognises *its own* error type — everything else becomes a `500`, with the `WWW-Authenticate` header dropped.

For MCP that header is the entire [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) discovery chain. An OAuth-aware client gets an opaque server error where it expected the pointer to the authorization server, so **OAuth discovery silently never starts** — and the server logs an "unhandled" error that was not unhandled at all. This hits every ttoss app that combines a custom error envelope with `authMiddleware` or `createMcpRouter`.

## Change

Two exports from `@ttoss/http-server` (`src/httpError.ts`):

- `toHttpError(error)` → `{ status, message, headers }` when the thrown value is a **deliberate, exposable 4xx**, `undefined` otherwise. It reads `status ?? statusCode`, requires a `4xx`, and gates on `expose === true` (which `http-errors` sets for 4xx) so a genuine bug still becomes a `500` with nothing leaked. Non-string header values are dropped; a missing/blank message falls back to a generic one.
- `applyHttpErrorHeaders({ ctx, error })` → copies the headers the thrower attached onto the response. Without this second half the status is fixed but MCP discovery is still broken.

Both halves kept the two properties the report asked for: the `expose` gate, and carrying `error.headers` through.

## Tests

`packages/http-server/tests/unit/tests/httpError.test.ts` covers the accepted shape, every rejection branch (non-object, `null`, plain `Error`, non-numeric status, 5xx, 3xx, `expose` absent/false, non-object headers), the message fallback, header filtering, and an end-to-end Koa app where a catch-all envelope round-trips a real `ctx.throw(401, …)` with `WWW-Authenticate` intact while a genuine bug still yields a header-free `500`. Package coverage stays at 100% across the board (its existing threshold), so `jest.config.ts` needed no change.

## Docs

`packages/http-server/README.md` — the "Error Handling" section now explains the swallowed-401 failure and shows the envelope recipe; the API reference lists both exports and the `NormalizedHttpError` type.

## Notes

`pnpm run build` for this package fails in the sandbox with `[BABEL]: request for '@babel/helper-plugin-utils' is from a module not been linked` inside the shared tsdown formatjs plugin. It reproduces on untouched packages (`@ttoss/i18n-cli`), so it is environmental and unrelated to this diff. Tests and lint (`eslint`, `prettier`, `syncpack`) pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UgRPAoSwGLDYQv82rad7x)_