### PR TITLE
fix(auth): hash client secrets at rest instead of storing plaintext

### DIFF
--- a/docs/website/docs/engineering/guidelines/oauth-authorization-server.md
+++ b/docs/website/docs/engineering/guidelines/oauth-authorization-server.md
@@ -103,6 +103,8 @@ Clients bootstrap by fetching metadata, so they need no manual configuration. Th
 
 `POST /register` ([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)) lets clients self-register: they post their `redirect_uris` and metadata, and the server issues a `client_id` (plus a `client_secret` for confidential clients) and persists it via `clientStore.register`. Your `ClientStore` only needs `get(clientId)` and `register(client)` — back it with DynamoDB, Postgres, or anything else.
 
+Implement the optional `verifyClientSecret({ clientId, clientSecret })` to keep secrets hashed at rest: the server hands over the value the client presented and your store compares it against its own stored form with `verifyClientSecret` from `@ttoss/auth-core`, so the raw secret never has to be recoverable. Without it the server compares the `client_secret` your `get` returns, which means the store must keep that value recoverable. `@ttoss/auth-postgresdb` implements it, so `client_secret_hash` is all its `oauth_clients` table holds.
+
 ## Authorization endpoint and PKCE
 
 `GET /authorize` validates the `client_id` and `redirect_uri` against the store, then calls your `onAuthorize` hook with the request and its headers. Return `{ approved: true, subject }` once the user is authenticated and has consented — the server issues a single-use code bound to the user, the requested scopes, and the PKCE challenge. Return `{ approved: false, redirect }` to send the user to your own login page (or `{ approved: false, status, body }` for an inline response); the adapter performs it. **PKCE S256 is mandatory** ([RFC 7636](https://www.rfc-editor.org/rfc/rfc7636)): the `code_challenge` is bound to the code and verified at the token endpoint, so codes are useless if intercepted.

--- a/packages/auth-core/README.md
+++ b/packages/auth-core/README.md
@@ -309,6 +309,12 @@ const res = await oauth.token({ query: {}, body, headers }); // { status, body }
 
 Your app keeps its user model, signing keys, and login/consent UI behind the hooks. See the [OAuth Authorization Server](https://ttoss.dev/docs/engineering/guidelines/oauth-authorization-server) guideline for the full flow.
 
+### Client secrets
+
+`hashClientSecret` and `verifyClientSecret` hash a `client_secret` with SHA-256 and compare a presented value against a stored hash in constant time. Plain SHA-256 is deliberate: a registered secret is 32 random bytes, so there is no low-entropy guess space for `hashPassword`'s PBKDF2 to slow down.
+
+Implement the optional `ClientStore.verifyClientSecret` to use them, and the raw secret never has to be recoverable — the engine hands your store the presented value instead of comparing the one `get` returned. A store that omits the method makes the engine fall back to comparing `get`'s `client_secret`, which requires keeping that value recoverable.
+
 ### Refresh token rotation
 
 `createRefreshRotation` implements opaque, server-stored refresh tokens with OAuth 2.1 rotation against any `RefreshTokenStore`: single use, expiry, scope narrowing, and reuse detection (replaying a rotated token revokes the owner's whole token set). Only token hashes are persisted. Wire `issue` into `issueTokens` and pass the ready `onRefreshToken` straight through.

--- a/packages/auth-core/src/authenticateClient.ts
+++ b/packages/auth-core/src/authenticateClient.ts
@@ -1,0 +1,60 @@
+import { timingSafeStringEqual } from './oauth';
+import type {
+  ClientStore,
+  OAuthClient,
+  OAuthRequest,
+} from './oauthServerTypes';
+
+/** Narrows an untyped request value to a string, or `undefined`. */
+export const asString = (value: unknown): string | undefined => {
+  return typeof value === 'string' ? value : undefined;
+};
+
+/**
+ * Authenticates the client at the token endpoint via `client_secret_basic`
+ * (Authorization header), `client_secret_post` (body), or `none` (public,
+ * PKCE-only). Returns the client, or `undefined` when authentication fails.
+ */
+export const authenticateClient = async (
+  request: OAuthRequest,
+  clientStore: ClientStore
+): Promise<OAuthClient | undefined> => {
+  let clientId = asString(request.body.client_id);
+  let clientSecret = asString(request.body.client_secret);
+
+  const authHeader = request.headers.authorization;
+  if (authHeader?.startsWith('Basic ')) {
+    const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
+    const separatorIndex = decoded.indexOf(':');
+    if (separatorIndex !== -1) {
+      clientId = decodeURIComponent(decoded.slice(0, separatorIndex));
+      clientSecret = decodeURIComponent(decoded.slice(separatorIndex + 1));
+    }
+  }
+
+  if (!clientId) {
+    return undefined;
+  }
+
+  const client = await clientStore.get(clientId);
+  if (!client) {
+    return undefined;
+  }
+
+  /**
+   * Confidential clients must present the matching secret. A store that keeps
+   * secrets hashed at rest owns the comparison — it cannot return the raw value
+   * for the engine to compare. Otherwise fall back to comparing the recoverable
+   * `client_secret` the store returned, in constant time.
+   */
+  const secretVerified = clientStore.verifyClientSecret
+    ? await clientStore.verifyClientSecret({ clientId, clientSecret })
+    : !client.client_secret ||
+      timingSafeStringEqual(client.client_secret, clientSecret);
+
+  if (!secretVerified) {
+    return undefined;
+  }
+
+  return client;
+};

--- a/packages/auth-core/src/index.ts
+++ b/packages/auth-core/src/index.ts
@@ -58,12 +58,14 @@ export {
   generateAuthorizationCode,
   type GeneratedAuthorizationCode,
   hashAuthorizationCode,
+  hashClientSecret,
   OAuthError,
   type OAuthErrorCode,
   oauthErrorCodes,
   type Rfc8414Metadata,
   type Rfc9728Metadata,
   validateRedirectUri,
+  verifyClientSecret,
   verifyPkceChallenge,
 } from './oauth';
 export {

--- a/packages/auth-core/src/oauth.ts
+++ b/packages/auth-core/src/oauth.ts
@@ -62,6 +62,69 @@ export const generateAuthorizationCode = (): GeneratedAuthorizationCode => {
 };
 
 // ---------------------------------------------------------------------------
+// Client secrets (RFC 6749 §2.3.1) — hashed at rest, compared by hash
+// ---------------------------------------------------------------------------
+
+/**
+ * Compares two secrets without leaking their contents through timing. Length is
+ * still observable, as it is everywhere else in this package.
+ *
+ * Internal: not re-exported from the package entry point.
+ */
+export const timingSafeStringEqual = (
+  expected: string,
+  presented: string | undefined
+): boolean => {
+  if (!presented) {
+    return false;
+  }
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(presented, 'utf8');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+};
+
+/**
+ * Hashes a `client_secret` with SHA-256 (hex output).
+ *
+ * Plain SHA-256 is the right primitive here, not `hashPassword`'s PBKDF2: a
+ * secret issued by `handleRegister` is 32 random bytes, so there is no
+ * low-entropy guess space for a key-derivation function to slow down.
+ */
+export const hashClientSecret = (args: { clientSecret: string }): string => {
+  return crypto.createHash('sha256').update(args.clientSecret).digest('hex');
+};
+
+/**
+ * Verifies a presented `client_secret` against a stored SHA-256 hash in
+ * constant time.
+ *
+ * Returns `false` for an absent or empty presented secret, so a confidential
+ * client can never authenticate by omitting the credential.
+ */
+export const verifyClientSecret = (args: {
+  /** The secret presented at the token endpoint. */
+  clientSecret: string | undefined;
+  /** The stored SHA-256 hex hash to compare against. */
+  clientSecretHash: string;
+}): boolean => {
+  if (!args.clientSecret) {
+    return false;
+  }
+  const a = Buffer.from(
+    hashClientSecret({ clientSecret: args.clientSecret }),
+    'hex'
+  );
+  const b = Buffer.from(args.clientSecretHash, 'hex');
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+};
+
+// ---------------------------------------------------------------------------
 // Redirect URI validation (RFC 6749 §4.1.2.1) — exact match, no wildcards
 // ---------------------------------------------------------------------------
 

--- a/packages/auth-core/src/oauthServer.ts
+++ b/packages/auth-core/src/oauthServer.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
 
+import { asString, authenticateClient } from './authenticateClient';
 import { verifyPkceChallenge } from './oauth';
 import type {
   ClientStore,
@@ -31,10 +32,6 @@ const generateToken = (bytes = 32): string => {
 
 const joinUrl = (issuer: string, path: string): string => {
   return `${issuer.replace(/\/$/, '')}${path}`;
-};
-
-const asString = (value: unknown): string | undefined => {
-  return typeof value === 'string' ? value : undefined;
 };
 
 const parseScopes = (scope: unknown): string[] => {
@@ -76,45 +73,6 @@ const redirectWithParams = (
     }
   }
   return url.toString();
-};
-
-/**
- * Authenticates the client at the token endpoint via `client_secret_basic`
- * (Authorization header), `client_secret_post` (body), or `none` (public,
- * PKCE-only). Returns the client, or `undefined` when authentication fails.
- */
-const authenticateClient = async (
-  request: OAuthRequest,
-  clientStore: ClientStore
-): Promise<OAuthClient | undefined> => {
-  let clientId = asString(request.body.client_id);
-  let clientSecret = asString(request.body.client_secret);
-
-  const authHeader = request.headers.authorization;
-  if (authHeader?.startsWith('Basic ')) {
-    const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
-    const separatorIndex = decoded.indexOf(':');
-    if (separatorIndex !== -1) {
-      clientId = decodeURIComponent(decoded.slice(0, separatorIndex));
-      clientSecret = decodeURIComponent(decoded.slice(separatorIndex + 1));
-    }
-  }
-
-  if (!clientId) {
-    return undefined;
-  }
-
-  const client = await clientStore.get(clientId);
-  if (!client) {
-    return undefined;
-  }
-
-  // Confidential clients must present the matching secret.
-  if (client.client_secret && client.client_secret !== clientSecret) {
-    return undefined;
-  }
-
-  return client;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/auth-core/src/oauthServerTypes.ts
+++ b/packages/auth-core/src/oauthServerTypes.ts
@@ -79,12 +79,38 @@ export interface OAuthClient extends OAuthClientMetadata {
  * app owns persistence (DynamoDB, Postgres, in-memory, …).
  */
 export interface ClientStore {
-  /** Look up a client by its `client_id`. Return `undefined` if unknown. */
+  /**
+   * Look up a client by its `client_id`. Return `undefined` if unknown.
+   *
+   * A store that implements {@link ClientStore.verifyClientSecret} should omit
+   * `client_secret` from the returned document — the core never needs the raw
+   * value, and leaving it out keeps it from reaching consent screens or logs.
+   */
   get: (
     clientId: string
   ) => Promise<OAuthClient | undefined> | OAuthClient | undefined;
   /** Persist a newly registered client. */
   register: (client: OAuthClient) => Promise<void> | void;
+  /**
+   * Verifies a `client_secret` presented at the token endpoint. Implement this
+   * to keep secrets hashed at rest: the core hands over the presented value and
+   * the store compares it against its own stored form, so the raw secret never
+   * has to be recoverable.
+   *
+   * Return `true` for a public client (one registered with
+   * `token_endpoint_auth_method: 'none'`, which has no secret to present), and
+   * `false` for an unknown `client_id`.
+   *
+   * When omitted, the core falls back to a constant-time comparison against the
+   * `client_secret` returned by {@link ClientStore.get} — which requires the
+   * store to keep the secret recoverable.
+   */
+  verifyClientSecret?: (args: {
+    /** The `client_id` being authenticated. */
+    clientId: string;
+    /** The secret presented by the client, absent when none was sent. */
+    clientSecret: string | undefined;
+  }) => Promise<boolean> | boolean;
 }
 
 /**

--- a/packages/auth-core/tests/unit/jest.config.ts
+++ b/packages/auth-core/tests/unit/jest.config.ts
@@ -3,10 +3,10 @@ import { jestUnitConfig } from '@ttoss/config';
 export default jestUnitConfig({
   coverageThreshold: {
     global: {
-      statements: 99,
-      branches: 97.9,
+      statements: 99.1,
+      branches: 97.95,
       functions: 100,
-      lines: 99,
+      lines: 99.1,
     },
   },
 });

--- a/packages/auth-core/tests/unit/tests/oauth.test.ts
+++ b/packages/auth-core/tests/unit/tests/oauth.test.ts
@@ -5,9 +5,11 @@ import {
   buildProtectedResourceMetadata,
   generateAuthorizationCode,
   hashAuthorizationCode,
+  hashClientSecret,
   OAuthError,
   oauthErrorCodes,
   validateRedirectUri,
+  verifyClientSecret,
   verifyPkceChallenge,
 } from 'src/oauth';
 
@@ -289,5 +291,48 @@ describe('buildProtectedResourceMetadata', () => {
     });
     expect(meta.resource).toBe('https://mcp.example.com');
     expect(meta.authorization_servers).toEqual(['https://auth.example.com']);
+  });
+});
+
+describe('hashClientSecret / verifyClientSecret', () => {
+  const clientSecret = 'a'.repeat(64);
+  const clientSecretHash = hashClientSecret({ clientSecret });
+
+  test('hashes with SHA-256 hex, matching the reference digest', () => {
+    expect(clientSecretHash).toBe(
+      crypto.createHash('sha256').update(clientSecret).digest('hex')
+    );
+  });
+
+  test('is deterministic', () => {
+    expect(hashClientSecret({ clientSecret })).toBe(clientSecretHash);
+  });
+
+  test('accepts the matching secret', () => {
+    expect(verifyClientSecret({ clientSecret, clientSecretHash })).toBe(true);
+  });
+
+  test('rejects a different secret of the same length', () => {
+    expect(
+      verifyClientSecret({ clientSecret: 'b'.repeat(64), clientSecretHash })
+    ).toBe(false);
+  });
+
+  test('rejects an absent secret', () => {
+    expect(
+      verifyClientSecret({ clientSecret: undefined, clientSecretHash })
+    ).toBe(false);
+  });
+
+  test('rejects an empty secret', () => {
+    expect(verifyClientSecret({ clientSecret: '', clientSecretHash })).toBe(
+      false
+    );
+  });
+
+  test('rejects a malformed stored hash instead of throwing', () => {
+    expect(
+      verifyClientSecret({ clientSecret, clientSecretHash: 'not-a-hash' })
+    ).toBe(false);
   });
 });

--- a/packages/auth-core/tests/unit/tests/oauthServer.test.ts
+++ b/packages/auth-core/tests/unit/tests/oauthServer.test.ts
@@ -5,9 +5,11 @@ import {
   type ClientStore,
   createOAuthHandlers,
   getWwwAuthenticateHeader,
+  hashClientSecret,
   type OAuthClient,
   type OAuthServerOptions,
   type StoredAuthorizationCode,
+  verifyClientSecret,
 } from '../../../src/index';
 
 const base64Url = (buffer: Buffer): string => {
@@ -447,6 +449,116 @@ describe('createOAuthHandlers — token (authorization_code)', () => {
       redirect_uri: 'https://app.example.com/callback',
       client_id: 'client-abc',
       client_secret: 'wrong',
+      code_verifier: CODE_VERIFIER,
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  /**
+   * A store that keeps secrets hashed at rest: it cannot return
+   * `client_secret`, so it owns the comparison via `verifyClientSecret`.
+   */
+  const createHashingClientStore = (): ClientStore => {
+    const hashes = new Map<string, string | null>([
+      ['client-abc', hashClientSecret({ clientSecret: 'secret-xyz' })],
+      ['public-client', null],
+    ]);
+    return {
+      get: (clientId) => {
+        if (!hashes.has(clientId)) {
+          return undefined;
+        }
+        return clientId === 'public-client'
+          ? publicClient
+          : { ...confidentialClient, client_secret: undefined };
+      },
+      register: (client) => {
+        hashes.set(
+          client.client_id,
+          client.client_secret
+            ? hashClientSecret({ clientSecret: client.client_secret })
+            : null
+        );
+      },
+      verifyClientSecret: ({ clientId, clientSecret }) => {
+        const clientSecretHash = hashes.get(clientId);
+        if (clientSecretHash === undefined) {
+          return false;
+        }
+        return (
+          clientSecretHash === null ||
+          verifyClientSecret({ clientSecret, clientSecretHash })
+        );
+      },
+    };
+  };
+
+  test('delegates to verifyClientSecret when the store hashes secrets', async () => {
+    const server = setup({ clientStore: createHashingClientStore() });
+    const code = await obtainCode(server);
+    const res = await token(server, {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: 'https://app.example.com/callback',
+      client_id: 'client-abc',
+      client_secret: 'secret-xyz',
+      code_verifier: CODE_VERIFIER,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('401 invalid_client when a hashing store rejects the secret', async () => {
+    const server = setup({ clientStore: createHashingClientStore() });
+    const code = await obtainCode(server);
+    const res = await token(server, {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: 'https://app.example.com/callback',
+      client_id: 'client-abc',
+      client_secret: 'secret-abc',
+      code_verifier: CODE_VERIFIER,
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  test('a hashing store still admits a public client with no secret', async () => {
+    const server = setup({ clientStore: createHashingClientStore() });
+    const code = await obtainCode(server, 'public-client');
+    const res = await token(server, {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: 'https://app.example.com/callback',
+      client_id: 'public-client',
+      code_verifier: CODE_VERIFIER,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('401 invalid_client when a same-length secret is wrong', async () => {
+    const server = setup();
+    const code = await obtainCode(server);
+    const res = await token(server, {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: 'https://app.example.com/callback',
+      client_id: 'client-abc',
+      client_secret: 'secret-abc',
+      code_verifier: CODE_VERIFIER,
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  test('401 invalid_client when a confidential client sends no secret', async () => {
+    const server = setup();
+    const code = await obtainCode(server);
+    const res = await token(server, {
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: 'https://app.example.com/callback',
+      client_id: 'client-abc',
       code_verifier: CODE_VERIFIER,
     });
     expect(res.status).toBe(401);

--- a/packages/auth-postgresdb/README.md
+++ b/packages/auth-postgresdb/README.md
@@ -57,11 +57,15 @@ Each store is also exported on its own (`createClientStore`, `createAuthCodeStor
 | `OAuthConsent`      | `oauth_consents`       | `code_challenge` |
 | `OAuthRefreshToken` | `oauth_refresh_tokens` | `token_hash`     |
 
-Credentials are stored by SHA-256 hash, never in plaintext, so a database dump yields nothing replayable. `OAuthClient` keeps the registered RFC 7591 fields in their own columns and any additional submitted metadata in a `metadata` JSONB column, so a registration document round-trips unchanged.
+Every credential — authorization codes (`code_hash`), refresh tokens (`token_hash`), and client secrets (`client_secret_hash`) — is stored by SHA-256 hash, never in plaintext, so a database dump yields nothing replayable. `OAuthClient` keeps the registered RFC 7591 fields in their own columns and any additional submitted metadata in a `metadata` JSONB column, so a registration document round-trips unchanged.
 
-## Two traps these adapters absorb
+## Three traps these adapters absorb
 
 **Authorization codes are hashed at rest.** `AuthCodeStore.get` is handed the plaintext code, but a code travels through a browser redirect and a client's URL bar. The engine never compares the returned `code` against anything — it reads only `clientId`, `redirectUri`, `codeChallenge`, `scopes`, `subject`, and `expiresAt` — so the adapter hashes to find the row and echoes the presented value back.
+
+**Client secrets are hashed at rest too, which takes a different mechanism.** A secret _is_ compared, so the adapter cannot simply hash the row away and echo the presented value back. Instead `clientStore` implements `ClientStore.verifyClientSecret`: the engine hands over the presented secret and the store compares it against the stored hash in constant time, so the raw value never has to be recoverable. Consequently `get` omits `client_secret` from the document it returns — nothing in the engine needs it, since the registration response echoes the secret from the document it just generated rather than from a read.
+
+Implementing `verifyClientSecret` is what makes hashing possible at all. A store that omits it falls back to the engine comparing the `client_secret` returned by `get`, which forces the store to keep the secret recoverable — plaintext, or encrypted with a key the app has to manage.
 
 **A live refresh token reports no `consumedAt` at all.** `createRefreshRotation` treats `stored.consumedAt !== undefined` as reuse. A nullable timestamp column reads back as `null`, which is `!== undefined`, so a naive adapter makes every live token look consumed: the first refresh is treated as a replay and revokes the owner's entire token set — "refresh works once, then the client must re-authorize forever". The adapter omits the key instead of setting it to `null`.
 

--- a/packages/auth-postgresdb/src/models/OAuthClient.ts
+++ b/packages/auth-postgresdb/src/models/OAuthClient.ts
@@ -21,14 +21,18 @@ export class OAuthClient extends Model {
   declare clientId: string;
 
   /**
-   * Client secret for confidential clients, `null` for public clients
-   * (`token_endpoint_auth_method: 'none'`).
+   * SHA-256 hash (hex) of the client secret for confidential clients, `null`
+   * for public clients (`token_endpoint_auth_method: 'none'`).
+   *
+   * The secret itself is never stored: the token endpoint only ever compares a
+   * presented value, so a hash is enough and a database dump yields nothing
+   * replayable.
    */
   @Column({
     type: DataType.STRING,
     allowNull: true,
   })
-  declare clientSecret: string | null;
+  declare clientSecretHash: string | null;
 
   /** Human-readable client name shown on consent screens. */
   @Column({

--- a/packages/auth-postgresdb/src/stores/createClientStore.ts
+++ b/packages/auth-postgresdb/src/stores/createClientStore.ts
@@ -2,12 +2,16 @@ import type {
   ClientStore,
   OAuthClient as OAuthClientRecord,
 } from '@ttoss/auth-core';
+import { hashClientSecret, verifyClientSecret } from '@ttoss/auth-core';
 
 import type { OAuthClient } from '../models/OAuthClient';
 
 /**
  * Registration fields that have their own column. Everything else a client
  * submits goes to `metadata`, so the document round-trips unchanged.
+ *
+ * `client_secret` is listed here even though no column holds it verbatim: it
+ * must never fall through to the `metadata` JSONB, which would defeat hashing.
  */
 const COLUMN_FIELDS = [
   'client_id',
@@ -26,7 +30,6 @@ const toRecord = (row: OAuthClient): OAuthClientRecord => {
     ...row.metadata,
     client_id: row.clientId,
     redirect_uris: row.redirectUris,
-    ...(row.clientSecret !== null && { client_secret: row.clientSecret }),
     ...(row.clientName !== null && { client_name: row.clientName }),
     ...(row.grantTypes !== null && { grant_types: row.grantTypes }),
     ...(row.responseTypes !== null && { response_types: row.responseTypes }),
@@ -53,7 +56,14 @@ const toMetadata = (client: OAuthClientRecord): Record<string, unknown> => {
 };
 
 /**
- * Creates a {@link ClientStore} backed by the `oauth_clients` table.
+ * Creates a {@link ClientStore} backed by the `oauth_clients` table, storing
+ * client secrets by SHA-256 hash.
+ *
+ * Because the secret is not recoverable, `get` omits `client_secret` and client
+ * authentication goes through `verifyClientSecret`, which compares the
+ * presented value against the stored hash. The engine only ever needs that
+ * comparison — the registration response echoes the secret from the document it
+ * just generated, never from a read — so nothing is lost by not keeping it.
  *
  * `register` upserts, so re-registering an existing `client_id` replaces the
  * stored document rather than failing on the primary key.
@@ -71,10 +81,30 @@ export const createClientStore = ({
       return row ? toRecord(row) : undefined;
     },
 
+    verifyClientSecret: async ({ clientId, clientSecret }) => {
+      const row = await model.findByPk(clientId);
+
+      if (!row) {
+        return false;
+      }
+
+      // A public client has no secret to present.
+      if (row.clientSecretHash === null) {
+        return true;
+      }
+
+      return verifyClientSecret({
+        clientSecret,
+        clientSecretHash: row.clientSecretHash,
+      });
+    },
+
     register: async (client) => {
       await model.upsert({
         clientId: client.client_id,
-        clientSecret: client.client_secret ?? null,
+        clientSecretHash: client.client_secret
+          ? hashClientSecret({ clientSecret: client.client_secret })
+          : null,
         clientName: client.client_name ?? null,
         redirectUris: client.redirect_uris,
         grantTypes: client.grant_types ?? null,

--- a/packages/auth-postgresdb/tests/unit/tests/createClientStore.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/createClientStore.test.ts
@@ -1,3 +1,4 @@
+import { hashClientSecret } from '@ttoss/auth-core';
 import type { OAuthClient } from 'src/models/OAuthClient';
 import { createClientStore } from 'src/stores/createClientStore';
 
@@ -22,7 +23,7 @@ const setup = () => {
 const row = (overrides: Partial<Record<string, unknown>> = {}) => {
   return {
     clientId: 'client-1',
-    clientSecret: 'secret',
+    clientSecretHash: hashClientSecret({ clientSecret: 'secret' }),
     clientName: 'Claude',
     redirectUris: ['https://claude.ai/callback'],
     grantTypes: ['authorization_code', 'refresh_token'],
@@ -45,7 +46,6 @@ test('rebuilds the registration document from its columns', async () => {
 
   await expect(store.get('client-1')).resolves.toEqual({
     client_id: 'client-1',
-    client_secret: 'secret',
     client_name: 'Claude',
     redirect_uris: ['https://claude.ai/callback'],
     grant_types: ['authorization_code', 'refresh_token'],
@@ -62,7 +62,7 @@ test('omits absent optional fields instead of reporting them as null', async () 
   const { model, store } = setup();
   model.findByPk.mockResolvedValue(
     row({
-      clientSecret: null,
+      clientSecretHash: null,
       clientName: null,
       grantTypes: null,
       responseTypes: null,
@@ -106,7 +106,7 @@ test('registers a public client without a secret', async () => {
 
   expect(upsertedBy(model)).toEqual({
     clientId: 'client-2',
-    clientSecret: null,
+    clientSecretHash: null,
     clientName: null,
     redirectUris: ['https://cursor.sh/callback'],
     grantTypes: null,
@@ -134,4 +134,87 @@ test('keeps unregistered metadata fields verbatim', async () => {
     software_id: 'abc',
   });
   expect(upsertedBy(model).clientName).toBe('Example');
+});
+
+test('stores the client secret hashed, never in plaintext', async () => {
+  const { model, store } = setup();
+
+  await store.register({
+    client_id: 'client-4',
+    client_secret: 'super-secret',
+    redirect_uris: ['https://example.com/callback'],
+  });
+
+  const upserted = upsertedBy(model);
+
+  expect(upserted.clientSecretHash).toBe(
+    hashClientSecret({ clientSecret: 'super-secret' })
+  );
+  expect(JSON.stringify(upserted)).not.toContain('super-secret');
+});
+
+test('omits client_secret from the document it reads back', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row());
+
+  const client = await store.get('client-1');
+
+  expect(client).not.toHaveProperty('client_secret');
+});
+
+test('accepts a confidential client presenting the matching secret', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row());
+
+  await expect(
+    store.verifyClientSecret?.({
+      clientId: 'client-1',
+      clientSecret: 'secret',
+    })
+  ).resolves.toBe(true);
+});
+
+test('rejects a confidential client presenting the wrong secret', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row());
+
+  await expect(
+    store.verifyClientSecret?.({
+      clientId: 'client-1',
+      clientSecret: 'wrong',
+    })
+  ).resolves.toBe(false);
+});
+
+test('rejects a confidential client presenting no secret at all', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row());
+
+  await expect(
+    store.verifyClientSecret?.({
+      clientId: 'client-1',
+      clientSecret: undefined,
+    })
+  ).resolves.toBe(false);
+});
+
+test('accepts a public client, which has no secret to present', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(row({ clientSecretHash: null }));
+
+  await expect(
+    store.verifyClientSecret?.({
+      clientId: 'client-1',
+      clientSecret: undefined,
+    })
+  ).resolves.toBe(true);
+});
+
+test('rejects an unknown client', async () => {
+  const { model, store } = setup();
+  model.findByPk.mockResolvedValue(null);
+
+  await expect(
+    store.verifyClientSecret?.({ clientId: 'nope', clientSecret: 'secret' })
+  ).resolves.toBe(false);
 });

--- a/packages/auth-postgresdb/tests/unit/tests/models.test.ts
+++ b/packages/auth-postgresdb/tests/unit/tests/models.test.ts
@@ -35,13 +35,20 @@ test.each([
   expect(model.primaryKeyAttributes).toEqual([primaryKey]);
 });
 
-test('stores hashes, never plaintext codes or tokens', () => {
+test('stores hashes, never plaintext codes, tokens, or secrets', () => {
   expect(Object.keys(oauthModels.OAuthAuthCode.getAttributes())).not.toContain(
     'code'
   );
   expect(
     Object.keys(oauthModels.OAuthRefreshToken.getAttributes())
   ).not.toContain('token');
+
+  const clientAttributes = Object.keys(oauthModels.OAuthClient.getAttributes());
+  expect(clientAttributes).not.toContain('clientSecret');
+  expect(clientAttributes).toContain('clientSecretHash');
+  expect(oauthModels.OAuthClient.getAttributes().clientSecretHash?.field).toBe(
+    'client_secret_hash'
+  );
 });
 
 test('underscores column names so the schema is snake_case', () => {


### PR DESCRIPTION
## Problem

`@ttoss/auth-postgresdb`'s `createClientStore` persisted a confidential client's `client_secret` verbatim in `oauth_clients` and returned it verbatim on read, unlike the auth code and refresh token stores in the same package. A database dump yielded every client secret directly, letting an attacker impersonate any client at the token endpoint — and the package README's claim that "credentials are stored by SHA-256 hash, never in plaintext" was untrue of one of its four tables.

## Why this couldn't be fixed in the adapter alone

`authenticateClient` compared the plaintext value that `ClientStore.get` returned:

```ts
if (client.client_secret && client.client_secret !== clientSecret) return undefined;
```

A store that hashed at rest had nothing valid to return, so hashing was structurally impossible for *any* store, app-provided or shipped. That limited every implementation to reversible encryption — the weaker property, plus a key to manage. Fixing it therefore had to start in `auth-core`, which owns client authentication as protocol mechanics; the `ClientStore` contract explicitly reserves only persistence for the app.

## Changes

**`@ttoss/auth-core`** — owns the verification contract:

- `hashClientSecret` / `verifyClientSecret` primitives. Plain SHA-256 is deliberate, not `hashPassword`'s PBKDF2: a registered secret is 32 random bytes, so there is no low-entropy guess space for a KDF to slow down. Mirrors `hashApiToken` / `verifyApiToken`.
- Optional `ClientStore.verifyClientSecret({ clientId, clientSecret })`, which the engine delegates to when a store implements it — so the raw secret never has to be recoverable.
- The fallback path now compares in constant time instead of `!==`, closing a timing side-channel that existed on the plaintext comparison.
- `authenticateClient` moved to its own module: `oauthServer.ts` was already at its 400-line lint ceiling.

**`@ttoss/auth-postgresdb`** — implements the method:

- `oauth_clients.client_secret` becomes `client_secret_hash`, matching `code_hash` and `token_hash`.
- `get` omits `client_secret` entirely. Nothing in the engine reads it — `handleRegister` echoes the secret from the document it just generated, never from a read — so no key management enters the picture, which encryption would have required.
- `client_secret` stays in `COLUMN_FIELDS` so it can never fall through to the `metadata` JSONB.

Docs updated: both READMEs and the OAuth authorization server guideline.

## Breaking change

For `@ttoss/auth-postgresdb` only: the column rename means existing rows hold a plaintext secret that cannot be verified against a hash, so registered clients must re-register. The package is at `0.1.0` with no adopters, so no migration path is provided.

Custom `ClientStore` implementations are unaffected — omitting the new optional method preserves the previous behavior, now with a constant-time comparison.

## Testing

- `auth-core`: 261 tests pass. New coverage for both primitives (including a malformed stored hash and an absent secret) and for both server paths — delegation to a hashing store, and the fallback including a same-length wrong secret and a confidential client sending no secret at all. `oauth.ts`, `oauthServer.ts`, and `authenticateClient.ts` at 100%; thresholds raised.
- `auth-postgresdb`: 40 tests pass at 100% coverage. Asserts the stored row contains the hash and does not contain the plaintext anywhere, that `get` omits `client_secret`, and covers `verifyClientSecret` for matching, wrong, absent, public-client, and unknown-client cases. `models.test.ts` now guards that `OAuthClient` exposes `clientSecretHash` and not `clientSecret`.
- `http-server-auth` (re-exports `ClientStore`): 63 tests pass.
- Lint and `syncpack` clean.

Note: `pnpm turbo run test` cannot complete in this environment — `@ttoss/i18n-cli#build-config` fails on a `babel-plugin-formatjs` module-linking error, and `@types/node` is not installed. Both reproduce on untouched packages at `main`, so they are pre-existing and unrelated. Suites were run directly with jest instead; CI should be the source of truth.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaAa9qR9zewRS2usBFqsfK)_