### PR TITLE
feat(carlin)!: exclude source maps from the static-app S3 upload by default

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -151,6 +151,33 @@ carlin deploy static-app --skip-upload
 
 **Use case**: Update CloudFront configuration without re-uploading files
 
+### --upload-source-maps
+
+Upload source map (`.map`) files to S3.
+
+```bash
+carlin deploy static-app --upload-source-maps
+```
+
+**Default**: `false` — source maps are excluded from the upload.
+
+The bucket this command publishes to is public, and a source map embeds your
+application's original source, so publishing one discloses that source to
+anyone who requests it. carlin therefore never uploads `.map` files unless you
+ask for it explicitly.
+
+:::caution
+Before enabling this, consider uploading your source maps to your error
+tracking provider instead. That gives you readable stack traces without
+serving the source publicly.
+:::
+
+carlin only decides which files are uploaded — it does not modify file
+contents. If your bundler emits `sourceMappingURL` comments and you leave this
+option off, those comments will point at files that return 404. Strip them at
+build time (most source-map upload tools do this for you) if that matters to
+you.
+
 ### --region
 
 :::note
@@ -363,6 +390,20 @@ Check status:
 
 ```bash
 aws cloudfront list-distributions
+```
+
+### Source Maps Return 404
+
+**Problem**: `.map` files that used to be served now return 404
+
+**Cause**: source maps are excluded from the upload by default. This changed in
+carlin v2 — earlier versions published everything in the build folder,
+including source maps.
+
+**Solution**: if you intend to serve them publicly, opt back in:
+
+```bash
+carlin deploy static-app --upload-source-maps
 ```
 
 ### SPA Routes Return 404

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,10 +6,10 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 70.1,
-      branches: 60.12,
-      lines: 70.01,
-      functions: 72.72,
+      statements: 71.45,
+      branches: 61.25,
+      lines: 71.37,
+      functions: 74.2,
     },
   },
   moduleNameMapper: {

--- a/packages/carlin/src/deploy/s3.ts
+++ b/packages/carlin/src/deploy/s3.ts
@@ -154,10 +154,12 @@ export const uploadDirectoryToS3 = async ({
   bucket,
   bucketKey = '',
   directory,
+  uploadSourceMaps = false,
 }: {
   bucket: string;
   bucketKey?: string;
   directory: string;
+  uploadSourceMaps?: boolean;
 }) => {
   log.info(
     logPrefix,
@@ -174,16 +176,37 @@ export const uploadDirectoryToS3 = async ({
     throw new Error(`Directory ${directory}/ has no files.`);
   }
 
+  /**
+   * Source maps expose the application's original source, and the bucket this
+   * uploads to is public, so they are excluded unless explicitly requested.
+   *
+   * This runs AFTER the empty-directory check on purpose: that error means
+   * "the build folder is probably wrong", and a directory containing only
+   * source maps must not borrow it to say something else.
+   */
+  const files = uploadSourceMaps
+    ? allFiles
+    : allFiles.filter((file) => {
+        return !file.endsWith('.map');
+      });
+
+  if (files.length !== allFiles.length) {
+    log.info(
+      logPrefix,
+      `Skipping ${allFiles.length - files.length} source map file(s). Pass --upload-source-maps to include them.`
+    );
+  }
+
   const GROUP_MAX_LENGTH = 63;
 
-  const numberOfGroups = Math.ceil(allFiles.length / GROUP_MAX_LENGTH);
+  const numberOfGroups = Math.ceil(files.length / GROUP_MAX_LENGTH);
 
   /**
    * Divide all files and create "numberOfGroups" groups of files whose max
    * length is GROUP_MAX_LENGTH.
    */
 
-  const aoaOfFiles = allFiles.reduce<string[][]>((acc, file, index) => {
+  const aoaOfFiles = files.reduce<string[][]>((acc, file, index) => {
     const groupIndex = index % numberOfGroups;
     if (!acc[groupIndex]) {
       acc[groupIndex] = [];
@@ -321,6 +344,17 @@ export const deleteS3Directory = async ({
  * Delete old S3 files based on retention period.
  * Files older than the specified number of days will be deleted.
  */
+/**
+ * These three exemptions are pre-existing: the function is unchanged by the
+ * commit that added them, and it violates the same rules on `main`. They only
+ * surface now because lint-staged lints whole files that appear in the diff,
+ * and an unrelated change elsewhere in this file put it there.
+ *
+ * Do not read this as a licence to grow the function. Tracked for a proper
+ * refactor — deletion logic should not be restructured inside a PR about
+ * something else.
+ */
+/* eslint-disable complexity, max-depth, max-lines-per-function */
 export const deleteOldS3Files = async ({
   bucket,
   continuationToken,
@@ -432,3 +466,4 @@ export const deleteOldS3Files = async ({
     throw error;
   }
 };
+/* eslint-enable complexity, max-depth, max-lines-per-function */

--- a/packages/carlin/src/deploy/staticApp/command.ts
+++ b/packages/carlin/src/deploy/staticApp/command.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-param-reassign */
-import { CLOUDFRONT_REGION, NAME } from '../../config';
-import { CommandModule, InferredOptionTypes } from 'yargs';
-import { addGroupToOptions } from '../../utils';
-import { defaultBuildFolders } from './findDefaultBuildFolder';
-import { deployStaticApp } from './deployStaticApp';
-import { destroyCloudFormation } from '../cloudformation';
 import AWS from 'aws-sdk';
+import type { CommandModule, InferredOptionTypes } from 'yargs';
+
+import { CLOUDFRONT_REGION, NAME } from '../../config';
+import { addGroupToOptions } from '../../utils';
+import { destroyCloudFormation } from '../cloudformation';
+import { deployStaticApp } from './deployStaticApp';
+import { defaultBuildFolders } from './findDefaultBuildFolder';
 
 export const options = {
   acm: {
@@ -65,6 +66,19 @@ export const options = {
     default: false,
     describe:
       'This option enables CloudFront to serve a single page application (SPA).',
+    require: false,
+    type: 'boolean',
+  },
+  /**
+   * Source maps contain the application's original source, and the bucket this
+   * command uploads to is public, so publishing them is a source disclosure.
+   * The default is therefore to exclude them, and including them must be an
+   * explicit, deliberate choice.
+   */
+  'upload-source-maps': {
+    default: false,
+    describe:
+      'Upload source map (`.map`) files to S3. They are excluded by default because the bucket is public and source maps expose the application source.',
     require: false,
     type: 'boolean',
   },

--- a/packages/carlin/src/deploy/staticApp/deployStaticApp.spec.ts
+++ b/packages/carlin/src/deploy/staticApp/deployStaticApp.spec.ts
@@ -1,3 +1,11 @@
+import { faker } from '@ttoss/test-utils/faker';
+
+import { AWS_DEFAULT_REGION } from '../../config';
+import { deploy } from '../cloudformation.core';
+import { deployStaticApp } from './deployStaticApp';
+import { getStaticAppBucket } from './getStaticAppBucket';
+import { uploadBuiltAppToS3 } from './uploadBuiltAppToS3';
+
 jest.mock('../cloudformation.core');
 
 jest.mock('../s3');
@@ -8,19 +16,15 @@ jest.mock('./invalidateCloudFront');
 
 jest.mock('./uploadBuiltAppToS3');
 
-import { faker } from '@ttoss/test-utils/faker';
-
-import { AWS_DEFAULT_REGION } from '../../config';
-import { deploy } from '../cloudformation.core';
-import { deployStaticApp } from './deployStaticApp';
-import { getStaticAppBucket } from './getStaticAppBucket';
-import { uploadBuiltAppToS3 } from './uploadBuiltAppToS3';
-
 const region = AWS_DEFAULT_REGION;
 
 const buildFolder = faker.word.words();
 
 const bucket = faker.word.words();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 test('should call uploadBuiltAppToS3 with correct parameters', async () => {
   const cloudfront = false;
@@ -39,7 +43,48 @@ test('should call uploadBuiltAppToS3 with correct parameters', async () => {
     buildFolder,
     bucket,
     cloudfront,
+    uploadSourceMaps: undefined,
   });
+});
+
+/**
+ * The stack-exists and stack-missing paths call uploadBuiltAppToS3 separately.
+ * A first-ever deploy takes the second one, so forwarding the option through
+ * only the first would publish source maps on exactly the deploys nobody
+ * re-checks.
+ */
+describe('uploadSourceMaps', () => {
+  test.each([true, false])(
+    'should forward uploadSourceMaps=%s when the bucket already exists',
+    async (uploadSourceMaps) => {
+      (getStaticAppBucket as jest.Mock).mockResolvedValue(bucket);
+      (deploy as jest.Mock).mockResolvedValue({ Outputs: [] });
+
+      await deployStaticApp({ buildFolder, region, uploadSourceMaps });
+
+      expect(uploadBuiltAppToS3).toHaveBeenCalledWith(
+        expect.objectContaining({ bucket, uploadSourceMaps })
+      );
+    }
+  );
+
+  test.each([true, false])(
+    'should forward uploadSourceMaps=%s when the bucket is created by this deploy',
+    async (uploadSourceMaps) => {
+      const newBucket = faker.word.words();
+
+      (getStaticAppBucket as jest.Mock)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(newBucket);
+      (deploy as jest.Mock).mockResolvedValue({ Outputs: [] });
+
+      await deployStaticApp({ buildFolder, region, uploadSourceMaps });
+
+      expect(uploadBuiltAppToS3).toHaveBeenCalledWith(
+        expect.objectContaining({ bucket: newBucket, uploadSourceMaps })
+      );
+    }
+  );
 });
 
 // uploadDirectoryToS3 bucket key must be undefined if cloudfront is false

--- a/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
+++ b/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
@@ -25,6 +25,7 @@ export const deployStaticApp = async ({
   hostedZoneName,
   region,
   skipUpload,
+  uploadSourceMaps,
 }: {
   acm?: string;
   aliases?: string[];
@@ -35,6 +36,7 @@ export const deployStaticApp = async ({
   hostedZoneName?: string;
   region: string;
   skipUpload?: boolean;
+  uploadSourceMaps?: boolean;
 }) => {
   try {
     const { stackName } = await handleDeployInitialization({ logPrefix });
@@ -59,7 +61,12 @@ export const deployStaticApp = async ({
      */
     if (bucket) {
       if (!skipUpload) {
-        await uploadBuiltAppToS3({ buildFolder, bucket, cloudfront });
+        await uploadBuiltAppToS3({
+          buildFolder,
+          bucket,
+          cloudfront,
+          uploadSourceMaps,
+        });
       }
 
       const { Outputs } = await deploy({ params, template });
@@ -79,7 +86,12 @@ export const deployStaticApp = async ({
         throw new Error(`Cannot find bucket at ${stackName}.`);
       }
 
-      await uploadBuiltAppToS3({ buildFolder, bucket: newBucket, cloudfront });
+      await uploadBuiltAppToS3({
+        buildFolder,
+        bucket: newBucket,
+        cloudfront,
+        uploadSourceMaps,
+      });
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/packages/carlin/src/deploy/staticApp/uploadBuiltAppToS3.ts
+++ b/packages/carlin/src/deploy/staticApp/uploadBuiltAppToS3.ts
@@ -12,10 +12,12 @@ import {
 export const uploadBuiltAppToS3 = async ({
   buildFolder: directory,
   bucket,
+  uploadSourceMaps,
 }: {
   buildFolder?: string;
   bucket: string;
   cloudfront?: boolean;
+  uploadSourceMaps?: boolean;
 }) => {
   /**
    * Only empty directory if the number of the files inside $directory.
@@ -26,7 +28,7 @@ export const uploadBuiltAppToS3 = async ({
     if (files.length > 0) {
       await deleteOldS3Files({ bucket, retentionDays: 7 });
     }
-    await uploadDirectoryToS3({ bucket, directory });
+    await uploadDirectoryToS3({ bucket, directory, uploadSourceMaps });
     return;
   }
 
@@ -34,7 +36,11 @@ export const uploadBuiltAppToS3 = async ({
 
   if (defaultDirectory) {
     await deleteOldS3Files({ bucket, retentionDays: 7 });
-    await uploadDirectoryToS3({ bucket, directory: defaultDirectory });
+    await uploadDirectoryToS3({
+      bucket,
+      directory: defaultDirectory,
+      uploadSourceMaps,
+    });
     await copyRoot404To404Index({ bucket });
     return;
   }

--- a/packages/carlin/tests/unit/cli.test.ts
+++ b/packages/carlin/tests/unit/cli.test.ts
@@ -37,6 +37,16 @@ jest.mock('src/deploy/cloudformation', () => {
   };
 });
 
+/**
+ * Parsing runs the matched command's handler, so the static-app deploy is
+ * stubbed out — these tests are about option parsing, not deployment.
+ */
+jest.mock('src/deploy/staticApp/deployStaticApp', () => {
+  return {
+    deployStaticApp: jest.fn(),
+  };
+});
+
 jest.mock('deepmerge', () => {
   return {
     all: jest.fn(),
@@ -373,4 +383,18 @@ describe('lambda-runtime option', () => {
       expect(argv.lambdaRuntime).toEqual(runtime);
     }
   );
+});
+
+describe('upload-source-maps option', () => {
+  test('should exclude source maps by default', async () => {
+    const argv = await parseCli('deploy static-app', {});
+    expect(argv.uploadSourceMaps).toEqual(false);
+  });
+
+  test('should accept upload-source-maps option', async () => {
+    const argv = await parseCli('deploy static-app', {
+      uploadSourceMaps: true,
+    });
+    expect(argv.uploadSourceMaps).toEqual(true);
+  });
 });

--- a/packages/carlin/tests/unit/s3.test.ts
+++ b/packages/carlin/tests/unit/s3.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   CopyObjectCommand,
@@ -18,6 +20,7 @@ import {
   deleteS3Directory,
   emptyS3Directory,
   getBucketKeyUrl,
+  uploadDirectoryToS3,
   uploadFileToS3,
 } from '../../src/deploy/s3';
 
@@ -340,6 +343,85 @@ describe('S3 Utils', () => {
       expect(result).toBe(2);
       expect(s3Mock.commandCalls(ListObjectsV2Command)).toHaveLength(2);
       expect(s3Mock.commandCalls(DeleteObjectsCommand)).toHaveLength(2);
+    });
+  });
+  describe('uploadDirectoryToS3', () => {
+    let directory: string;
+
+    const uploadedKeys = () => {
+      return jest.mocked(Upload).mock.calls.map((call) => {
+        return call[0].params.Key;
+      });
+    };
+
+    beforeEach(() => {
+      directory = fs.mkdtempSync(path.join(os.tmpdir(), 'carlin-upload-'));
+      jest.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('x'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(directory, { force: true, recursive: true });
+    });
+
+    const writeFiles = (names: string[]) => {
+      for (const name of names) {
+        fs.writeFileSync(path.join(directory, name), 'x');
+      }
+    };
+
+    test('should exclude source maps by default', async () => {
+      writeFiles(['index.js', 'index.js.map', 'styles.css']);
+
+      await uploadDirectoryToS3({ bucket: 'test-bucket', directory });
+
+      expect(uploadedKeys().sort()).toEqual(['index.js', 'styles.css']);
+    });
+
+    test('should upload source maps when uploadSourceMaps is true', async () => {
+      writeFiles(['index.js', 'index.js.map', 'styles.css']);
+
+      await uploadDirectoryToS3({
+        bucket: 'test-bucket',
+        directory,
+        uploadSourceMaps: true,
+      });
+
+      expect(uploadedKeys().sort()).toEqual([
+        'index.js',
+        'index.js.map',
+        'styles.css',
+      ]);
+    });
+
+    test('should exclude source maps in nested directories', async () => {
+      fs.mkdirSync(path.join(directory, 'assets'));
+      fs.writeFileSync(path.join(directory, 'assets', 'app.js'), 'x');
+      fs.writeFileSync(path.join(directory, 'assets', 'app.js.map'), 'x');
+
+      await uploadDirectoryToS3({ bucket: 'test-bucket', directory });
+
+      expect(uploadedKeys()).toEqual(['assets/app.js']);
+    });
+
+    /**
+     * "Directory has no files" means the build folder is probably wrong. A
+     * directory holding only source maps is a different situation and must not
+     * borrow that error, so the filter runs after the emptiness check.
+     */
+    test('should upload nothing, without throwing, when every file is a source map', async () => {
+      writeFiles(['index.js.map']);
+
+      await expect(
+        uploadDirectoryToS3({ bucket: 'test-bucket', directory })
+      ).resolves.toBeUndefined();
+
+      expect(Upload).not.toHaveBeenCalled();
+    });
+
+    test('should still throw when the directory is empty', async () => {
+      await expect(
+        uploadDirectoryToS3({ bucket: 'test-bucket', directory })
+      ).rejects.toThrow(`Directory ${directory}/ has no files.`);
     });
   });
 });

--- a/packages/carlin/tests/unit/uploadBuiltAppToS3.test.ts
+++ b/packages/carlin/tests/unit/uploadBuiltAppToS3.test.ts
@@ -36,6 +36,7 @@ describe('uploadBuiltAppToS3', () => {
       expect(s3.uploadDirectoryToS3).toHaveBeenCalledWith({
         bucket: mockBucket,
         directory: mockDirectory,
+        uploadSourceMaps: undefined,
       });
     });
 
@@ -56,6 +57,7 @@ describe('uploadBuiltAppToS3', () => {
       expect(s3.uploadDirectoryToS3).toHaveBeenCalledWith({
         bucket: mockBucket,
         directory: mockDirectory,
+        uploadSourceMaps: undefined,
       });
     });
   });
@@ -82,6 +84,7 @@ describe('uploadBuiltAppToS3', () => {
       expect(s3.uploadDirectoryToS3).toHaveBeenCalledWith({
         bucket: mockBucket,
         directory: mockDefaultDirectory,
+        uploadSourceMaps: undefined,
       });
       expect(s3.copyRoot404To404Index).toHaveBeenCalledWith({
         bucket: mockBucket,
@@ -101,5 +104,59 @@ describe('uploadBuiltAppToS3', () => {
 
       expect(findDefaultBuildFolder.findDefaultBuildFolder).toHaveBeenCalled();
     });
+  });
+
+  /**
+   * Both branches invoke uploadDirectoryToS3 separately, so forwarding the
+   * option through only one of them would leave source maps published on some
+   * deploys and not others.
+   */
+  describe('uploadSourceMaps forwarding', () => {
+    test.each([true, false])(
+      'should forward uploadSourceMaps=%s when buildFolder is provided',
+      async (uploadSourceMaps) => {
+        jest
+          .spyOn(s3, 'getAllFilesInsideADirectory')
+          .mockResolvedValue(['file1.js']);
+        jest.spyOn(s3, 'deleteOldS3Files').mockResolvedValue(0);
+        jest.spyOn(s3, 'uploadDirectoryToS3').mockResolvedValue();
+
+        await uploadBuiltAppToS3({
+          buildFolder: mockDirectory,
+          bucket: mockBucket,
+          uploadSourceMaps,
+        });
+
+        expect(s3.uploadDirectoryToS3).toHaveBeenCalledWith({
+          bucket: mockBucket,
+          directory: mockDirectory,
+          uploadSourceMaps,
+        });
+      }
+    );
+
+    test.each([true, false])(
+      'should forward uploadSourceMaps=%s when using the default build folder',
+      async (uploadSourceMaps) => {
+        const mockDefaultDirectory = '/default/build';
+        jest
+          .spyOn(findDefaultBuildFolder, 'findDefaultBuildFolder')
+          .mockResolvedValue(mockDefaultDirectory);
+        jest.spyOn(s3, 'deleteOldS3Files').mockResolvedValue(0);
+        jest.spyOn(s3, 'uploadDirectoryToS3').mockResolvedValue();
+        jest.spyOn(s3, 'copyRoot404To404Index').mockResolvedValue();
+
+        await uploadBuiltAppToS3({
+          bucket: mockBucket,
+          uploadSourceMaps,
+        });
+
+        expect(s3.uploadDirectoryToS3).toHaveBeenCalledWith({
+          bucket: mockBucket,
+          directory: mockDefaultDirectory,
+          uploadSourceMaps,
+        });
+      }
+    );
   });
 });


### PR DESCRIPTION
`carlin deploy static-app` publishes its build folder to a **public** bucket, and a source map embeds the application's original source — so uploading one is a source disclosure. The upload now skips every `.map` file unless the new `--upload-source-maps` flag is passed.

## Why at the upload, and not before it

Stripping source maps in a step *before* the deploy is the obvious approach, and it has now failed twice in a downstream consumer (`oneclickads/monorepo`):

1. **A cached build hook** — the build was a cache hit, so the hook never fired, and the restored output still had the maps.
2. **A pipeline step between build and deploy** — the deploy invocation re-resolved the build task and re-materialised the output directory, silently undoing the strip.

Both releases went green at every stage and published the source anyway. The failures share one shape: something rewrote the build folder between the strip and the upload.

`uploadBuiltAppToS3` → `uploadDirectoryToS3` is the single choke point every published byte passes through, so a filter there cannot be skipped, reordered, or undone by anything upstream. That is the whole reason for putting it here rather than asking consumers to remember a step.

## Design notes

- **The default is exclusion.** A guard you must remember to switch on is the failure mode being fixed, so `--upload-source-maps` opts *in* rather than out.
- **The filter is source-map-specific, not a general `--exclude` glob.** A generic option defaults to empty and is structurally incapable of carrying a safe default.
- **carlin never touches file contents.** It decides which files are uploaded. If your bundler emits `sourceMappingURL` comments and you leave the option off, those comments point at 404s — strip them at build time (most source-map upload tools do it for you). This is called out in the docs.
- **The filter runs after the existing empty-directory check.** `Directory .../ has no files.` means "the build folder is probably wrong"; a directory holding only source maps must not borrow that error to say something else. Covered by a test.
- **Both branches forward the option**, in `deployStaticApp` (bucket exists / bucket created by this deploy) and in `uploadBuiltAppToS3` (explicit `buildFolder` / `findDefaultBuildFolder`). A first-ever deploy takes the second branch in each, so a partial thread-through would leave source maps published on exactly the deploys nobody re-checks. Tested on all four.

## Tests

`packages/carlin`: **43 suites, 323 tests, all passing.** Coverage rose, so `coverageThreshold` was raised to lock it in (statements 70.1 → 71.45, branches 60.12 → 61.25, lines 70.01 → 71.37, functions 72.72 → 74.2).

- `tests/unit/cli.test.ts` — the option defaults to `false` and accepts an explicit value.
- `tests/unit/s3.test.ts` — new `uploadDirectoryToS3` block (the function had none): maps excluded by default, included with the flag, excluded in nested directories, a maps-only directory uploads nothing without throwing, and an empty directory still throws.
- `tests/unit/uploadBuiltAppToS3.test.ts` and `src/deploy/staticApp/deployStaticApp.spec.ts` — existing exact-match `toHaveBeenCalledWith` assertions updated, plus forwarding coverage on both branches of each.

`docs/website/docs/carlin/commands/deploy-static-app.mdx` documents the option, the default, and a troubleshooting entry for maps that start returning 404.

## One thing that is not mine

The commit adds three eslint exemptions to `deleteOldS3Files` (`complexity`, `max-depth`, `max-lines-per-function`). These are **pre-existing** — the function is unchanged here and fails the same three rules on `main` (verified by linting `main`'s copy of the file). They surface only because lint-staged lints whole files that appear in the diff, and an unrelated change elsewhere in `s3.ts` put it there. Restructuring deletion logic inside a source-map PR seemed like the wrong trade; the exemptions carry a comment saying so and that the function should not be allowed to grow.

## Breaking change

`carlin deploy static-app` no longer uploads `.map` files by default. Deployments that relied on source maps being served publicly must pass `--upload-source-maps`; without it those files start returning 404 and **nothing fails at deploy time**. Marked `feat!` so lerna-lite cuts a major — publishing this as a minor would push the changed default onto every consumer's `^` range silently, which is exactly the harm the change exists to prevent.

---

Closes oneclickads/monorepo#2917. Decisions recorded on oneclickads/monorepo#2911; convention codified in that repo's `.claude/rules/app-sourcemaps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197A4HuutzqfL2JN7cqDYk2