### PR TITLE
docs(blog): point the closing link at the live workflows module docs

### DIFF
--- a/docs/website/blog/2026-08-08-your-pipeline-cannot-model-a-ticket-that-reopens.md
+++ b/docs/website/blog/2026-08-08-your-pipeline-cannot-model-a-ticket-that-reopens.md
@@ -152,9 +152,9 @@ modeled the thing as a state machine in the first place.
 
 We built this distinction into [SOAT](https://soat.ttoss.dev) as two separate primitives
 rather than one flexible one — orchestrations for the acyclic pipelines, workflows and tasks
-for the cyclic state graphs, with an explicit dispatch edge between them. The reasoning, the
-full comparison, and the composition patterns are written up in
-[Choosing an Automation Model](https://soat.ttoss.dev/docs/getting-started/choosing-an-automation-model).
+for the cyclic state graphs, with an explicit dispatch edge between them. The state model,
+the guards and transition history, and the composition patterns are written up in the
+[Workflows & Tasks](https://soat.ttoss.dev/docs/modules/workflows) module documentation.
 
 But the idea outlives the implementation. Before you add another `status` column, ask which
 of the two shapes the thing in front of you actually has. If it can go backward, no amount


### PR DESCRIPTION
## Why

The post added in #1192 closes with a link to `soat.ttoss.dev/docs/getting-started/choosing-an-automation-model`. That page is added by **ttoss/soat#898**, which has not merged or deployed yet — verified just now:

```
/docs/modules/workflows                          → 200
/docs/getting-started/choosing-an-automation-model → 404
```

## What changed

One sentence. The closing link now points at the **Workflows & Tasks** module page, which is live today and covers the same state model, guards, transition history, and composition patterns the post refers to. The surrounding paragraph is reworded to match what that page actually documents rather than promising a comparison page.

No other content changes.

## Note

#1192 is merged, so this is a fresh branch off `main` and a new PR rather than a reopen. Once soat#898 merges and the SOAT website deploys, the link can be pointed at the comparison page if that reads better as the entry point — but nothing breaks if it stays as is.

Lint clean (`git add` + `pnpm run -w lint`, prettier and syncpack both pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UU1CkKPbcdXMkQh418Sew9)_