### PR TITLE
docs: document four OAuth traps in the MCP and authorization server guidelines

### DIFF
--- a/docs/website/docs/engineering/guidelines/mcp-server-oauth.md
+++ b/docs/website/docs/engineering/guidelines/mcp-server-oauth.md
@@ -112,6 +112,10 @@ const mcpRouter = createMcpRouter(mcpServer, {
 
 Setting both `resourceServerUrl` and `authorizationServerUrl` also serves that metadata document at `/.well-known/oauth-protected-resource`, completing the discovery chain the `WWW-Authenticate` header points to.
 
+**One document per path.** `oauthServer({ resource })` serves `/.well-known/oauth-protected-resource` too, so a deployment that hosts both halves ends up with two routers answering the same path — whichever mounted first wins, and nothing breaks because the bodies agree, which is exactly why nobody notices there are now two sources for one contract. When the authorization server is in the same deployment, set only `resourceMetadataUrl` on the MCP router and let the authorization server serve the document.
+
+**Error envelopes swallow the `401`.** The router rejects with `ctx.throw(401, 'Unauthorized', { headers })`, and an app whose catch-all error middleware recognizes only its own error class turns that into a `500` with no `WWW-Authenticate` header. The client then gets an opaque server error where it expected the pointer to the authorization server, so discovery silently never starts and it reads like a client bug. Run caught values through `toHttpError` and `applyHttpErrorHeaders` from [`@ttoss/http-server`](/docs/modules/packages/http-server) before falling back to `500`.
+
 **`publicMethods` and the OAuth flow.** With the default `['initialize', 'tools/list']`, an OAuth-aware client (Claude connector, Cursor) receives `200` on `initialize` and concludes the server is public — it never starts the OAuth PKCE flow, while `notifications/initialized` still returns `401`, silently breaking the handshake. The visible symptom is "connected, no tools available, no sign-in prompt". Setting `publicMethods: []` makes `initialize` return `401 + WWW-Authenticate`, which is what triggers the client's OAuth discovery and login. Use the default only when auth is handled outside the client-initiated OAuth flow (e.g. API keys or tokens injected by a gateway); set `publicMethods: []` whenever you want the client to authenticate itself before any other interaction.
 
 ## Authorization server: issuing tokens
@@ -131,6 +135,20 @@ createMcpRouter(mcpServer, {
     requiredScopes: ['mcp:access'],
   },
 });
+```
+
+**`requiredScopes` and first-party credentials.** An endpoint that accepts both OAuth tokens and the app's own API keys or session JWTs has a problem: those credentials carry no `scope` claim, so the scope check throws `verifyToken returned no scope/scopes but requiredScopes is set` and the caller gets a `403` for a claim it can never present. Report first-party credentials as holding the required scope in `verifyToken` — they already carry the user's full authority:
+
+```typescript
+verifyToken: async (token) => {
+  const principal = await authenticateBearer(token);
+  return {
+    sub: principal.userId,
+    // Session JWTs and API keys predate OAuth and hold the user's full
+    // authority; without this they fail a scope check they cannot satisfy.
+    scope: (principal.scopes ?? ['mcp:access']).join(' '),
+  };
+},
 ```
 
 ## Choosing your setup

--- a/docs/website/docs/engineering/guidelines/oauth-authorization-server.md
+++ b/docs/website/docs/engineering/guidelines/oauth-authorization-server.md
@@ -141,9 +141,34 @@ const authServer = oauthServer({
 
 The store persists only token hashes — plaintext tokens never touch your database — keyed so the `(clientId, subject)` owner is the unit revoked on reuse.
 
-## In-memory reference stores
+## Stores
 
 `@ttoss/auth-core` ships `createMemoryClientStore`, `createMemoryAuthCodeStore`, and `createMemoryRefreshTokenStore` — `Map`-backed implementations of the three store contracts. They are for tests, local development, and examples (state is lost on restart); production swaps in a durable backend behind the same interfaces.
+
+For Postgres that backend is [`@ttoss/auth-postgresdb`](/docs/modules/packages/auth-postgresdb): register its `oauthModels` alongside your own so `ttoss-postgresdb sync` manages the tables, then build every store from the `db` handle.
+
+```typescript
+import {
+  createPostgresdbOAuthStores,
+  oauthModels,
+} from '@ttoss/auth-postgresdb';
+import { initialize } from '@ttoss/postgresdb';
+
+const db = await initialize({ models: { ...oauthModels, User } });
+
+const { clientStore, authCodeStore, consentStore, refreshTokenStore } =
+  createPostgresdbOAuthStores({ db });
+```
+
+Writing a store by hand? Two details are not obvious from the interfaces. `AuthCodeStore.get` is handed the plaintext code, but the engine reads only the bound metadata off the result — so hash the code to look the row up and echo the presented value back, because a code that travels through a browser redirect must not sit in the database in plaintext. And a live refresh token's `consumedAt` must be **absent**, never `null`: rotation treats `consumedAt !== undefined` as reuse, so a nullable timestamp column makes the first refresh look like a replay and revokes the owner's whole token set.
+
+## Deferred consent screens
+
+`createRedirectConsentOnAuthorize` sends the user to an external consent page with the OAuth parameters — including `redirect_uri` — on the query string, and consumes the approval it records (see `ConsentGrantStore`). Two rules keep that page safe.
+
+**Never navigate to `redirect_uri`.** The consent page cannot distinguish a genuine redirect from `/authorize` from a URL an attacker built and sent to a victim, so using that parameter to navigate turns an authenticated page into an open redirector. On approval, navigate to the authorization server's own `/authorize` with the parameters it was handed — the server re-validates `redirect_uri` against the registered client, so a forged one fails there. On cancel, render a terminal "nothing was connected" state; losing the OAuth-conformant `error=access_denied` redirect is the correct trade.
+
+**Render sign-in in place.** If the consent route redirects an unauthenticated visitor to `/login`, the OAuth parameters have to be carried there and back — threading a single-use PKCE challenge through a redirect chain where it can land in logs or a `Referer` header. Render the sign-in form on the consent route instead, so the query string stays in exactly one place.
 
 ## Scopes
 


### PR DESCRIPTION
Part 3 of 3 from the "Three gaps found while building an MCP OAuth server on ttoss" report. Docs only.

All four traps cost real debugging time on an app built by following these guidelines, and the first two are caused by combinations the guidelines actively suggest.

## `mcp-server-oauth.md`

- **Enforcing scopes** — `requiredScopes` fails first-party credentials. An endpoint that also accepts the app's own API keys or session JWTs (which the "opaque API tokens work the same way" note encourages) gets `verifyToken returned no scope/scopes but requiredScopes is set` and answers `403` for a claim the caller can never present. Shows the one-line fix in `verifyToken`.
- **Client discovery** — two protected-resource documents at one path. `oauthServer({ resource })` and `createMcpRouter({ auth: { resourceServerUrl, authorizationServerUrl } })` both serve `/.well-known/oauth-protected-resource`; whichever mounts first wins and the bodies agree, so one contract quietly gets two sources. Says explicitly to set only `resourceMetadataUrl` when the authorization server is in the same deployment.
- **Client discovery** — a custom error envelope turns the router's `401` into a `500` and drops `WWW-Authenticate`, so discovery never starts and it reads like a client bug. Points at `toHttpError` / `applyHttpErrorHeaders`.

## `oauth-authorization-server.md`

- **In-memory reference stores → Stores** — points at the durable Postgres backend with the `initialize` + `createPostgresdbOAuthStores` snippet, and states the two contract details invisible in the interfaces: hash authorization codes at rest and echo the presented value back, and report a live refresh token's `consumedAt` as absent rather than `null` (rotation treats `!== undefined` as reuse, so `null` makes the first refresh revoke the owner's whole token set).
- **New "Deferred consent screens" section** — the consent page must never navigate to `redirect_uri` (it cannot tell a genuine redirect from an attacker-built URL, so that would make an authenticated page an open redirector): approve navigates back to the AS's own `/authorize`, which re-validates the URI against the registered client, and cancel renders a terminal state. And sign-in renders in place, so a single-use PKCE challenge is not threaded through a redirect chain where it can land in logs or a `Referer`.

## Forward references

Two links point at APIs from the other PRs in this series: `toHttpError` / `applyHttpErrorHeaders` (#1178) and `@ttoss/auth-postgresdb` (#1179). Merge those first, or ask and I will drop the paragraphs that reference them.

Prettier passes on both files.

---
_Generated by [Claude Code](https://claude.ai/code/session_013UgRPAoSwGLDYQv82rad7x)_