### PR TITLE
feat(auth-postgresdb): add durable Postgres OAuth stores and models

### DIFF
--- a/packages/auth-postgresdb/README.md
+++ b/packages/auth-postgresdb/README.md
@@ -1,0 +1,76 @@
+# @ttoss/auth-postgresdb
+
+Durable Postgres persistence for the OAuth 2.1 authorization server in [`@ttoss/auth-core`](https://ttoss.dev/docs/modules/packages/auth-core): the Sequelize models for the RFC data model, plus the store adapters `createOAuthHandlers`, `createRefreshRotation`, and `createRedirectConsentOnAuthorize` expect.
+
+`@ttoss/auth-core` ships `Map`-backed stores for tests and local development; this package is what production swaps in behind the same interfaces, without reaching around your ORM to inject a raw `pg` query runner.
+
+## Installation
+
+```bash
+pnpm add @ttoss/auth-postgresdb @ttoss/auth-core @ttoss/postgresdb
+```
+
+## Usage
+
+Register `oauthModels` alongside your own models so `ttoss-postgresdb sync` and `erd` manage these tables like any other, then build the stores from the `db` handle:
+
+```typescript
+import {
+  createPostgresdbOAuthStores,
+  oauthModels,
+} from '@ttoss/auth-postgresdb';
+import { initialize } from '@ttoss/postgresdb';
+
+import { User } from './models/User';
+
+export const db = await initialize({ models: { ...oauthModels, User } });
+
+export const { clientStore, authCodeStore, consentStore, refreshTokenStore } =
+  createPostgresdbOAuthStores({ db });
+```
+
+The stores drop straight into the OAuth server:
+
+```typescript
+import { createRefreshRotation } from '@ttoss/auth-core';
+import { oauthServer } from '@ttoss/http-server-auth';
+
+const refresh = createRefreshRotation({ store: refreshTokenStore });
+
+const authServer = oauthServer({
+  issuer: 'https://api.example.com',
+  clientStore,
+  authCodeStore,
+  onRefreshToken: refresh.onRefreshToken,
+  // …issueTokens, onAuthorize…
+});
+```
+
+Each store is also exported on its own (`createClientStore`, `createAuthCodeStore`, `createConsentStore`, `createRefreshTokenStore`) for apps that register only some of the models.
+
+## Schema
+
+| Model               | Table                  | Primary key      |
+| ------------------- | ---------------------- | ---------------- |
+| `OAuthClient`       | `oauth_clients`        | `client_id`      |
+| `OAuthAuthCode`     | `oauth_auth_codes`     | `code_hash`      |
+| `OAuthConsent`      | `oauth_consents`       | `code_challenge` |
+| `OAuthRefreshToken` | `oauth_refresh_tokens` | `token_hash`     |
+
+Credentials are stored by SHA-256 hash, never in plaintext, so a database dump yields nothing replayable. `OAuthClient` keeps the registered RFC 7591 fields in their own columns and any additional submitted metadata in a `metadata` JSONB column, so a registration document round-trips unchanged.
+
+## Two traps these adapters absorb
+
+**Authorization codes are hashed at rest.** `AuthCodeStore.get` is handed the plaintext code, but a code travels through a browser redirect and a client's URL bar. The engine never compares the returned `code` against anything — it reads only `clientId`, `redirectUri`, `codeChallenge`, `scopes`, `subject`, and `expiresAt` — so the adapter hashes to find the row and echoes the presented value back.
+
+**A live refresh token reports no `consumedAt` at all.** `createRefreshRotation` treats `stored.consumedAt !== undefined` as reuse. A nullable timestamp column reads back as `null`, which is `!== undefined`, so a naive adapter makes every live token look consumed: the first refresh is treated as a replay and revokes the owner's entire token set — "refresh works once, then the client must re-authorize forever". The adapter omits the key instead of setting it to `null`.
+
+## Consent
+
+`consentStore` satisfies the `ConsentGrantStore` that `createRedirectConsentOnAuthorize` consumes, and adds `saveConsentGrant` for the write your consent page performs on approval. It is the single-use handoff keyed by the PKCE `code_challenge` — not a durable "user X trusts client Y" record, which is an app-level authorization decision and belongs in your own schema.
+
+## Related
+
+- [OAuth Authorization Server](https://ttoss.dev/docs/engineering/guidelines/oauth-authorization-server) — the full server setup and the ttoss-vs-app responsibility split
+- [MCP Server with OAuth](https://ttoss.dev/docs/engineering/guidelines/mcp-server-oauth) — the MCP application of these primitives
+- [`@ttoss/postgresdb`](https://ttoss.dev/docs/modules/packages/postgresdb) — `initialize`, and the `sync` / `erd` CLI

--- a/packages/auth-postgresdb/package.json
+++ b/packages/auth-postgresdb/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@ttoss/auth-postgresdb",
+  "version": "0.0.0",
+  "description": "Durable Postgres OAuth stores and models for @ttoss/auth-core",
+  "keywords": [
+    "auth",
+    "oauth",
+    "postgres",
+    "sequelize",
+    "ttoss"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ttoss/ttoss.git",
+    "directory": "packages/auth-postgresdb"
+  },
+  "license": "MIT",
+  "author": "ttoss",
+  "contributors": [
+    "Pedro Arantes <pedro@arantespp.com> (https://arantespp.com)"
+  ],
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "pretest": "pnpm run build",
+    "test": "jest --projects tests/unit"
+  },
+  "devDependencies": {
+    "@ttoss/auth-core": "workspace:^",
+    "@ttoss/config": "workspace:^",
+    "@ttoss/postgresdb": "workspace:^",
+    "jest": "^30.4.2",
+    "tsdown": "^0.22.2"
+  },
+  "peerDependencies": {
+    "@ttoss/auth-core": "workspace:^",
+    "@ttoss/postgresdb": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "types": "./dist/index.d.mts"
+      }
+    },
+    "provenance": true
+  }
+}

--- a/packages/auth-postgresdb/src/createPostgresdbOAuthStores.ts
+++ b/packages/auth-postgresdb/src/createPostgresdbOAuthStores.ts
@@ -1,0 +1,64 @@
+import type {
+  AuthCodeStore,
+  ClientStore,
+  RefreshTokenStore,
+} from '@ttoss/auth-core';
+
+import type { OAuthModels } from './models';
+import { createAuthCodeStore } from './stores/createAuthCodeStore';
+import { createClientStore } from './stores/createClientStore';
+import {
+  createConsentStore,
+  type PostgresdbConsentStore,
+} from './stores/createConsentStore';
+import { createRefreshTokenStore } from './stores/createRefreshTokenStore';
+
+/** The durable OAuth stores returned by {@link createPostgresdbOAuthStores}. */
+export interface PostgresdbOAuthStores {
+  /** Dynamic client registrations, for `createOAuthHandlers`. */
+  clientStore: ClientStore;
+  /** Single-use authorization codes, stored by hash. */
+  authCodeStore: AuthCodeStore;
+  /** Consent handoff records for `createRedirectConsentOnAuthorize`. */
+  consentStore: PostgresdbConsentStore;
+  /** Tracked refresh tokens, for `createRefreshRotation`. */
+  refreshTokenStore: RefreshTokenStore;
+}
+
+/**
+ * Creates every durable OAuth store from a `@ttoss/postgresdb` `db` handle.
+ *
+ * The stores are mechanical adapters between the `@ttoss/auth-core` store
+ * contracts and Sequelize, so an app that already uses `@ttoss/postgresdb` does
+ * not have to write them — nor reach around its own ORM to inject a raw `pg`
+ * query runner.
+ *
+ * @example
+ * ```typescript
+ * import { createPostgresdbOAuthStores, oauthModels } from '@ttoss/auth-postgresdb';
+ * import { initialize } from '@ttoss/postgresdb';
+ *
+ * const db = await initialize({ models: { ...oauthModels, User } });
+ *
+ * const { clientStore, authCodeStore, consentStore, refreshTokenStore } =
+ *   createPostgresdbOAuthStores({ db });
+ * ```
+ */
+export const createPostgresdbOAuthStores = ({
+  db,
+}: {
+  /**
+   * The handle returned by `@ttoss/postgresdb`'s `initialize`, with
+   * `oauthModels` among its registered models.
+   */
+  db: OAuthModels;
+}): PostgresdbOAuthStores => {
+  return {
+    clientStore: createClientStore({ model: db.OAuthClient }),
+    authCodeStore: createAuthCodeStore({ model: db.OAuthAuthCode }),
+    consentStore: createConsentStore({ model: db.OAuthConsent }),
+    refreshTokenStore: createRefreshTokenStore({
+      model: db.OAuthRefreshToken,
+    }),
+  };
+};

--- a/packages/auth-postgresdb/src/index.ts
+++ b/packages/auth-postgresdb/src/index.ts
@@ -1,0 +1,19 @@
+export {
+  createPostgresdbOAuthStores,
+  type PostgresdbOAuthStores,
+} from './createPostgresdbOAuthStores';
+export {
+  OAuthAuthCode,
+  OAuthClient,
+  OAuthConsent,
+  type OAuthModels,
+  oauthModels,
+  OAuthRefreshToken,
+} from './models';
+export { createAuthCodeStore } from './stores/createAuthCodeStore';
+export { createClientStore } from './stores/createClientStore';
+export {
+  createConsentStore,
+  type PostgresdbConsentStore,
+} from './stores/createConsentStore';
+export { createRefreshTokenStore } from './stores/createRefreshTokenStore';

--- a/packages/auth-postgresdb/src/models/OAuthAuthCode.ts
+++ b/packages/auth-postgresdb/src/models/OAuthAuthCode.ts
@@ -1,0 +1,65 @@
+import { Column, DataType, Model, PrimaryKey, Table } from '@ttoss/postgresdb';
+
+/**
+ * A short-lived authorization code with its bound PKCE challenge.
+ *
+ * The primary key is the code's SHA-256 hash, never the code itself: a code
+ * travels through a browser redirect and a client's URL bar, so storing it in
+ * plaintext would make a database dump yield replayable codes.
+ */
+@Table({
+  tableName: 'oauth_auth_codes',
+  modelName: 'oauthAuthCode',
+  indexes: [{ fields: ['expires_at'] }],
+})
+export class OAuthAuthCode extends Model {
+  /** SHA-256 hash (hex) of the authorization code. */
+  @PrimaryKey
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare codeHash: string;
+
+  /** The `client_id` the code was issued to. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare clientId: string;
+
+  /** The redirect URI the code was issued for (must match on exchange). */
+  @Column({
+    type: DataType.TEXT,
+    allowNull: false,
+  })
+  declare redirectUri: string;
+
+  /** The PKCE `code_challenge` (S256) bound to this code. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare codeChallenge: string;
+
+  /** The scopes granted to this code. */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: false,
+  })
+  declare scopes: string[];
+
+  /** The authenticated end-user subject identifier. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare subject: string;
+
+  /** Instant after which the code is invalid. */
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+  })
+  declare expiresAt: Date;
+}

--- a/packages/auth-postgresdb/src/models/OAuthClient.ts
+++ b/packages/auth-postgresdb/src/models/OAuthClient.ts
@@ -1,0 +1,92 @@
+import { Column, DataType, Model, PrimaryKey, Table } from '@ttoss/postgresdb';
+
+/**
+ * A registered OAuth client (RFC 7591 dynamic client registration).
+ *
+ * The RFC's registered fields get their own columns so they can be queried and
+ * indexed; any additional metadata a client submits is kept verbatim in
+ * `metadata`, because `OAuthClientMetadata` is an open shape.
+ */
+@Table({
+  tableName: 'oauth_clients',
+  modelName: 'oauthClient',
+})
+export class OAuthClient extends Model {
+  /** The `client_id` issued by the authorization server. */
+  @PrimaryKey
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare clientId: string;
+
+  /**
+   * Client secret for confidential clients, `null` for public clients
+   * (`token_endpoint_auth_method: 'none'`).
+   */
+  @Column({
+    type: DataType.STRING,
+    allowNull: true,
+  })
+  declare clientSecret: string | null;
+
+  /** Human-readable client name shown on consent screens. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: true,
+  })
+  declare clientName: string | null;
+
+  /** Exact redirect URIs registered for this client. */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: false,
+  })
+  declare redirectUris: string[];
+
+  /** OAuth grant types the client may use. */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: true,
+  })
+  declare grantTypes: string[] | null;
+
+  /** OAuth response types the client may use. */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: true,
+  })
+  declare responseTypes: string[] | null;
+
+  /** Client authentication method at the token endpoint. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: true,
+  })
+  declare tokenEndpointAuthMethod: string | null;
+
+  /** Space-separated scopes the client may request. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: true,
+  })
+  declare scope: string | null;
+
+  /** Unix timestamp (seconds) when the client was registered. */
+  @Column({
+    type: DataType.BIGINT,
+    allowNull: true,
+  })
+  declare clientIdIssuedAt: number | null;
+
+  /**
+   * Registration metadata outside the columns above, preserved so a client's
+   * submitted document round-trips unchanged (e.g. `logo_uri`, `client_uri`).
+   */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: false,
+    defaultValue: {},
+  })
+  declare metadata: Record<string, unknown>;
+}

--- a/packages/auth-postgresdb/src/models/OAuthConsent.ts
+++ b/packages/auth-postgresdb/src/models/OAuthConsent.ts
@@ -1,0 +1,45 @@
+import { Column, DataType, Model, PrimaryKey, Table } from '@ttoss/postgresdb';
+
+/**
+ * A single-use consent handoff, correlated by the PKCE `code_challenge`.
+ *
+ * This is the record an external consent screen writes on approval so the
+ * restarted `/authorize` request can be approved without asking again — it is
+ * not a durable "user X trusts client Y" grant, which is an app-level
+ * authorization decision and belongs in the app's own schema.
+ */
+@Table({
+  tableName: 'oauth_consents',
+  modelName: 'oauthConsent',
+  indexes: [{ fields: ['expires_at'] }],
+})
+export class OAuthConsent extends Model {
+  /** The PKCE `code_challenge` the consent was recorded against. */
+  @PrimaryKey
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare codeChallenge: string;
+
+  /** The authenticated end-user subject identifier. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare subject: string;
+
+  /** The scopes the user approved. */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: false,
+  })
+  declare scopes: string[];
+
+  /** Instant after which the consent is no longer usable. */
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+  })
+  declare expiresAt: Date;
+}

--- a/packages/auth-postgresdb/src/models/OAuthRefreshToken.ts
+++ b/packages/auth-postgresdb/src/models/OAuthRefreshToken.ts
@@ -1,0 +1,60 @@
+import { Column, DataType, Model, PrimaryKey, Table } from '@ttoss/postgresdb';
+
+/**
+ * A refresh token tracked for OAuth 2.1 rotation, stored by hash so a database
+ * dump yields no usable credentials.
+ *
+ * `consumedAt` marks a rotated token. Presenting one again is reuse, and
+ * `createRefreshRotation` revokes the whole `(clientId, subject)` token set —
+ * which is why the store adapter must report a live token's `consumedAt` as
+ * absent rather than as `null`.
+ */
+@Table({
+  tableName: 'oauth_refresh_tokens',
+  modelName: 'oauthRefreshToken',
+  indexes: [{ fields: ['client_id', 'subject'] }, { fields: ['expires_at'] }],
+})
+export class OAuthRefreshToken extends Model {
+  /** SHA-256 hash (hex) of the opaque refresh token. */
+  @PrimaryKey
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare tokenHash: string;
+
+  /** The `client_id` the token was issued to. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare clientId: string;
+
+  /** The authenticated end-user subject identifier. */
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  declare subject: string;
+
+  /** The scopes granted to this token. */
+  @Column({
+    type: DataType.JSONB,
+    allowNull: false,
+  })
+  declare scopes: string[];
+
+  /** Instant after which the token is invalid. */
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+  })
+  declare expiresAt: Date;
+
+  /** Instant the token was rotated (consumed), or `null` while it is live. */
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+  })
+  declare consumedAt: Date | null;
+}

--- a/packages/auth-postgresdb/src/models/index.ts
+++ b/packages/auth-postgresdb/src/models/index.ts
@@ -1,0 +1,29 @@
+import { OAuthAuthCode } from './OAuthAuthCode';
+import { OAuthClient } from './OAuthClient';
+import { OAuthConsent } from './OAuthConsent';
+import { OAuthRefreshToken } from './OAuthRefreshToken';
+
+/**
+ * The OAuth data model, ready to register alongside the application's own
+ * models so `ttoss-postgresdb sync` and `erd` cover these tables like any
+ * other instead of them being a side-channel schema the CLI cannot see.
+ *
+ * @example
+ * ```typescript
+ * import { oauthModels } from '@ttoss/auth-postgresdb';
+ * import { initialize } from '@ttoss/postgresdb';
+ *
+ * export const db = await initialize({ models: { ...oauthModels, User } });
+ * ```
+ */
+export const oauthModels = {
+  OAuthAuthCode,
+  OAuthClient,
+  OAuthConsent,
+  OAuthRefreshToken,
+};
+
+/** The shape a `db` handle must have to back the OAuth stores. */
+export type OAuthModels = typeof oauthModels;
+
+export { OAuthAuthCode, OAuthClient, OAuthConsent, OAuthRefreshToken };

--- a/packages/auth-postgresdb/src/stores/createAuthCodeStore.ts
+++ b/packages/auth-postgresdb/src/stores/createAuthCodeStore.ts
@@ -1,0 +1,59 @@
+import type { AuthCodeStore } from '@ttoss/auth-core';
+import { hashAuthorizationCode } from '@ttoss/auth-core';
+
+import type { OAuthAuthCode } from '../models/OAuthAuthCode';
+
+/**
+ * Creates an {@link AuthCodeStore} backed by the `oauth_auth_codes` table,
+ * storing codes by SHA-256 hash.
+ *
+ * The engine hands the store the plaintext code on every call and never compares
+ * the returned `code` against anything — it reads only `clientId`,
+ * `redirectUri`, `codeChallenge`, `scopes`, `subject`, and `expiresAt`. So the
+ * adapter hashes to find the row and echoes the presented value back, and a
+ * database dump yields no replayable codes.
+ */
+export const createAuthCodeStore = ({
+  model,
+}: {
+  /** The `OAuthAuthCode` model class, taken from the app's `db` handle. */
+  model: typeof OAuthAuthCode;
+}): AuthCodeStore => {
+  return {
+    save: async (code) => {
+      await model.upsert({
+        codeHash: hashAuthorizationCode({ code: code.code }),
+        clientId: code.clientId,
+        redirectUri: code.redirectUri,
+        codeChallenge: code.codeChallenge,
+        scopes: code.scopes,
+        subject: code.subject,
+        expiresAt: new Date(code.expiresAt),
+      });
+    },
+
+    get: async (code) => {
+      const row = await model.findByPk(hashAuthorizationCode({ code }));
+
+      if (!row) {
+        return undefined;
+      }
+
+      return {
+        code,
+        clientId: row.clientId,
+        redirectUri: row.redirectUri,
+        codeChallenge: row.codeChallenge,
+        scopes: row.scopes,
+        subject: row.subject,
+        expiresAt: row.expiresAt.getTime(),
+      };
+    },
+
+    delete: async (code) => {
+      await model.destroy({
+        where: { codeHash: hashAuthorizationCode({ code }) },
+      });
+    },
+  };
+};

--- a/packages/auth-postgresdb/src/stores/createClientStore.ts
+++ b/packages/auth-postgresdb/src/stores/createClientStore.ts
@@ -1,0 +1,89 @@
+import type {
+  ClientStore,
+  OAuthClient as OAuthClientRecord,
+} from '@ttoss/auth-core';
+
+import type { OAuthClient } from '../models/OAuthClient';
+
+/**
+ * Registration fields that have their own column. Everything else a client
+ * submits goes to `metadata`, so the document round-trips unchanged.
+ */
+const COLUMN_FIELDS = [
+  'client_id',
+  'client_secret',
+  'client_name',
+  'redirect_uris',
+  'grant_types',
+  'response_types',
+  'token_endpoint_auth_method',
+  'scope',
+  'client_id_issued_at',
+] as const;
+
+const toRecord = (row: OAuthClient): OAuthClientRecord => {
+  return {
+    ...row.metadata,
+    client_id: row.clientId,
+    redirect_uris: row.redirectUris,
+    ...(row.clientSecret !== null && { client_secret: row.clientSecret }),
+    ...(row.clientName !== null && { client_name: row.clientName }),
+    ...(row.grantTypes !== null && { grant_types: row.grantTypes }),
+    ...(row.responseTypes !== null && { response_types: row.responseTypes }),
+    ...(row.tokenEndpointAuthMethod !== null && {
+      token_endpoint_auth_method: row.tokenEndpointAuthMethod,
+    }),
+    ...(row.scope !== null && { scope: row.scope }),
+    ...(row.clientIdIssuedAt !== null && {
+      client_id_issued_at: Number(row.clientIdIssuedAt),
+    }),
+  };
+};
+
+const toMetadata = (client: OAuthClientRecord): Record<string, unknown> => {
+  const metadata: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(client)) {
+    if (!(COLUMN_FIELDS as readonly string[]).includes(key)) {
+      metadata[key] = value;
+    }
+  }
+
+  return metadata;
+};
+
+/**
+ * Creates a {@link ClientStore} backed by the `oauth_clients` table.
+ *
+ * `register` upserts, so re-registering an existing `client_id` replaces the
+ * stored document rather than failing on the primary key.
+ */
+export const createClientStore = ({
+  model,
+}: {
+  /** The `OAuthClient` model class, taken from the app's `db` handle. */
+  model: typeof OAuthClient;
+}): ClientStore => {
+  return {
+    get: async (clientId) => {
+      const row = await model.findByPk(clientId);
+
+      return row ? toRecord(row) : undefined;
+    },
+
+    register: async (client) => {
+      await model.upsert({
+        clientId: client.client_id,
+        clientSecret: client.client_secret ?? null,
+        clientName: client.client_name ?? null,
+        redirectUris: client.redirect_uris,
+        grantTypes: client.grant_types ?? null,
+        responseTypes: client.response_types ?? null,
+        tokenEndpointAuthMethod: client.token_endpoint_auth_method ?? null,
+        scope: client.scope ?? null,
+        clientIdIssuedAt: client.client_id_issued_at ?? null,
+        metadata: toMetadata(client),
+      });
+    },
+  };
+};

--- a/packages/auth-postgresdb/src/stores/createConsentStore.ts
+++ b/packages/auth-postgresdb/src/stores/createConsentStore.ts
@@ -1,0 +1,59 @@
+import type { ConsentGrant, ConsentGrantStore } from '@ttoss/auth-core';
+
+import type { OAuthConsent } from '../models/OAuthConsent';
+
+/** A {@link ConsentGrantStore} plus the write side an app's consent page needs. */
+export interface PostgresdbConsentStore extends ConsentGrantStore {
+  /**
+   * Record an approval so the restarted `/authorize` request can consume it.
+   * Call this from the consent page's approve handler, before navigating back
+   * to the authorization server's `/authorize`.
+   */
+  saveConsentGrant: (
+    grant: ConsentGrant & { codeChallenge: string }
+  ) => Promise<void>;
+}
+
+/**
+ * Creates a consent store backed by the `oauth_consents` table, for use with
+ * `createRedirectConsentOnAuthorize`.
+ *
+ * Reads and deletes satisfy `ConsentGrantStore`; `saveConsentGrant` covers the
+ * write the consent page performs. Grants are single-use — the `onAuthorize`
+ * hook deletes each one as it consumes it.
+ */
+export const createConsentStore = ({
+  model,
+}: {
+  /** The `OAuthConsent` model class, taken from the app's `db` handle. */
+  model: typeof OAuthConsent;
+}): PostgresdbConsentStore => {
+  return {
+    saveConsentGrant: async ({ codeChallenge, subject, scopes, expiresAt }) => {
+      await model.upsert({
+        codeChallenge,
+        subject,
+        scopes,
+        expiresAt: new Date(expiresAt),
+      });
+    },
+
+    getConsentGrant: async ({ codeChallenge }) => {
+      const row = await model.findByPk(codeChallenge);
+
+      if (!row) {
+        return undefined;
+      }
+
+      return {
+        subject: row.subject,
+        scopes: row.scopes,
+        expiresAt: row.expiresAt.getTime(),
+      };
+    },
+
+    deleteConsentGrant: async ({ codeChallenge }) => {
+      await model.destroy({ where: { codeChallenge } });
+    },
+  };
+};

--- a/packages/auth-postgresdb/src/stores/createRefreshTokenStore.ts
+++ b/packages/auth-postgresdb/src/stores/createRefreshTokenStore.ts
@@ -1,0 +1,63 @@
+import type { RefreshTokenStore } from '@ttoss/auth-core';
+
+import type { OAuthRefreshToken } from '../models/OAuthRefreshToken';
+
+/**
+ * Creates a {@link RefreshTokenStore} backed by the `oauth_refresh_tokens`
+ * table, keyed by token hash and by the `(clientId, subject)` owner that
+ * `deleteByOwner` revokes on reuse detection.
+ */
+export const createRefreshTokenStore = ({
+  model,
+}: {
+  /** The `OAuthRefreshToken` model class, taken from the app's `db` handle. */
+  model: typeof OAuthRefreshToken;
+}): RefreshTokenStore => {
+  return {
+    save: async (token) => {
+      await model.upsert({
+        tokenHash: token.tokenHash,
+        clientId: token.clientId,
+        subject: token.subject,
+        scopes: token.scopes,
+        expiresAt: new Date(token.expiresAt),
+        consumedAt:
+          token.consumedAt === undefined ? null : new Date(token.consumedAt),
+      });
+    },
+
+    get: async (tokenHash) => {
+      const row = await model.findByPk(tokenHash);
+
+      if (!row) {
+        return undefined;
+      }
+
+      return {
+        tokenHash: row.tokenHash,
+        clientId: row.clientId,
+        subject: row.subject,
+        scopes: row.scopes,
+        expiresAt: row.expiresAt.getTime(),
+        /**
+         * The key is omitted, not set to `null`. Rotation tests
+         * `stored.consumedAt !== undefined` to detect reuse, and a nullable
+         * timestamp column reads back as `null` — which would make every live
+         * token look consumed, so the first refresh would be treated as a
+         * replay and revoke the owner's entire token set.
+         */
+        ...(row.consumedAt !== null && {
+          consumedAt: row.consumedAt.getTime(),
+        }),
+      };
+    },
+
+    delete: async (tokenHash) => {
+      await model.destroy({ where: { tokenHash } });
+    },
+
+    deleteByOwner: async ({ clientId, subject }) => {
+      await model.destroy({ where: { clientId, subject } });
+    },
+  };
+};

--- a/packages/auth-postgresdb/tests/tsconfig.json
+++ b/packages/auth-postgresdb/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@ttoss/config/tsconfig.test.json",
+  "compilerOptions": {
+    "paths": {
+      "src/*": ["../src/*"],
+      "tests/*": ["./*"]
+    }
+  }
+}

--- a/packages/auth-postgresdb/tests/unit/babel.config.cjs
+++ b/packages/auth-postgresdb/tests/unit/babel.config.cjs
@@ -1,0 +1,3 @@
+const { babelConfig } = require('@ttoss/config');
+
+module.exports = babelConfig();

--- a/packages/auth-postgresdb/tests/unit/jest.config.ts
+++ b/packages/auth-postgresdb/tests/unit/jest.config.ts
@@ -1,0 +1,25 @@
+import { jestUnitConfig } from '@ttoss/config';
+
+export default jestUnitConfig({
+  /**
+   * Babel cannot transform decorated `declare` fields, so the models are
+   * exercised through the `pretest` bundle — the same pattern
+   * `@terezinha-farm/postgresdb` uses. Coverage therefore measures the store
+   * adapters, which are plain functions.
+   */
+  moduleNameMapper: {
+    '^dist/index$': '<rootDir>/../../dist/index.cjs',
+  },
+  coveragePathIgnorePatterns: [
+    '<rootDir>/../../src/models/',
+    '<rootDir>/../../src/index.ts',
+  ],
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      lines: 100,
+    },
+  },
+});

--- a/packages/auth-postgresdb/tests/unit/tests/createAuthCodeStore.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/createAuthCodeStore.test.ts
@@ -1,0 +1,85 @@
+import { hashAuthorizationCode } from '@ttoss/auth-core';
+import type { OAuthAuthCode } from 'src/models/OAuthAuthCode';
+import { createAuthCodeStore } from 'src/stores/createAuthCodeStore';
+
+const setup = () => {
+  const model = {
+    findByPk: jest.fn(),
+    upsert: jest.fn(),
+    destroy: jest.fn(),
+  };
+  const store = createAuthCodeStore({
+    model: model as unknown as typeof OAuthAuthCode,
+  });
+  return { model, store };
+};
+
+const CODE = 'plaintext-authorization-code';
+const CODE_HASH = hashAuthorizationCode({ code: CODE });
+const EXPIRES_AT = 1_700_000_600_000;
+
+test('persists the code hash, never the code itself', async () => {
+  const { model, store } = setup();
+
+  await store.save({
+    code: CODE,
+    clientId: 'client-1',
+    redirectUri: 'https://claude.ai/callback',
+    codeChallenge: 'challenge',
+    scopes: ['mcp:access'],
+    subject: 'user-1',
+    expiresAt: EXPIRES_AT,
+  });
+
+  expect(model.upsert).toHaveBeenCalledWith({
+    codeHash: CODE_HASH,
+    clientId: 'client-1',
+    redirectUri: 'https://claude.ai/callback',
+    codeChallenge: 'challenge',
+    scopes: ['mcp:access'],
+    subject: 'user-1',
+    expiresAt: new Date(EXPIRES_AT),
+  });
+  expect(JSON.stringify(model.upsert.mock.calls[0])).not.toContain(CODE);
+});
+
+test('looks the row up by hash and echoes the presented code back', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue({
+    codeHash: CODE_HASH,
+    clientId: 'client-1',
+    redirectUri: 'https://claude.ai/callback',
+    codeChallenge: 'challenge',
+    scopes: ['mcp:access'],
+    subject: 'user-1',
+    expiresAt: new Date(EXPIRES_AT),
+  });
+
+  await expect(store.get(CODE)).resolves.toEqual({
+    code: CODE,
+    clientId: 'client-1',
+    redirectUri: 'https://claude.ai/callback',
+    codeChallenge: 'challenge',
+    scopes: ['mcp:access'],
+    subject: 'user-1',
+    expiresAt: EXPIRES_AT,
+  });
+  expect(model.findByPk).toHaveBeenCalledWith(CODE_HASH);
+});
+
+test('resolves undefined for an unknown code', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(null);
+
+  await expect(store.get(CODE)).resolves.toBeUndefined();
+});
+
+test('deletes by hash to enforce single use', async () => {
+  const { model, store } = setup();
+
+  await store.delete(CODE);
+
+  expect(model.destroy).toHaveBeenCalledWith({
+    where: { codeHash: CODE_HASH },
+  });
+});

--- a/packages/auth-postgresdb/tests/unit/tests/createClientStore.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/createClientStore.test.ts
@@ -1,0 +1,137 @@
+import type { OAuthClient } from 'src/models/OAuthClient';
+import { createClientStore } from 'src/stores/createClientStore';
+
+const createModelDouble = () => {
+  return {
+    findByPk: jest.fn(),
+    upsert: jest.fn(),
+    destroy: jest.fn(),
+  };
+};
+
+type ModelDouble = ReturnType<typeof createModelDouble>;
+
+const setup = () => {
+  const model = createModelDouble();
+  const store = createClientStore({
+    model: model as unknown as typeof OAuthClient,
+  });
+  return { model, store };
+};
+
+const row = (overrides: Partial<Record<string, unknown>> = {}) => {
+  return {
+    clientId: 'client-1',
+    clientSecret: 'secret',
+    clientName: 'Claude',
+    redirectUris: ['https://claude.ai/callback'],
+    grantTypes: ['authorization_code', 'refresh_token'],
+    responseTypes: ['code'],
+    tokenEndpointAuthMethod: 'client_secret_post',
+    scope: 'mcp:access',
+    clientIdIssuedAt: 1700000000,
+    metadata: { logo_uri: 'https://claude.ai/logo.png' },
+    ...overrides,
+  };
+};
+
+const upsertedBy = (model: ModelDouble) => {
+  return model.upsert.mock.calls[0]?.[0] as Record<string, unknown>;
+};
+
+test('rebuilds the registration document from its columns', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row());
+
+  await expect(store.get('client-1')).resolves.toEqual({
+    client_id: 'client-1',
+    client_secret: 'secret',
+    client_name: 'Claude',
+    redirect_uris: ['https://claude.ai/callback'],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'client_secret_post',
+    scope: 'mcp:access',
+    client_id_issued_at: 1700000000,
+    logo_uri: 'https://claude.ai/logo.png',
+  });
+  expect(model.findByPk).toHaveBeenCalledWith('client-1');
+});
+
+test('omits absent optional fields instead of reporting them as null', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(
+    row({
+      clientSecret: null,
+      clientName: null,
+      grantTypes: null,
+      responseTypes: null,
+      tokenEndpointAuthMethod: null,
+      scope: null,
+      clientIdIssuedAt: null,
+      metadata: {},
+    })
+  );
+
+  await expect(store.get('client-1')).resolves.toEqual({
+    client_id: 'client-1',
+    redirect_uris: ['https://claude.ai/callback'],
+  });
+});
+
+test('reads a BIGINT client_id_issued_at back as a number', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row({ clientIdIssuedAt: '1700000000' }));
+
+  const client = await store.get('client-1');
+
+  expect(client?.client_id_issued_at).toBe(1700000000);
+});
+
+test('resolves undefined for an unknown client', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(null);
+
+  await expect(store.get('nope')).resolves.toBeUndefined();
+});
+
+test('registers a public client without a secret', async () => {
+  const { model, store } = setup();
+
+  await store.register({
+    client_id: 'client-2',
+    redirect_uris: ['https://cursor.sh/callback'],
+    token_endpoint_auth_method: 'none',
+  });
+
+  expect(upsertedBy(model)).toEqual({
+    clientId: 'client-2',
+    clientSecret: null,
+    clientName: null,
+    redirectUris: ['https://cursor.sh/callback'],
+    grantTypes: null,
+    responseTypes: null,
+    tokenEndpointAuthMethod: 'none',
+    scope: null,
+    clientIdIssuedAt: null,
+    metadata: {},
+  });
+});
+
+test('keeps unregistered metadata fields verbatim', async () => {
+  const { model, store } = setup();
+
+  await store.register({
+    client_id: 'client-3',
+    redirect_uris: ['https://example.com/callback'],
+    client_name: 'Example',
+    client_uri: 'https://example.com',
+    software_id: 'abc',
+  });
+
+  expect(upsertedBy(model).metadata).toEqual({
+    client_uri: 'https://example.com',
+    software_id: 'abc',
+  });
+  expect(upsertedBy(model).clientName).toBe('Example');
+});

--- a/packages/auth-postgresdb/tests/unit/tests/createConsentStore.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/createConsentStore.test.ts
@@ -1,0 +1,71 @@
+import type { OAuthConsent } from 'src/models/OAuthConsent';
+import { createConsentStore } from 'src/stores/createConsentStore';
+
+const setup = () => {
+  const model = {
+    findByPk: jest.fn(),
+    upsert: jest.fn(),
+    destroy: jest.fn(),
+  };
+  const store = createConsentStore({
+    model: model as unknown as typeof OAuthConsent,
+  });
+  return { model, store };
+};
+
+const EXPIRES_AT = 1_700_000_300_000;
+
+test('records an approval against the PKCE challenge', async () => {
+  const { model, store } = setup();
+
+  await store.saveConsentGrant({
+    codeChallenge: 'challenge',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: EXPIRES_AT,
+  });
+
+  expect(model.upsert).toHaveBeenCalledWith({
+    codeChallenge: 'challenge',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: new Date(EXPIRES_AT),
+  });
+});
+
+test('reads a grant back with epoch-millisecond expiry', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue({
+    codeChallenge: 'challenge',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: new Date(EXPIRES_AT),
+  });
+
+  await expect(
+    store.getConsentGrant({ codeChallenge: 'challenge' })
+  ).resolves.toEqual({
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: EXPIRES_AT,
+  });
+});
+
+test('resolves undefined when no consent was recorded', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(null);
+
+  await expect(
+    store.getConsentGrant({ codeChallenge: 'challenge' })
+  ).resolves.toBeUndefined();
+});
+
+test('deletes a consumed grant to keep it single-use', async () => {
+  const { model, store } = setup();
+
+  await store.deleteConsentGrant({ codeChallenge: 'challenge' });
+
+  expect(model.destroy).toHaveBeenCalledWith({
+    where: { codeChallenge: 'challenge' },
+  });
+});

--- a/packages/auth-postgresdb/tests/unit/tests/createPostgresdbOAuthStores.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/createPostgresdbOAuthStores.test.ts
@@ -1,0 +1,43 @@
+import { createPostgresdbOAuthStores } from 'src/createPostgresdbOAuthStores';
+import type { OAuthModels } from 'src/models';
+
+const model = (name: string) => {
+  return {
+    name,
+    findByPk: jest.fn(),
+    upsert: jest.fn(),
+    destroy: jest.fn(),
+  };
+};
+
+const db = {
+  OAuthAuthCode: model('OAuthAuthCode'),
+  OAuthClient: model('OAuthClient'),
+  OAuthConsent: model('OAuthConsent'),
+  OAuthRefreshToken: model('OAuthRefreshToken'),
+};
+
+const stores = createPostgresdbOAuthStores({
+  db: db as unknown as OAuthModels,
+});
+
+test('returns every store createOAuthHandlers and rotation need', () => {
+  expect(Object.keys(stores).sort()).toEqual([
+    'authCodeStore',
+    'clientStore',
+    'consentStore',
+    'refreshTokenStore',
+  ]);
+});
+
+test('wires each store to its own model', async () => {
+  await stores.clientStore.get('client-1');
+  await stores.consentStore.getConsentGrant({ codeChallenge: 'challenge' });
+  await stores.refreshTokenStore.get('hash-1');
+  await stores.authCodeStore.get('code-1');
+
+  expect(db.OAuthClient.findByPk).toHaveBeenCalledWith('client-1');
+  expect(db.OAuthConsent.findByPk).toHaveBeenCalledWith('challenge');
+  expect(db.OAuthRefreshToken.findByPk).toHaveBeenCalledWith('hash-1');
+  expect(db.OAuthAuthCode.findByPk).toHaveBeenCalledTimes(1);
+});

--- a/packages/auth-postgresdb/tests/unit/tests/createRefreshTokenStore.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/createRefreshTokenStore.test.ts
@@ -1,0 +1,213 @@
+import type { OAuthClient as OAuthClientRecord } from '@ttoss/auth-core';
+import { createRefreshRotation } from '@ttoss/auth-core';
+import type { OAuthRefreshToken } from 'src/models/OAuthRefreshToken';
+import { createRefreshTokenStore } from 'src/stores/createRefreshTokenStore';
+
+type Row = {
+  tokenHash: string;
+  clientId: string;
+  subject: string;
+  scopes: string[];
+  expiresAt: Date;
+  consumedAt: Date | null;
+};
+
+/**
+ * A model double backed by a `Map`, reproducing what Postgres gives back: a
+ * nullable timestamp column reads as `null`, never `undefined`.
+ */
+const createFakeModel = () => {
+  const rows = new Map<string, Row>();
+
+  return {
+    rows,
+    findByPk: jest.fn(async (tokenHash: string) => {
+      return rows.get(tokenHash) ?? null;
+    }),
+    upsert: jest.fn(async (values: Row) => {
+      rows.set(values.tokenHash, { ...values });
+    }),
+    destroy: jest.fn(
+      async ({
+        where,
+      }: {
+        where: { tokenHash?: string; clientId?: string; subject?: string };
+      }) => {
+        for (const [tokenHash, row] of rows) {
+          const matches =
+            where.tokenHash !== undefined
+              ? tokenHash === where.tokenHash
+              : row.clientId === where.clientId &&
+                row.subject === where.subject;
+
+          if (matches) {
+            rows.delete(tokenHash);
+          }
+        }
+      }
+    ),
+  };
+};
+
+const setup = () => {
+  const model = createFakeModel();
+  const store = createRefreshTokenStore({
+    model: model as unknown as typeof OAuthRefreshToken,
+  });
+  return { model, store };
+};
+
+const EXPIRES_AT = 1_700_000_000_000;
+
+test('writes a live token with a null consumedAt column', async () => {
+  const { model, store } = setup();
+
+  await store.save({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: EXPIRES_AT,
+  });
+
+  expect(model.rows.get('hash-1')).toEqual({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: new Date(EXPIRES_AT),
+    consumedAt: null,
+  });
+});
+
+test('omits consumedAt for a live token rather than reporting null', async () => {
+  const { store } = setup();
+
+  await store.save({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: EXPIRES_AT,
+  });
+
+  const stored = await store.get('hash-1');
+
+  expect(stored).not.toHaveProperty('consumedAt');
+  expect(stored?.consumedAt).toBeUndefined();
+});
+
+test('round-trips a consumed token as epoch milliseconds', async () => {
+  const { store } = setup();
+
+  await store.save({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: EXPIRES_AT,
+    consumedAt: EXPIRES_AT - 1000,
+  });
+
+  await expect(store.get('hash-1')).resolves.toEqual({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: EXPIRES_AT,
+    consumedAt: EXPIRES_AT - 1000,
+  });
+});
+
+test('resolves undefined for an unknown token', async () => {
+  const { store } = setup();
+
+  await expect(store.get('nope')).resolves.toBeUndefined();
+});
+
+test('deletes one token by hash', async () => {
+  const { model, store } = setup();
+  await store.save({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: [],
+    expiresAt: EXPIRES_AT,
+  });
+
+  await store.delete('hash-1');
+
+  expect(model.rows.size).toBe(0);
+});
+
+test('revokes every token of one owner, leaving other owners alone', async () => {
+  const { model, store } = setup();
+  await store.save({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: [],
+    expiresAt: EXPIRES_AT,
+  });
+  await store.save({
+    tokenHash: 'hash-2',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: [],
+    expiresAt: EXPIRES_AT,
+  });
+  await store.save({
+    tokenHash: 'hash-3',
+    clientId: 'client-1',
+    subject: 'user-2',
+    scopes: [],
+    expiresAt: EXPIRES_AT,
+  });
+
+  await store.deleteByOwner({ clientId: 'client-1', subject: 'user-1' });
+
+  expect([...model.rows.keys()]).toEqual(['hash-3']);
+});
+
+describe('with createRefreshRotation', () => {
+  const client: OAuthClientRecord = {
+    client_id: 'client-1',
+    redirect_uris: ['https://claude.ai/callback'],
+  };
+
+  test('rotates on the first refresh instead of treating it as replay', async () => {
+    const { store } = setup();
+    const refresh = createRefreshRotation({ store });
+
+    const token = await refresh.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['mcp:access'],
+    });
+
+    await expect(
+      refresh.onRefreshToken({ refreshToken: token, client, scopes: [] })
+    ).resolves.toEqual({ subject: 'user-1', scopes: ['mcp:access'] });
+  });
+
+  test('detects reuse of an already-rotated token', async () => {
+    const { model, store } = setup();
+    const refresh = createRefreshRotation({ store });
+
+    const first = await refresh.issue({
+      client,
+      subject: 'user-1',
+      scopes: ['mcp:access'],
+    });
+    await refresh.onRefreshToken({
+      refreshToken: first,
+      client,
+      scopes: [],
+    });
+
+    await expect(
+      refresh.onRefreshToken({ refreshToken: first, client, scopes: [] })
+    ).resolves.toBeUndefined();
+    expect(model.rows.size).toBe(0);
+  });
+});

--- a/packages/auth-postgresdb/tests/unit/tests/models.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/models.test.ts
@@ -1,0 +1,78 @@
+import { Sequelize } from '@ttoss/postgresdb';
+import { oauthModels } from 'dist/index';
+
+/**
+ * Registers the models against a Sequelize instance that never connects, which
+ * is enough to assert the schema the `ttoss-postgresdb sync` CLI will create.
+ */
+const sequelize = new Sequelize({
+  dialect: 'postgres',
+  logging: false,
+  define: { underscored: true },
+  models: Object.values(oauthModels),
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+test('registers every OAuth model on the app connection', () => {
+  expect(Object.keys(oauthModels)).toEqual([
+    'OAuthAuthCode',
+    'OAuthClient',
+    'OAuthConsent',
+    'OAuthRefreshToken',
+  ]);
+});
+
+test.each([
+  [oauthModels.OAuthAuthCode, 'oauth_auth_codes', 'codeHash'],
+  [oauthModels.OAuthClient, 'oauth_clients', 'clientId'],
+  [oauthModels.OAuthConsent, 'oauth_consents', 'codeChallenge'],
+  [oauthModels.OAuthRefreshToken, 'oauth_refresh_tokens', 'tokenHash'],
+])('%# maps to table %s keyed by %s', (model, tableName, primaryKey) => {
+  expect(model.getTableName()).toBe(tableName);
+  expect(model.primaryKeyAttributes).toEqual([primaryKey]);
+});
+
+test('stores hashes, never plaintext codes or tokens', () => {
+  expect(Object.keys(oauthModels.OAuthAuthCode.getAttributes())).not.toContain(
+    'code'
+  );
+  expect(
+    Object.keys(oauthModels.OAuthRefreshToken.getAttributes())
+  ).not.toContain('token');
+});
+
+test('underscores column names so the schema is snake_case', () => {
+  expect(oauthModels.OAuthRefreshToken.getAttributes().consumedAt?.field).toBe(
+    'consumed_at'
+  );
+  expect(oauthModels.OAuthClient.getAttributes().redirectUris?.field).toBe(
+    'redirect_uris'
+  );
+});
+
+test('exposes attributes through Sequelize, unshadowed by class fields', () => {
+  const instance = oauthModels.OAuthRefreshToken.build({
+    tokenHash: 'hash-1',
+    clientId: 'client-1',
+    subject: 'user-1',
+    scopes: ['mcp:access'],
+    expiresAt: new Date(1_700_000_000_000),
+    consumedAt: null,
+  });
+
+  expect(instance.tokenHash).toBe('hash-1');
+  expect(instance.scopes).toEqual(['mcp:access']);
+  expect(instance.consumedAt).toBeNull();
+});
+
+test('keeps a live refresh token consumedAt nullable', () => {
+  expect(
+    oauthModels.OAuthRefreshToken.getAttributes().consumedAt?.allowNull
+  ).toBe(true);
+  expect(
+    oauthModels.OAuthRefreshToken.getAttributes().expiresAt?.allowNull
+  ).toBe(false);
+});

--- a/packages/auth-postgresdb/tsconfig.json
+++ b/packages/auth-postgresdb/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ttoss/config/tsconfig.json"
+}

--- a/packages/auth-postgresdb/tsdown.config.ts
+++ b/packages/auth-postgresdb/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { tsdownConfig } from '@ttoss/config';
+
+export default tsdownConfig({
+  entry: ['src/index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,24 @@ importers:
         specifier: ^0.22.2
         version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
 
+  packages/auth-postgresdb:
+    devDependencies:
+      '@ttoss/auth-core':
+        specifier: workspace:^
+        version: link:../auth-core
+      '@ttoss/config':
+        specifier: workspace:^
+        version: link:../config
+      '@ttoss/postgresdb':
+        specifier: workspace:^
+        version: link:../postgresdb
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+
   packages/aws-appsync-nodejs:
     dependencies:
       '@aws-crypto/sha256-js':
@@ -822,7 +840,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -19394,7 +19412,7 @@ snapshots:
   '@commitlint/is-ignored@21.0.1':
     dependencies:
       '@commitlint/types': 21.0.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@commitlint/lint@21.0.1':
     dependencies:
@@ -22595,7 +22613,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -23386,7 +23404,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.4
 
@@ -24547,7 +24565,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -24558,7 +24576,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -24566,11 +24584,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -24579,13 +24597,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -24593,7 +24611,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
@@ -25326,7 +25344,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -26999,7 +27017,7 @@ snapshots:
   capital-case@1.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
       upper-case-first: 2.0.2
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
@@ -27297,7 +27315,7 @@ snapshots:
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
       upper-case: 2.0.2
 
   content-disposition@0.5.2: {}
@@ -27512,7 +27530,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.15)
       postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
-      semver: 7.8.1
+      semver: 7.8.5
     optionalDependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.23)
       webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(postcss@8.5.15)
@@ -29027,9 +29045,9 @@ snapshots:
     dependencies:
       walk-up-path: 4.0.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   feed@4.2.2:
     dependencies:
@@ -29733,7 +29751,7 @@ snapshots:
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   hermes-estree@0.25.1: {}
 
@@ -30112,7 +30130,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -32136,7 +32154,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   node-abort-controller@3.1.1: {}
 
@@ -32173,7 +32191,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       tar: 7.5.15
       tinyglobby: 0.2.17
       undici: 6.26.0
@@ -32192,7 +32210,7 @@ snapshots:
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
-      semver: 7.8.1
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -32550,7 +32568,7 @@ snapshots:
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   path-data-parser@0.1.0: {}
 
@@ -32853,7 +32871,7 @@ snapshots:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
       postcss: 8.5.15
-      semver: 7.8.1
+      semver: 7.8.5
       webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
@@ -34262,7 +34280,7 @@ snapshots:
 
   semver-diff@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   semver@6.3.1: {}
 
@@ -34291,7 +34309,7 @@ snapshots:
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
       upper-case-first: 2.0.2
 
   sequelize-erd@1.3.1:
@@ -35121,7 +35139,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -35156,13 +35174,13 @@ snapshots:
 
   tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@1.1.1: {}
 
@@ -35321,10 +35339,10 @@ snapshots:
       hookable: 6.1.1
       import-without-cache: 0.4.0
       obug: 2.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rolldown: 1.1.0
       rolldown-plugin-dts: 0.25.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.1.0)(typescript@6.0.3)
-      semver: 7.8.1
+      semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -35666,7 +35684,7 @@ snapshots:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 


### PR DESCRIPTION
Part 1 of 3 from the "Three gaps found while building an MCP OAuth server on ttoss" report.

## Problem

`createOAuthHandlers` needs four app-provided stores, and `@ttoss/auth-core` ships only `Map`-backed implementations ("for tests, local development, and examples"). The one durable store, `createPostgresConsentStore`, takes an injected raw query runner — so an app that already uses `@ttoss/postgresdb` (Sequelize models, `initialize`, the `ttoss-postgresdb sync` CLI) must either reach around its own ORM to inject a `pg` runner or hand-write every store. The report measured that at ~183 lines of adapters plus ~179 lines of models, none of it product-specific.

## Change

New package `@ttoss/auth-postgresdb`, peer-depending on `@ttoss/auth-core` and `@ttoss/postgresdb`:

- **`oauthModels`** — `OAuthClient`, `OAuthAuthCode`, `OAuthConsent`, `OAuthRefreshToken` as sequelize-typescript models. Shipping the classes is what lets `ttoss-postgresdb sync` / `erd` manage these tables instead of them being a side-channel schema the CLI cannot see.
- **`createPostgresdbOAuthStores({ db })`** — returns `clientStore`, `authCodeStore`, `consentStore`, `refreshTokenStore` from the handle `initialize` returns. Each store is also exported individually.

`OAuthClient` keeps the registered RFC 7591 fields in their own columns and preserves any additional submitted metadata in a `metadata` JSONB column, so a registration document round-trips unchanged. Codes and tokens are keyed by SHA-256 hash.

### The two traps the adapters absorb

- **Authorization codes are hashed at rest.** `AuthCodeStore.get` receives the plaintext code, but the engine never compares the returned `code` against anything — it reads only `clientId`, `redirectUri`, `codeChallenge`, `scopes`, `subject`, `expiresAt`. The adapter hashes to find the row and echoes the presented value back, so a database dump yields no replayable codes.
- **A live refresh token omits `consumedAt` rather than reporting `null`.** `createRefreshRotation` treats `stored.consumedAt !== undefined` as reuse; a nullable timestamp column reads back as `null`, which would make every first refresh look like a replay and revoke the owner's entire token set ("refresh works once, then re-authorize forever"). Two tests pin this by driving the real `createRefreshRotation` against the store.

`consentStore` covers the single-use, `code_challenge`-keyed handoff `createRedirectConsentOnAuthorize` consumes, plus the `saveConsentGrant` write a consent page performs. Per the report, the durable per-user/per-client consent record stays app-side.

## Tests

33 tests, 100% statements/branches/functions/lines over the store adapters. `models.test.ts` registers the models on an offline Sequelize instance and asserts table names, primary keys, snake_case columns, that no plaintext `code`/`token` column exists, and — via `Model.build()` — that attributes are not shadowed by emitted class fields.

Babel cannot transform decorated `declare` fields, so the models are exercised through a `pretest` bundle (`moduleNameMapper` → `dist/index.cjs`), the same pattern `@terezinha-farm/postgresdb` and `@ttoss/postgresdb` already use for their models; `src/models` and the re-export barrel are therefore in `coveragePathIgnorePatterns`. Store adapters are plain functions and are covered from `src` directly.

## Docs

`packages/auth-postgresdb/README.md` — install, the `initialize` + `createPostgresdbOAuthStores` wiring, the schema table, and both traps written out. Pointing the OAuth guidelines at this package is left to the docs PR of this series so the three branches don't collide on the same files.

## Notes

Verified with Node 24 (the repo's engine requirement): `pnpm run build` and `pnpm run test` both pass. Under the sandbox's default Node 22, `tsdown` fails for every package in the repo with a `@babel/helper-plugin-utils` link error, unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UgRPAoSwGLDYQv82rad7x)_