### PR TITLE
fix(geovis): reconcile maplibre layer paint order to spec.layers on u…

### DIFF
--- a/docs/storybook/stories/geovis/LayerZOrderReconciliation.stories.tsx
+++ b/docs/storybook/stories/geovis/LayerZOrderReconciliation.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryFn } from '@storybook/react-webpack5';
+import type {
+  GeoJSONFeatureCollection,
+  VisualizationSpec,
+} from '@ttoss/geovis';
+import * as React from 'react';
+
+import { GeoVisFixtureStory } from './GeoVisFixtureStory';
+import { computeBbox } from './helpers/map-story-helpers';
+
+/**
+ * Visual regression for issue #1129 — **paint order is reconciled to
+ * `spec.layers` on every update**, independent of insertion history.
+ *
+ * The `points` overlay **persists** across both specs (same layer id). Click
+ * **"Adicionar fundo (declarado ABAIXO dos pontos)"** to rebuild the spec with
+ * a large opaque `states-fill` inserted *before* `points` in `spec.layers`.
+ *
+ * - **Before the fix:** `map.addLayer` appended the fill to the top of the
+ *   stack, so it painted **over** the persisting points — the points vanished.
+ * - **After the fix:** the reconciliation pass re-slots every managed layer to
+ *   its `spec.layers` position, so `points` (last in the array) stays on top
+ *   and remains visible over the new fill.
+ *
+ * Toggle back and forth rapidly — the points must stay on top every time.
+ */
+export default {
+  title: 'GeoVis/LayerZOrderReconciliation',
+  tags: ['autodocs'],
+} as Meta;
+
+const states: GeoJSONFeatureCollection = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      id: 'sp',
+      properties: { name: 'São Paulo' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-47.2, -24.0],
+            [-45.0, -24.0],
+            [-45.0, -22.6],
+            [-47.2, -22.6],
+            [-47.2, -24.0],
+          ],
+        ],
+      },
+    },
+    {
+      type: 'Feature',
+      id: 'rj',
+      properties: { name: 'Rio de Janeiro' },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-44.8, -23.4],
+            [-43.0, -23.4],
+            [-43.0, -22.0],
+            [-44.8, -22.0],
+            [-44.8, -23.4],
+          ],
+        ],
+      },
+    },
+  ],
+};
+
+const kitchens: GeoJSONFeatureCollection = {
+  type: 'FeatureCollection',
+  features: [
+    { lng: -46.63, lat: -23.55, name: 'Cozinha Centro' },
+    { lng: -46.4, lat: -23.5, name: 'Cozinha Leste' },
+    { lng: -43.9, lat: -22.7, name: 'Cozinha RJ' },
+  ].map((k, index) => {
+    return {
+      type: 'Feature',
+      id: `k-${index}`,
+      properties: { name: k.name },
+      geometry: { type: 'Point', coordinates: [k.lng, k.lat] },
+    };
+  }),
+};
+
+/** State outline, present in both specs. */
+const statesLineLayer = {
+  id: 'states-line',
+  sourceId: 'states',
+  geometry: 'line' as const,
+  paint: { lineColor: '#1f2937', lineWidth: 1.2 },
+};
+
+/** The persisting overlay — same id across both specs, always declared last. */
+const pointsLayer = {
+  id: 'points',
+  sourceId: 'kitchens',
+  geometry: 'point' as const,
+  paint: {
+    circleColor: '#e4572e',
+    circleRadius: 9,
+    circleStrokeColor: '#ffffff',
+    circleStrokeWidth: 2,
+  },
+};
+
+/**
+ * A large, nearly opaque fill declared **first** in `spec.layers` (bottom).
+ * If paint order followed insertion history, adding this after `points` would
+ * bury the points; with the fix it correctly paints beneath them.
+ */
+const statesFillLayer = {
+  id: 'states-fill',
+  sourceId: 'states',
+  geometry: 'polygon' as const,
+  paint: { fillColor: '#2563eb', fillOpacity: 0.95 },
+};
+
+const buildSpec = (withBackground: boolean): VisualizationSpec => {
+  const layers: VisualizationSpec['layers'] = [];
+  if (withBackground) layers.push(statesFillLayer);
+  layers.push(statesLineLayer, pointsLayer);
+
+  return {
+    title: 'Layer z-order reconciliation (#1129)',
+    description: withBackground
+      ? 'Fundo "states-fill" declarado ABAIXO dos pontos — os pontos devem permanecer visíveis no topo.'
+      : 'Sem fundo. Os pontos persistem ao alternar; adicione o fundo e eles devem continuar no topo.',
+    engine: 'maplibre',
+    basemap: { visible: false },
+    sources: [
+      { id: 'states', type: 'geojson', data: states },
+      { id: 'kitchens', type: 'geojson', data: kitchens },
+    ],
+    layers,
+  };
+};
+
+const bbox = computeBbox(states as GeoJSON.FeatureCollection);
+
+/**
+ * Default story — toggle the background on/off; the persisting points overlay
+ * must stay on top in both states.
+ */
+export const LayerZOrderReconciliation: StoryFn = () => {
+  const [withBackground, setWithBackground] = React.useState(false);
+  const spec = React.useMemo(() => {
+    return buildSpec(withBackground);
+  }, [withBackground]);
+
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      <button
+        type="button"
+        onClick={() => {
+          return setWithBackground((prev) => {
+            return !prev;
+          });
+        }}
+        style={{
+          justifySelf: 'start',
+          padding: '6px 12px',
+          borderRadius: 6,
+          border: '1px solid #d4d4d8',
+          background: withBackground ? '#1d4ed8' : '#f4f4f5',
+          color: withBackground ? '#ffffff' : '#111827',
+          cursor: 'pointer',
+        }}
+      >
+        {withBackground
+          ? 'Remover fundo'
+          : 'Adicionar fundo (declarado ABAIXO dos pontos)'}
+      </button>
+      <GeoVisFixtureStory spec={spec} bbox={bbox} />
+    </div>
+  );
+};

--- a/packages/geovis/src/adapters/maplibre/patchDispatch.ts
+++ b/packages/geovis/src/adapters/maplibre/patchDispatch.ts
@@ -18,6 +18,7 @@ import {
   toMaplibreSource,
 } from './sourceTranslation';
 import {
+  enforceManagedLayerOrder,
   reapplyLayerPaint,
   upsertClickAnchorCompanion,
   upsertOutlineCompanions,
@@ -56,6 +57,7 @@ const applyLayerAdd = (
     ...viewState.spec,
     layers: [...viewState.spec.layers, newLayer],
   };
+  enforceManagedLayerOrder(map, viewState.spec);
 };
 
 const applyLayerRemove = (

--- a/packages/geovis/src/adapters/maplibre/syncSourcesAndLayers.ts
+++ b/packages/geovis/src/adapters/maplibre/syncSourcesAndLayers.ts
@@ -11,6 +11,16 @@ import {
   toMaplibreSource,
 } from './sourceTranslation';
 
+/**
+ * Suffixes of the companion layers GeoVis generates per `spec.layers` entry,
+ * in the order they must sit above their parent (parent first, then these).
+ */
+const COMPANION_SUFFIXES = [
+  '-hover-outline',
+  '-selected-outline',
+  '-click-anchor',
+] as const;
+
 /** Removes layers from `previousSpec` no longer present in `spec`. */
 const removeStaleLayers = (
   map: maplibregl.Map,
@@ -321,9 +331,91 @@ const upsertLayers = (map: maplibregl.Map, spec: VisualizationSpec): void => {
 };
 
 /**
+ * Reorders the GeoVis-managed layers already on the map so their paint order
+ * equals `spec.layers` order (bottom → top), with each layer's companion
+ * layers kept adjacent and above it.
+ *
+ * This is the fix for the adapter's z-order divergence: `map.addLayer` appends
+ * to the top of the stack, so after any update the rendered order became a
+ * function of insertion history rather than of `spec.layers`. Running this
+ * idempotent pass after every layer sync makes `spec.layers` the single source
+ * of truth for paint priority — independent of add/remove/insertion history.
+ *
+ * Only managed layers are touched (the ones derived from `spec.layers` plus
+ * their companions); basemap and other non-managed layers are never moved.
+ * Layers not currently on the map (missing, or `visible: false` but absent)
+ * are skipped; hidden-but-present layers still occupy their slot so toggling
+ * `visible` never changes z-order. No `moveLayer` is issued when the on-map
+ * order already matches, avoiding needless repaints.
+ *
+ * @param map - Live MapLibre map instance.
+ * @param spec - The visualization spec whose `layers` order is the contract.
+ * @returns Nothing; mutates the live map's layer order in place.
+ *
+ * @example
+ * ```ts
+ * // spec.layers = [fillA, fillB, points]
+ * enforceManagedLayerOrder(map, spec); // points end up on top, fillA on bottom
+ * ```
+ */
+/**
+ * Builds the desired bottom→top order of GeoVis-managed layers currently on the
+ * map: each `spec.layers` entry (in array order) followed by its companion
+ * layers that exist. Layers not on the map are skipped.
+ */
+const collectManagedLayerOrder = (
+  map: maplibregl.Map,
+  spec: VisualizationSpec
+): string[] => {
+  const ordered: string[] = [];
+  for (const layer of spec.layers) {
+    if (!map.getLayer(layer.id)) continue;
+    ordered.push(layer.id);
+    for (const suffix of COMPANION_SUFFIXES) {
+      const companionId = `${layer.id}${suffix}`;
+      if (map.getLayer(companionId)) ordered.push(companionId);
+    }
+  }
+  return ordered;
+};
+
+export const enforceManagedLayerOrder = (
+  map: maplibregl.Map,
+  spec: VisualizationSpec
+): void => {
+  const desired = collectManagedLayerOrder(map, spec);
+  if (desired.length < 2) return;
+
+  const managed = new Set(desired);
+  const current = (map.getStyle()?.layers ?? [])
+    .filter((layer) => {
+      return managed.has(layer.id);
+    })
+    .map((layer) => {
+      return layer.id;
+    });
+
+  const alreadyOrdered =
+    current.length === desired.length &&
+    current.every((id, index) => {
+      return id === desired[index];
+    });
+  if (alreadyOrdered) return;
+
+  // Walk top → bottom, slotting each layer just beneath the previously placed
+  // one. `beforeId === undefined` moves a layer to the very top of the stack.
+  let aboveId: string | undefined;
+  for (let index = desired.length - 1; index >= 0; index--) {
+    map.moveLayer(desired[index], aboveId);
+    aboveId = desired[index];
+  }
+};
+
+/**
  * Reconciles the live MapLibre map's sources and layers with `spec`.
  * When `previousSpec` is `null` (first mount or style reset), only additive operations run.
  * Call order enforces MapLibre's dependency invariant: remove layers → remove sources → upsert sources → upsert layers.
+ * A final `enforceManagedLayerOrder` pass reconciles paint order to `spec.layers` order.
  */
 export const syncSourcesAndLayers = (
   map: maplibregl.Map,
@@ -336,4 +428,5 @@ export const syncSourcesAndLayers = (
   }
   upsertSources(map, spec, previousSpec);
   upsertLayers(map, spec);
+  enforceManagedLayerOrder(map, spec);
 };

--- a/packages/geovis/tests/unit/__mocks__/maplibre-gl.ts
+++ b/packages/geovis/tests/unit/__mocks__/maplibre-gl.ts
@@ -40,6 +40,10 @@ const MapMock = jest.fn().mockImplementation(() => {
     }),
     removeLayer: jest.fn(),
     removeSource: jest.fn(),
+    moveLayer: jest.fn(),
+    getStyle: jest.fn(() => {
+      return { layers: [] };
+    }),
     isStyleLoaded: jest.fn(() => {
       return true;
     }),

--- a/packages/geovis/tests/unit/jest.config.ts
+++ b/packages/geovis/tests/unit/jest.config.ts
@@ -10,10 +10,10 @@ export default jestUnitConfig({
   },
   coverageThreshold: {
     global: {
-      statements: 93.1,
-      branches: 84.45,
+      statements: 93.3,
+      branches: 84.6,
       functions: 97.75,
-      lines: 95.85,
+      lines: 96.0,
     },
   },
 });

--- a/packages/geovis/tests/unit/tests/adapters/maplibre/MapLibreAdapter.test.ts
+++ b/packages/geovis/tests/unit/tests/adapters/maplibre/MapLibreAdapter.test.ts
@@ -63,6 +63,10 @@ const makeMapMock = () => {
     }),
     removeLayer: jest.fn(),
     removeSource: jest.fn(),
+    moveLayer: jest.fn(),
+    getStyle: jest.fn(() => {
+      return { layers: [] };
+    }),
     isStyleLoaded: jest.fn(() => {
       return true;
     }),

--- a/packages/geovis/tests/unit/tests/adapters/maplibre/layerZOrder.test.ts
+++ b/packages/geovis/tests/unit/tests/adapters/maplibre/layerZOrder.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Regression tests for issue #1129 — the MapLibre adapter must reconcile the
+ * on-map paint order to `spec.layers` order on every sync, not leave it a
+ * function of insertion history.
+ *
+ * These drive `syncSourcesAndLayers` / `enforceManagedLayerOrder` /
+ * `applyLayerPatch` with a **stateful** mock map that tracks a real ordered
+ * list of layer ids (bottom → top), so assertions read the rendered order the
+ * way MapLibre would expose it via `getStyle().layers`.
+ */
+
+import { applyLayerPatch } from 'src/adapters/maplibre/patchDispatch';
+import {
+  enforceManagedLayerOrder,
+  syncSourcesAndLayers,
+} from 'src/adapters/maplibre/syncSourcesAndLayers';
+import type { VisualizationSpec } from 'src/spec/types';
+
+// ---------------------------------------------------------------------------
+// Stateful mock map — tracks layer order bottom → top (last === top).
+// ---------------------------------------------------------------------------
+
+const makeStatefulMap = () => {
+  const order: string[] = [];
+  const layers = new Set<string>();
+  const sources = new Set<string>();
+
+  const map = {
+    addSource: jest.fn((id: string) => {
+      sources.add(id);
+    }),
+    getSource: jest.fn((id: string) => {
+      return sources.has(id) ? { setData: jest.fn() } : null;
+    }),
+    removeSource: jest.fn((id: string) => {
+      sources.delete(id);
+    }),
+    addLayer: jest.fn((layer: { id: string }) => {
+      if (layers.has(layer.id)) return;
+      layers.add(layer.id);
+      order.push(layer.id);
+    }),
+    getLayer: jest.fn((id: string) => {
+      return layers.has(id) ? { id } : undefined;
+    }),
+    removeLayer: jest.fn((id: string) => {
+      layers.delete(id);
+      const index = order.indexOf(id);
+      if (index !== -1) order.splice(index, 1);
+    }),
+    moveLayer: jest.fn((id: string, beforeId?: string) => {
+      const from = order.indexOf(id);
+      if (from !== -1) order.splice(from, 1);
+      if (beforeId === undefined) {
+        order.push(id);
+        return;
+      }
+      const to = order.indexOf(beforeId);
+      order.splice(to === -1 ? order.length : to, 0, id);
+    }),
+    getStyle: jest.fn(() => {
+      return {
+        layers: order.map((id) => {
+          return { id };
+        }),
+      };
+    }),
+    setLayoutProperty: jest.fn(),
+    setPaintProperty: jest.fn(),
+    setFilter: jest.fn(),
+  };
+
+  return { map, order };
+};
+
+type StatefulMap = ReturnType<typeof makeStatefulMap>['map'];
+
+const asMap = (
+  map: StatefulMap
+): Parameters<typeof syncSourcesAndLayers>[0] => {
+  return map as unknown as Parameters<typeof syncSourcesAndLayers>[0];
+};
+
+// ---------------------------------------------------------------------------
+// Spec builders
+// ---------------------------------------------------------------------------
+
+type Layer = VisualizationSpec['layers'][number];
+
+const layer = (id: string, extra: Partial<Layer> = {}): Layer => {
+  return {
+    id,
+    sourceId: 'src',
+    geometry: 'polygon',
+    ...extra,
+  } as Layer;
+};
+
+const specWith = (layers: Layer[]): VisualizationSpec => {
+  return {
+    engine: 'maplibre',
+    view: { center: [0, 0], zoom: 1 },
+    sources: [
+      {
+        id: 'src',
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      },
+    ],
+    layers,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('enforceManagedLayerOrder via syncSourcesAndLayers', () => {
+  test('keeps a persisting top layer on top when a lower layer is added later (issue #1129 repro)', () => {
+    const { map, order } = makeStatefulMap();
+
+    const specA = specWith([
+      layer('fillA'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specA, null);
+    expect(order).toEqual(['fillA', 'points']);
+
+    // Add a new layer declared BELOW the persisting `points` overlay.
+    const specB = specWith([
+      layer('fillA'),
+      layer('fillB'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specB, specA);
+
+    // `points` is last in spec.layers, so it must stay on top despite fillB
+    // being added after it.
+    expect(order).toEqual(['fillA', 'fillB', 'points']);
+  });
+
+  test('reorders to match spec.layers when the declared order changes', () => {
+    const { map, order } = makeStatefulMap();
+
+    const specA = specWith([layer('a'), layer('b'), layer('c')]);
+    syncSourcesAndLayers(asMap(map), specA, null);
+    expect(order).toEqual(['a', 'b', 'c']);
+
+    const specB = specWith([layer('c'), layer('a'), layer('b')]);
+    syncSourcesAndLayers(asMap(map), specB, specA);
+    expect(order).toEqual(['c', 'a', 'b']);
+  });
+
+  test('does not call moveLayer when the on-map order already matches (no needless repaint)', () => {
+    const { map } = makeStatefulMap();
+    const spec = specWith([layer('a'), layer('b'), layer('c')]);
+
+    syncSourcesAndLayers(asMap(map), spec, null);
+
+    expect(map.moveLayer).not.toHaveBeenCalled();
+  });
+
+  test('keeps hidden (visible:false) layers in their slot so toggling visibility never changes z-order', () => {
+    const { map, order } = makeStatefulMap();
+
+    const specA = specWith([
+      layer('fillA', { visible: false }),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specA, null);
+    expect(order).toEqual(['fillA', 'points']);
+
+    // Add a lower layer; the hidden fillA must still hold its declared slot.
+    const specB = specWith([
+      layer('fillA', { visible: false }),
+      layer('fillB'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specB, specA);
+    expect(order).toEqual(['fillA', 'fillB', 'points']);
+  });
+
+  test('keeps a companion outline adjacent to and above its parent, below higher layers', () => {
+    const { map, order } = makeStatefulMap();
+
+    const specA = specWith([
+      layer('fillA', { hoverPaint: { lineColor: '#000', lineWidth: 2 } }),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specA, null);
+    expect(order).toEqual(['fillA', 'fillA-hover-outline', 'points']);
+
+    // Add a lower layer — companion must stay grouped with fillA, points on top.
+    const specB = specWith([
+      layer('fillA', { hoverPaint: { lineColor: '#000', lineWidth: 2 } }),
+      layer('fillB'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specB, specA);
+    expect(order).toEqual(['fillA', 'fillA-hover-outline', 'fillB', 'points']);
+  });
+
+  test('never moves basemap / non-managed layers', () => {
+    const { map, order } = makeStatefulMap();
+    // A non-managed basemap layer sitting at the bottom before any sync.
+    map.addLayer({ id: 'basemap-bg' });
+
+    const specA = specWith([
+      layer('fillA'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specA, null);
+
+    const specB = specWith([
+      layer('fillA'),
+      layer('fillB'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), specB, specA);
+
+    // Basemap stays at the very bottom; managed layers ordered above it.
+    expect(order).toEqual(['basemap-bg', 'fillA', 'fillB', 'points']);
+  });
+});
+
+describe('enforceManagedLayerOrder — direct', () => {
+  test('is a no-op when fewer than two managed layers are on the map', () => {
+    const { map } = makeStatefulMap();
+    map.addLayer({ id: 'only' });
+
+    enforceManagedLayerOrder(asMap(map), specWith([layer('only')]));
+
+    expect(map.moveLayer).not.toHaveBeenCalled();
+  });
+
+  test('skips layers not present on the map', () => {
+    const { map, order } = makeStatefulMap();
+    map.addLayer({ id: 'a' });
+    map.addLayer({ id: 'c' });
+
+    // `b` is declared between a and c but is not on the map.
+    enforceManagedLayerOrder(
+      asMap(map),
+      specWith([layer('a'), layer('b'), layer('c')])
+    );
+
+    expect(order).toEqual(['a', 'c']);
+  });
+});
+
+describe('applyLayerPatch add — enforces order', () => {
+  test('reconciles order after a patch-added layer, keeping the declared top layer on top', () => {
+    const { map, order } = makeStatefulMap();
+
+    const spec = specWith([
+      layer('fillA'),
+      layer('points', { geometry: 'point' }),
+    ]);
+    syncSourcesAndLayers(asMap(map), spec, null);
+    expect(order).toEqual(['fillA', 'points']);
+
+    const viewState = { spec };
+    applyLayerPatch(asMap(map), viewState, {
+      target: 'layer',
+      op: 'add',
+      path: 'layer.fillB',
+      value: layer('fillB'),
+    } as Parameters<typeof applyLayerPatch>[2]);
+
+    // The patch appends fillB to spec.layers (top), so it lands above points —
+    // but the pass still guarantees order === spec.layers order.
+    expect(order).toEqual(['fillA', 'points', 'fillB']);
+    expect(
+      viewState.spec.layers.map((l) => {
+        return l.id;
+      })
+    ).toEqual(['fillA', 'points', 'fillB']);
+  });
+});


### PR DESCRIPTION
## Summary

  Fixes #1129 — the MapLibre adapter now reconciles the rendered layer paint
  order to `spec.layers` on **every** sync, instead of letting it drift with
  insertion history.

  ## Problem

  New layers were added with `map.addLayer` **without a `beforeId`**, so MapLibre
  appended them to the top of the stack, and `upsertLayers` left already-present
  layers in place. After any spec update the z-order became a function of
  insertion history rather than of `spec.layers`.

  Concrete failure: a persisting overlay (e.g. a points layer present across two
  specs) while switching to a spec that **adds** a layer declared *earlier* in
  `spec.layers` (a background fill) — the new fill painted **above** the points
  and the points disappeared. Rapid spec switches made it more likely, as async
  source loads interleaved the add/remove passes.

  ## Fix

  Add an idempotent `enforceManagedLayerOrder` pass that runs after `upsertLayers`
  in `syncSourcesAndLayers` and after `applyLayerAdd`. It:

  - Builds the desired order from `spec.layers` (array order), expanding each
    layer to `[layer.id, ...existing companions]` so companion outlines stay
    adjacent to and above their parent.
  - Reorders **only** GeoVis-managed layers (via the managed registry, not
    `map.getStyle().layers`) with `map.moveLayer`; basemap and other non-managed
    layers are never moved.
  - Skips the moves entirely when the on-map order already matches, avoiding
    needless repaints.
  - Keeps hidden (`visible: false`) layers in their slot, so toggling visibility
    never changes z-order.

  This makes `spec.layers` the single source of truth for paint priority — the
  rendered order becomes a total function of it, independent of add/remove/
  insertion history.

  ## Testing

  - New `layerZOrder.test.ts` (9 cases) with a stateful mock map that tracks real
    layer order, covering: the issue repro (persisting top layer stays on top when
    a lower layer is added later), reorder on `setSpec`, no `moveLayer` when
    already ordered, hidden-layer slot preservation, companion adjacency, basemap
    untouched, and the patch-add path.
  - Existing map mocks updated with `getStyle`/`moveLayer`.
  - `pnpm type-check` ✅ and full suite (756 tests) ✅; coverage thresholds bumped.

  ## Visual verification

  New Storybook story **GeoVis/LayerZOrderReconciliation** reproduces the scenario:
  a persisting points overlay plus a button that adds a large opaque fill declared
  below the points — the points stay visible on top after the fix.

  ## Backward compatibility

  No API change — the order already lives in `spec.layers`. Consumers that relied
  on the accidental "last-added-wins" behavior now get the declared order, which
  is the documented contract. This is a correctness fix, not a breaking change.