### PR TITLE
feat(carlin): add response headers options to deploy static-app

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -141,6 +141,79 @@ carlin deploy static-app --spa
 
 **Use case**: React Router, Vue Router, Angular Router
 
+### --response-headers
+
+Headers that CloudFront adds to every response it sends to viewers.
+
+```bash
+carlin deploy static-app --cloudfront --response-headers.x-robots-tag=noindex
+```
+
+Header values such as a content security policy are long and awkward to quote
+on a command line, so prefer the configuration file:
+
+```typescript
+import { defineConfig } from 'carlin/config';
+
+export default defineConfig({
+  cloudfront: true,
+  responseHeaders: {
+    'content-security-policy': "default-src 'self'",
+    'permissions-policy': 'geolocation=()',
+  },
+});
+```
+
+Headers defined this way override the ones received from the origin. Use the
+array form when a header should be sent only when the origin doesn't send it:
+
+```typescript
+responseHeaders: [
+  {
+    header: 'x-robots-tag',
+    value: 'noindex',
+    override: false,
+  },
+];
+```
+
+**Requires**: `--cloudfront`. The headers are added by CloudFront, so a bucket
+only deploy has nothing to attach them to.
+
+Every deploy uses the managed `CORS-with-preflight-and-SecurityHeadersPolicy`,
+which sends `Strict-Transport-Security`, `X-Content-Type-Options`,
+`X-Frame-Options`, `Referrer-Policy`, `X-XSS-Protection` and the CORS headers.
+Defining response headers replaces that managed policy with one carlin creates,
+which reproduces those settings so both deploys behave the same. Defining one
+of the security headers above replaces the managed value with yours. The CORS
+headers are configured as a unit and cannot be replaced individually — use
+`--response-headers-policy` when you need to change them.
+
+Changing headers updates the distribution, which takes a few minutes to reach
+every edge location. No invalidation is needed: the headers are applied to
+cache hits too.
+
+### --response-headers-policy
+
+The id of an existing [response headers policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/modifying-response-headers.html),
+or the name of an exported value whose value is the id, to associate to the
+distribution instead of the default managed one.
+
+```bash
+# Managed or custom policy id
+carlin deploy static-app --cloudfront --response-headers-policy 67f7725c-6f97-4210-82d7-5512b31e9d03
+
+# CloudFormation export
+carlin deploy static-app --cloudfront --response-headers-policy MyResponseHeadersPolicyId
+```
+
+Use this when the policy is managed elsewhere, or when you need settings that
+`--response-headers` doesn't reach, such as CORS or removing headers. carlin
+takes the policy as given and adds nothing to it.
+
+**Requires**: `--cloudfront`. **Conflicts with**: `--response-headers`. A cache
+behavior takes a single response headers policy.
+
 ### --skip-upload
 
 Update CloudFormation without uploading files.

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,10 +6,10 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 71.45,
-      branches: 61.25,
-      lines: 71.37,
-      functions: 74.2,
+      statements: 72.15,
+      branches: 62.9,
+      lines: 72.05,
+      functions: 74.8,
     },
   },
   moduleNameMapper: {

--- a/packages/carlin/src/deploy/staticApp/command.ts
+++ b/packages/carlin/src/deploy/staticApp/command.ts
@@ -7,6 +7,7 @@ import { addGroupToOptions } from '../../utils';
 import { destroyCloudFormation } from '../cloudformation';
 import { deployStaticApp } from './deployStaticApp';
 import { defaultBuildFolders } from './findDefaultBuildFolder';
+import { parseResponseHeaders } from './responseHeaders';
 
 export const options = {
   acm: {
@@ -56,6 +57,17 @@ export const options = {
     hidden: true,
     type: 'string',
   },
+  'response-headers': {
+    coerce: parseResponseHeaders,
+    default: [],
+    describe:
+      'Headers added by CloudFront to every response sent to viewers. Pass an object whose keys are header names and values are header values.',
+  },
+  'response-headers-policy': {
+    describe:
+      'The id of an existing CloudFront response headers policy, or the name of the exported variable whose value is the id, that will be associated to the distribution instead of the default one.',
+    type: 'string',
+  },
   'skip-upload': {
     default: false,
     describe:
@@ -95,6 +107,36 @@ export const deployStaticAppCommand: CommandModule<
     return (
       yargs
         .options(addGroupToOptions(options, 'Deploy Static App Options'))
+        /**
+         * `implies` and `conflicts` cannot be used for these checks because
+         * `cloudfront` and `response-headers` have default values, which yargs
+         * considers as provided.
+         */
+        .check(({ cloudfront, responseHeaders, responseHeadersPolicy }) => {
+          const hasResponseHeaders = responseHeaders?.length > 0;
+
+          if (hasResponseHeaders && responseHeadersPolicy) {
+            throw new Error(
+              'The response-headers and response-headers-policy options are mutually exclusive. The distribution takes a single response headers policy.'
+            );
+          }
+
+          /**
+           * Response headers are applied by CloudFront, so a bucket only
+           * deploy has nothing to attach them to.
+           */
+          if (!cloudfront && (hasResponseHeaders || responseHeadersPolicy)) {
+            throw new Error(
+              `The ${
+                hasResponseHeaders
+                  ? 'response-headers'
+                  : 'response-headers-policy'
+              } option requires the cloudfront option.`
+            );
+          }
+
+          return true;
+        })
         /**
          * CloudFront triggers can be only in US East (N. Virginia) Region.
          * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-cloudfront-triggers

--- a/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
+++ b/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
@@ -2,6 +2,7 @@ import { deploy } from '../cloudformation.core';
 import { handleDeployError, handleDeployInitialization } from '../utils';
 import { getStaticAppBucket } from './getStaticAppBucket';
 import { invalidateCloudFront } from './invalidateCloudFront';
+import { type ResponseHeader } from './responseHeaders';
 import { getStaticAppTemplate } from './staticApp.template';
 import { uploadBuiltAppToS3 } from './uploadBuiltAppToS3';
 
@@ -21,6 +22,8 @@ export const deployStaticApp = async ({
   appendIndexHtml,
   buildFolder,
   cloudfront,
+  responseHeaders,
+  responseHeadersPolicy,
   spa,
   hostedZoneName,
   region,
@@ -32,6 +35,8 @@ export const deployStaticApp = async ({
   appendIndexHtml?: boolean;
   buildFolder?: string;
   cloudfront?: boolean;
+  responseHeaders?: ResponseHeader[];
+  responseHeadersPolicy?: string;
   spa?: boolean;
   hostedZoneName?: string;
   region: string;
@@ -48,6 +53,8 @@ export const deployStaticApp = async ({
       aliases,
       appendIndexHtml,
       cloudfront,
+      responseHeaders,
+      responseHeadersPolicy,
       spa,
       hostedZoneName,
       region,

--- a/packages/carlin/src/deploy/staticApp/responseHeaders.ts
+++ b/packages/carlin/src/deploy/staticApp/responseHeaders.ts
@@ -1,0 +1,236 @@
+/**
+ * Response headers added to the CloudFront distribution.
+ *
+ * CloudFront applies these natively on the response path via an
+ * `AWS::CloudFront::ResponseHeadersPolicy`. No edge function is involved.
+ */
+export type ResponseHeader = {
+  header: string;
+  value: string;
+  override: boolean;
+};
+
+/**
+ * The header names emitted by the `SecurityHeadersConfig` of the baseline
+ * policy, mapped to the config key that emits them. Each key is optional in
+ * `SecurityHeadersConfig`, so a user-defined header of the same name replaces
+ * the baseline one by removing the key.
+ */
+const SECURITY_HEADERS_CONFIG_KEYS: { [header: string]: string } = {
+  'content-security-policy': 'ContentSecurityPolicy',
+  'referrer-policy': 'ReferrerPolicy',
+  'strict-transport-security': 'StrictTransportSecurity',
+  'x-content-type-options': 'ContentTypeOptions',
+  'x-frame-options': 'FrameOptions',
+  'x-xss-protection': 'XSSProtection',
+};
+
+/**
+ * The header names emitted by the `CorsConfig` of the baseline policy.
+ * `CorsConfig` requires its fields as a unit, so a single header cannot be
+ * replaced without inventing semantics for the others. Defining one of these
+ * is an error instead.
+ */
+const CORS_CONFIG_HEADERS = [
+  'access-control-allow-credentials',
+  'access-control-allow-headers',
+  'access-control-allow-methods',
+  'access-control-allow-origin',
+  'access-control-expose-headers',
+  'access-control-max-age',
+];
+
+/**
+ * https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+ */
+const HEADER_NAME_REGEX = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/**
+ * Configuration of the managed policy
+ * `CORS-with-preflight-and-SecurityHeadersPolicy`
+ * (`eaab4381-ed33-4a86-88ca-d9558dc6cd63`), which every static app deploy has
+ * used since CloudFront support was added.
+ *
+ * A custom policy replaces the managed one instead of extending it, so the
+ * managed settings are reproduced here to keep deploys that define response
+ * headers equivalent to the ones that don't.
+ *
+ * Transcribed 2026-08-22 from
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
+ *
+ * `AccessControlAllowHeaders` is required by CloudFormation but isn't listed
+ * on that page. It mirrors the `AllowedHeaders` of the bucket CORS rules.
+ *
+ * Note the `Override` flags are not uniform: `X-Content-Type-Options` is the
+ * only header the managed policy overrides the origin for.
+ */
+export const BASELINE_RESPONSE_HEADERS_CONFIG = {
+  CorsConfig: {
+    AccessControlAllowCredentials: false,
+    AccessControlAllowHeaders: { Items: ['*'] },
+    AccessControlAllowMethods: {
+      Items: ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'],
+    },
+    AccessControlAllowOrigins: { Items: ['*'] },
+    AccessControlExposeHeaders: { Items: ['*'] },
+    OriginOverride: false,
+  },
+  SecurityHeadersConfig: {
+    ReferrerPolicy: {
+      Override: false,
+      ReferrerPolicy: 'strict-origin-when-cross-origin',
+    },
+    StrictTransportSecurity: {
+      AccessControlMaxAgeSec: 31536000,
+      IncludeSubdomains: false,
+      Override: false,
+      Preload: false,
+    },
+    ContentTypeOptions: {
+      Override: true,
+    },
+    FrameOptions: {
+      FrameOption: 'SAMEORIGIN',
+      Override: false,
+    },
+    XSSProtection: {
+      ModeBlock: true,
+      Override: false,
+      Protection: true,
+    },
+  },
+} as const;
+
+type ResponseHeadersPolicyConfig = {
+  Comment: unknown;
+  CorsConfig: unknown;
+  CustomHeadersConfig: {
+    Items: { Header: string; Override: boolean; Value: string }[];
+  };
+  Name: unknown;
+  SecurityHeadersConfig?: { [key: string]: unknown };
+};
+
+const validateResponseHeaders = (responseHeaders: ResponseHeader[]) => {
+  const seen = new Set<string>();
+
+  for (const { header } of responseHeaders) {
+    if (!header || !HEADER_NAME_REGEX.test(header)) {
+      throw new Error(
+        `"${header}" is not a valid HTTP header name for the response-headers option.`
+      );
+    }
+
+    const headerLowerCase = header.toLowerCase();
+
+    if (seen.has(headerLowerCase)) {
+      throw new Error(
+        `The response header "${header}" was defined more than once. Header names are case-insensitive.`
+      );
+    }
+
+    seen.add(headerLowerCase);
+
+    if (CORS_CONFIG_HEADERS.includes(headerLowerCase)) {
+      throw new Error(
+        `The response header "${header}" is part of the CORS configuration and cannot be defined by the response-headers option. Use the response-headers-policy option to take full control of the policy.`
+      );
+    }
+  }
+};
+
+/**
+ * Normalizes the `response-headers` option into a list of headers.
+ *
+ * Accepts the object form, which is the one to prefer:
+ *
+ * ```ts
+ * {
+ *  'content-security-policy': "default-src 'self'",
+ * }
+ * ```
+ *
+ * And the array form, needed only to set `override` per header:
+ *
+ * ```ts
+ * [
+ *  { header: 'content-security-policy', value: "default-src 'self'", override: false },
+ * ]
+ * ```
+ */
+export const parseResponseHeaders = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  arg: any
+): ResponseHeader[] => {
+  if (!arg) {
+    return [];
+  }
+
+  const responseHeaders: ResponseHeader[] = Array.isArray(arg)
+    ? arg.map(({ header, value, override = true }) => {
+        return { header, value, override };
+      })
+    : Object.entries(arg).map(([header, value]) => {
+        return { header, value: String(value), override: true };
+      });
+
+  validateResponseHeaders(responseHeaders);
+
+  return responseHeaders;
+};
+
+/**
+ * Builds the `ResponseHeadersPolicyConfig` of the policy created when the
+ * response-headers option is defined: the baseline managed policy settings
+ * with the user-defined headers layered on top.
+ */
+export const getResponseHeadersPolicyConfig = ({
+  responseHeaders,
+}: {
+  responseHeaders: ResponseHeader[];
+}): ResponseHeadersPolicyConfig => {
+  const securityHeadersConfig: {
+    [key: string]: unknown;
+  } = { ...BASELINE_RESPONSE_HEADERS_CONFIG.SecurityHeadersConfig };
+
+  /**
+   * A user-defined header replaces the baseline one instead of being emitted
+   * alongside it.
+   */
+  for (const { header } of responseHeaders) {
+    const securityHeadersConfigKey =
+      SECURITY_HEADERS_CONFIG_KEYS[header.toLowerCase()];
+
+    if (securityHeadersConfigKey) {
+      delete securityHeadersConfig[securityHeadersConfigKey];
+    }
+  }
+
+  return {
+    Comment: {
+      'Fn::Sub': [
+        'Response headers policy for ${Project} project.',
+        { Project: { Ref: 'Project' } },
+      ],
+    },
+    CorsConfig: BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig,
+    CustomHeadersConfig: {
+      Items: responseHeaders.map(({ header, value, override }) => {
+        return {
+          Header: header,
+          Override: override,
+          Value: value,
+        };
+      }),
+    },
+    /**
+     * Response headers policy names must be unique per AWS account. Static app
+     * deploys are always in us-east-1, so the stack name cannot collide with a
+     * same-named stack in another region.
+     */
+    Name: { Ref: 'AWS::StackName' },
+    ...(Object.keys(securityHeadersConfig).length > 0
+      ? { SecurityHeadersConfig: securityHeadersConfig }
+      : {}),
+  };
+};

--- a/packages/carlin/src/deploy/staticApp/staticApp.template.ts
+++ b/packages/carlin/src/deploy/staticApp/staticApp.template.ts
@@ -1,3 +1,8 @@
+/**
+ * `getCloudFrontTemplate` is a single CloudFormation template literal, which
+ * these rules were not written for.
+ */
+/* eslint-disable complexity, max-lines, max-lines-per-function */
 import type {
   CloudFormationTemplate,
   Output,
@@ -6,6 +11,10 @@ import type {
 
 import { getPackageVersion } from '../../utils';
 import { BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME } from '../baseStack/config';
+import {
+  getResponseHeadersPolicyConfig,
+  type ResponseHeader,
+} from './responseHeaders';
 
 const PACKAGE_VERSION = getPackageVersion();
 
@@ -15,6 +24,9 @@ export const CLOUDFRONT_DISTRIBUTION_LOGICAL_ID = 'CloudFrontDistribution';
 
 export const CLOUDFRONT_ORIGIN_ACCESS_CONTROL_LOGICAL_ID =
   'OriginAccessControl';
+
+export const CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID =
+  'ResponseHeadersPolicy';
 
 export const ROUTE_53_RECORD_SET_GROUP_LOGICAL_ID = 'Route53RecordSetGroup';
 
@@ -38,8 +50,50 @@ const ORIGIN_REQUEST_POLICY_ID = '88a5eaf4-2fd4-4709-b370-b4c650ea3fcf';
  * Name: CORS-with-preflight-and-SecurityHeadersPolicy
  * ID: eaab4381-ed33-4a86-88ca-d9558dc6cd63
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
+ *
+ * Used when neither the `responseHeaders` nor the `responseHeadersPolicy`
+ * option is defined. Its settings are reproduced in
+ * `BASELINE_RESPONSE_HEADERS_CONFIG` for the policy created by the
+ * `responseHeaders` option.
  */
-const ORIGIN_RESPONSE_POLICY_ID = 'eaab4381-ed33-4a86-88ca-d9558dc6cd63';
+export const ORIGIN_RESPONSE_POLICY_ID = 'eaab4381-ed33-4a86-88ca-d9558dc6cd63';
+
+/**
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-responseheaderspolicy.html
+ */
+const RESPONSE_HEADERS_POLICY_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * The distribution takes a single response headers policy id, so the three
+ * sources are mutually exclusive:
+ *
+ * 1. `responseHeadersPolicy`: an existing policy id, or the name of an
+ *    exported value whose value is a policy id.
+ * 1. `responseHeaders`: the policy created by this template.
+ * 1. Neither: the managed policy used by every deploy so far.
+ */
+const getResponseHeadersPolicyId = ({
+  responseHeaders = [],
+  responseHeadersPolicy,
+}: {
+  responseHeaders?: ResponseHeader[];
+  responseHeadersPolicy?: string;
+}) => {
+  if (responseHeadersPolicy) {
+    return RESPONSE_HEADERS_POLICY_ID_REGEX.test(responseHeadersPolicy)
+      ? responseHeadersPolicy
+      : { 'Fn::ImportValue': responseHeadersPolicy };
+  }
+
+  if (responseHeaders.length > 0) {
+    return {
+      'Fn::GetAtt': [CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID, 'Id'],
+    };
+  }
+
+  return ORIGIN_RESPONSE_POLICY_ID;
+};
 
 const getBucketStaticWebsiteTemplate = ({
   spa,
@@ -113,6 +167,8 @@ const getCloudFrontTemplate = ({
   acm,
   aliases = [],
   appendIndexHtml,
+  responseHeaders = [],
+  responseHeadersPolicy,
   spa,
   hostedZoneName,
 }: {
@@ -120,6 +176,8 @@ const getCloudFrontTemplate = ({
   aliases?: string[];
   appendIndexHtml?: boolean;
   cloudfront: true;
+  responseHeaders?: ResponseHeader[];
+  responseHeadersPolicy?: string;
   spa?: boolean;
   hostedZoneName?: string;
   region: string;
@@ -228,7 +286,10 @@ const getCloudFrontTemplate = ({
              * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html#cfn-cloudfront-distribution-defaultcachebehavior-cachepolicyid
              */
             CachePolicyId: CACHE_POLICY_ID,
-            ResponseHeadersPolicyId: ORIGIN_RESPONSE_POLICY_ID,
+            ResponseHeadersPolicyId: getResponseHeadersPolicyId({
+              responseHeaders,
+              responseHeadersPolicy,
+            }),
             TargetOriginId: { Ref: STATIC_APP_BUCKET_LOGICAL_ID },
             ViewerProtocolPolicy: 'redirect-to-https',
           },
@@ -277,6 +338,18 @@ const getCloudFrontTemplate = ({
         },
       },
     },
+    ...(responseHeaders.length > 0
+      ? {
+          [CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID]: {
+            Type: 'AWS::CloudFront::ResponseHeadersPolicy',
+            Properties: {
+              ResponseHeadersPolicyConfig: getResponseHeadersPolicyConfig({
+                responseHeaders,
+              }),
+            },
+          },
+        }
+      : {}),
   };
 
   if (acm) {
@@ -439,6 +512,8 @@ export const getStaticAppTemplate = ({
   aliases,
   appendIndexHtml,
   cloudfront,
+  responseHeaders,
+  responseHeadersPolicy,
   spa,
   hostedZoneName,
   region,
@@ -447,6 +522,8 @@ export const getStaticAppTemplate = ({
   aliases?: string[];
   appendIndexHtml?: boolean;
   cloudfront?: boolean;
+  responseHeaders?: ResponseHeader[];
+  responseHeadersPolicy?: string;
   spa?: boolean;
   hostedZoneName?: string;
   region: string;
@@ -457,6 +534,8 @@ export const getStaticAppTemplate = ({
       aliases,
       appendIndexHtml,
       cloudfront,
+      responseHeaders,
+      responseHeadersPolicy,
       spa,
       hostedZoneName,
       region,

--- a/packages/carlin/tests/unit/cli.test.ts
+++ b/packages/carlin/tests/unit/cli.test.ts
@@ -398,3 +398,33 @@ describe('upload-source-maps option', () => {
     expect(argv.uploadSourceMaps).toEqual(true);
   });
 });
+
+describe('response headers options', () => {
+  test('should not define response headers by default', async () => {
+    const argv = await parseCli('deploy static-app', {});
+    expect(argv.responseHeaders).toEqual([]);
+    expect(argv.responseHeadersPolicy).toBeUndefined();
+  });
+
+  test('should accept response-headers option', async () => {
+    const argv = await parseCli(
+      'deploy static-app --cloudfront --response-headers.x-custom=some-value',
+      {}
+    );
+
+    expect(argv.responseHeaders).toEqual([
+      { header: 'x-custom', override: true, value: 'some-value' },
+    ]);
+  });
+
+  test('should accept response-headers-policy option', async () => {
+    const responseHeadersPolicy = '67f7725c-6f97-4210-82d7-5512b31e9d03';
+
+    const argv = await parseCli(
+      `deploy static-app --cloudfront --response-headers-policy=${responseHeadersPolicy}`,
+      {}
+    );
+
+    expect(argv.responseHeadersPolicy).toEqual(responseHeadersPolicy);
+  });
+});

--- a/packages/carlin/tests/unit/deploy/staticApp/command.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/command.test.ts
@@ -1,14 +1,14 @@
+import { faker } from '@ttoss/test-utils/faker';
+import AWS from 'aws-sdk';
+import { CLOUDFRONT_REGION } from 'src/config';
+import { destroyCloudFormation } from 'src/deploy/cloudformation';
+import { deployStaticAppCommand } from 'src/deploy/staticApp/command';
+import { deployStaticApp } from 'src/deploy/staticApp/deployStaticApp';
+import yargs from 'yargs';
+
 jest.mock('src/deploy/cloudformation');
 
 jest.mock('src/deploy/staticApp/deployStaticApp');
-
-import { CLOUDFRONT_REGION } from 'src/config';
-import { deployStaticApp } from 'src/deploy/staticApp/deployStaticApp';
-import { deployStaticAppCommand } from 'src/deploy/staticApp/command';
-import { destroyCloudFormation } from 'src/deploy/cloudformation';
-import { faker } from '@ttoss/test-utils/faker';
-import AWS from 'aws-sdk';
-import yargs from 'yargs';
 
 const cli = yargs().command(deployStaticAppCommand);
 
@@ -144,5 +144,98 @@ describe('should set cloudfront', () => {
     ];
 
     return expect(testHelper(options, false)).resolves.toBeTruthy();
+  });
+});
+
+/**
+ * `parse` passes the options as the yargs context, which skips `coerce` and
+ * the checks, so these tests parse a command line instead.
+ */
+const parseArgs = (args: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Promise<any>((resolve, reject) => {
+    cli.parse(args, {}, (err, argv) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(argv);
+    });
+  });
+};
+
+describe('response headers options', () => {
+  const responseHeadersPolicyId = '67f7725c-6f97-4210-82d7-5512b31e9d03';
+
+  test('should default response-headers to an empty list', async () => {
+    const argv = await parseArgs('static-app');
+    expect(argv.responseHeaders).toEqual([]);
+    expect(argv.responseHeadersPolicy).toBeUndefined();
+  });
+
+  test('should parse the response-headers object into a list', async () => {
+    const argv = await parseArgs(
+      'static-app --cloudfront --response-headers.x-custom=some-value'
+    );
+
+    expect(argv.responseHeaders).toEqual([
+      { header: 'x-custom', override: true, value: 'some-value' },
+    ]);
+
+    expect(deployStaticApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseHeaders: [
+          { header: 'x-custom', override: true, value: 'some-value' },
+        ],
+      })
+    );
+  });
+
+  test('should accept response-headers-policy', async () => {
+    const argv = await parseArgs(
+      `static-app --cloudfront --response-headers-policy=${responseHeadersPolicyId}`
+    );
+
+    expect(argv.responseHeadersPolicy).toEqual(responseHeadersPolicyId);
+  });
+
+  test('should throw for an invalid header name', () => {
+    return expect(
+      parseArgs('static-app --cloudfront --response-headers.x:custom=value')
+    ).rejects.toThrow('is not a valid HTTP header name');
+  });
+
+  test('should throw for a header of the CORS configuration', () => {
+    return expect(
+      parseArgs(
+        'static-app --cloudfront --response-headers.access-control-allow-origin="*"'
+      )
+    ).rejects.toThrow('response-headers-policy');
+  });
+
+  /**
+   * Response headers are applied by CloudFront, so a bucket only deploy has
+   * nothing to attach them to.
+   */
+  test('should throw when response-headers is defined without cloudfront', () => {
+    return expect(
+      parseArgs('static-app --response-headers.x-custom=some-value')
+    ).rejects.toThrow('requires the cloudfront option');
+  });
+
+  test('should throw when response-headers-policy is defined without cloudfront', () => {
+    return expect(
+      parseArgs(
+        `static-app --response-headers-policy=${responseHeadersPolicyId}`
+      )
+    ).rejects.toThrow('requires the cloudfront option');
+  });
+
+  test('should throw when both response headers options are defined', () => {
+    return expect(
+      parseArgs(
+        `static-app --cloudfront --response-headers.x-custom=some-value --response-headers-policy=${responseHeadersPolicyId}`
+      )
+    ).rejects.toThrow('mutually exclusive');
   });
 });

--- a/packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts
@@ -1,0 +1,148 @@
+import {
+  BASELINE_RESPONSE_HEADERS_CONFIG,
+  getResponseHeadersPolicyConfig,
+  parseResponseHeaders,
+} from 'src/deploy/staticApp/responseHeaders';
+
+describe('parseResponseHeaders', () => {
+  test.each([[undefined], [null], [[]], [{}]])(
+    'should return an empty list for %p',
+    (arg) => {
+      expect(parseResponseHeaders(arg)).toEqual([]);
+    }
+  );
+
+  test('should parse the object form and override the origin by default', () => {
+    expect(
+      parseResponseHeaders({
+        'content-security-policy': "default-src 'self'",
+        'permissions-policy': 'geolocation=()',
+      })
+    ).toEqual([
+      {
+        header: 'content-security-policy',
+        override: true,
+        value: "default-src 'self'",
+      },
+      {
+        header: 'permissions-policy',
+        override: true,
+        value: 'geolocation=()',
+      },
+    ]);
+  });
+
+  test('should parse the array form keeping the defined override', () => {
+    expect(
+      parseResponseHeaders([
+        { header: 'x-custom', override: false, value: 'some-value' },
+        { header: 'x-other', value: 'other-value' },
+      ])
+    ).toEqual([
+      { header: 'x-custom', override: false, value: 'some-value' },
+      { header: 'x-other', override: true, value: 'other-value' },
+    ]);
+  });
+
+  test.each([['invalid header'], ['invalid:header'], ['']])(
+    'should throw for the invalid header name %p',
+    (header) => {
+      expect(() => {
+        return parseResponseHeaders({ [header]: 'some-value' });
+      }).toThrow('is not a valid HTTP header name');
+    }
+  );
+
+  test('should throw when the same header is defined twice', () => {
+    expect(() => {
+      return parseResponseHeaders([
+        { header: 'X-Custom', value: 'some-value' },
+        { header: 'x-custom', value: 'other-value' },
+      ]);
+    }).toThrow('was defined more than once');
+  });
+
+  /**
+   * CorsConfig requires its fields as a unit, so a single CORS header cannot
+   * be replaced without inventing semantics for the others.
+   */
+  test.each([
+    ['access-control-allow-origin'],
+    ['Access-Control-Allow-Methods'],
+    ['access-control-max-age'],
+  ])('should throw for the CORS header %p', (header) => {
+    expect(() => {
+      return parseResponseHeaders({ [header]: '*' });
+    }).toThrow('response-headers-policy');
+  });
+});
+
+describe('getResponseHeadersPolicyConfig', () => {
+  test('should keep the baseline settings of the managed policy', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders({ 'x-custom': 'some-value' }),
+    });
+
+    expect(config.CorsConfig).toEqual(
+      BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig
+    );
+    expect(config.SecurityHeadersConfig).toEqual(
+      BASELINE_RESPONSE_HEADERS_CONFIG.SecurityHeadersConfig
+    );
+    expect(config.Name).toEqual({ Ref: 'AWS::StackName' });
+    expect(config.CustomHeadersConfig).toEqual({
+      Items: [{ Header: 'x-custom', Override: true, Value: 'some-value' }],
+    });
+  });
+
+  /**
+   * The managed policy overrides the origin only for X-Content-Type-Options.
+   */
+  test('should keep the override flags of the managed policy', () => {
+    const { SecurityHeadersConfig } = BASELINE_RESPONSE_HEADERS_CONFIG;
+
+    expect(SecurityHeadersConfig.ContentTypeOptions.Override).toBe(true);
+    expect(SecurityHeadersConfig.FrameOptions.Override).toBe(false);
+    expect(SecurityHeadersConfig.ReferrerPolicy.Override).toBe(false);
+    expect(SecurityHeadersConfig.StrictTransportSecurity.Override).toBe(false);
+    expect(SecurityHeadersConfig.XSSProtection.Override).toBe(false);
+  });
+
+  test.each([
+    ['content-security-policy', 'ContentSecurityPolicy'],
+    ['referrer-policy', 'ReferrerPolicy'],
+    ['Strict-Transport-Security', 'StrictTransportSecurity'],
+    ['x-content-type-options', 'ContentTypeOptions'],
+    ['X-Frame-Options', 'FrameOptions'],
+    ['x-xss-protection', 'XSSProtection'],
+  ])(
+    'should drop the baseline %p so the defined header is the only one sent',
+    (header, securityHeadersConfigKey) => {
+      const config = getResponseHeadersPolicyConfig({
+        responseHeaders: parseResponseHeaders({ [header]: 'some-value' }),
+      });
+
+      expect(config.SecurityHeadersConfig).not.toHaveProperty(
+        securityHeadersConfigKey
+      );
+
+      expect(config.CustomHeadersConfig.Items).toEqual([
+        { Header: header, Override: true, Value: 'some-value' },
+      ]);
+    }
+  );
+
+  test('should not add SecurityHeadersConfig when every baseline header is replaced', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders({
+        'referrer-policy': 'no-referrer',
+        'strict-transport-security': 'max-age=63072000',
+        'x-content-type-options': 'nosniff',
+        'x-frame-options': 'DENY',
+        'x-xss-protection': '0',
+      }),
+    });
+
+    expect(config).not.toHaveProperty('SecurityHeadersConfig');
+  });
+});

--- a/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
@@ -1,3 +1,19 @@
+import { faker } from '@ttoss/test-utils/faker';
+import { BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME } from 'src/deploy/baseStack/config';
+import {
+  getResponseHeadersPolicyConfig,
+  parseResponseHeaders,
+} from 'src/deploy/staticApp/responseHeaders';
+import {
+  CLOUDFRONT_DISTRIBUTION_LOGICAL_ID,
+  CLOUDFRONT_ORIGIN_ACCESS_CONTROL_LOGICAL_ID,
+  CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID,
+  getStaticAppTemplate,
+  ORIGIN_RESPONSE_POLICY_ID,
+  ROUTE_53_RECORD_SET_GROUP_LOGICAL_ID,
+  STATIC_APP_BUCKET_LOGICAL_ID,
+} from 'src/deploy/staticApp/staticApp.template';
+
 jest.mock('src/utils', () => {
   const PACKAGE_VERSION = '10.40.23';
 
@@ -7,16 +23,6 @@ jest.mock('src/utils', () => {
     getPackageVersion: jest.fn().mockReturnValue(PACKAGE_VERSION),
   };
 });
-
-import { BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME } from 'src/deploy/baseStack/config';
-import {
-  CLOUDFRONT_DISTRIBUTION_LOGICAL_ID,
-  CLOUDFRONT_ORIGIN_ACCESS_CONTROL_LOGICAL_ID,
-  ROUTE_53_RECORD_SET_GROUP_LOGICAL_ID,
-  STATIC_APP_BUCKET_LOGICAL_ID,
-  getStaticAppTemplate,
-} from 'src/deploy/staticApp/staticApp.template';
-import { faker } from '@ttoss/test-utils/faker';
 
 const region = faker.word.words();
 
@@ -158,4 +164,101 @@ test('should add CloudFront Function that append index.html', () => {
       },
     },
   ]);
+});
+
+describe('response headers', () => {
+  const getDefaultCacheBehavior = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    template: any
+  ) => {
+    return template.Resources[CLOUDFRONT_DISTRIBUTION_LOGICAL_ID].Properties
+      .DistributionConfig.DefaultCacheBehavior;
+  };
+
+  test('should keep the managed policy when no option is defined', () => {
+    const template = getStaticAppTemplate({ region, cloudfront: true });
+
+    expect(getDefaultCacheBehavior(template).ResponseHeadersPolicyId).toEqual(
+      ORIGIN_RESPONSE_POLICY_ID
+    );
+
+    expect(template.Resources).not.toHaveProperty(
+      CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID
+    );
+  });
+
+  test('should create a policy when response headers are defined', () => {
+    const responseHeaders = parseResponseHeaders({
+      'content-security-policy': "default-src 'self'",
+    });
+
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      responseHeaders,
+    });
+
+    expect(getDefaultCacheBehavior(template).ResponseHeadersPolicyId).toEqual({
+      'Fn::GetAtt': [CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID, 'Id'],
+    });
+
+    expect(
+      template.Resources[CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID]
+    ).toEqual({
+      Type: 'AWS::CloudFront::ResponseHeadersPolicy',
+      Properties: {
+        ResponseHeadersPolicyConfig: getResponseHeadersPolicyConfig({
+          responseHeaders,
+        }),
+      },
+    });
+  });
+
+  test('should use the response headers policy id when it is an id', () => {
+    const responseHeadersPolicy = '67f7725c-6f97-4210-82d7-5512b31e9d03';
+
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      responseHeadersPolicy,
+    });
+
+    expect(getDefaultCacheBehavior(template).ResponseHeadersPolicyId).toEqual(
+      responseHeadersPolicy
+    );
+
+    expect(template.Resources).not.toHaveProperty(
+      CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID
+    );
+  });
+
+  test('should import the response headers policy id when it is an exported name', () => {
+    const responseHeadersPolicy = faker.word.words().replace(/\s/g, '');
+
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      responseHeadersPolicy,
+    });
+
+    expect(getDefaultCacheBehavior(template).ResponseHeadersPolicyId).toEqual({
+      'Fn::ImportValue': responseHeadersPolicy,
+    });
+  });
+
+  /**
+   * Response headers are applied by CloudFront, so there is nothing to attach
+   * them to on a bucket-only deploy.
+   */
+  test('should not create a policy without cloudfront', () => {
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: false,
+      responseHeaders: parseResponseHeaders({ 'x-custom': 'some-value' }),
+    });
+
+    expect(template.Resources).not.toHaveProperty(
+      CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID
+    );
+  });
 });


### PR DESCRIPTION
## What

Adds two options to `carlin deploy static-app`, so a static app can send custom response headers without forking the template. Until now response headers came entirely from a hardcoded managed policy, with no way to change them.

### `--response-headers`

An object of header name to value, which creates an `AWS::CloudFront::ResponseHeadersPolicy` attached to the default cache behavior:

```typescript
export default defineConfig({
  cloudfront: true,
  responseHeaders: {
    'content-security-policy': "default-src 'self'",
    'permissions-policy': 'geolocation=()',
  },
});
```

The array form is accepted for the one thing the map can't express — sending a header only when the origin doesn't already send it:

```typescript
responseHeaders: [{ header: 'x-robots-tag', value: 'noindex', override: false }];
```

The object form mirrors the existing `parameters` option of `carlin deploy`. Header names are unique keys, so a map models them natively and merges cleanly across `environments` blocks. It also works on a command line through yargs dot-notation: `--response-headers.x-robots-tag=noindex`.

### `--response-headers-policy`

The id of an existing policy, or the name of an exported value whose value is the id, for policies managed elsewhere — mirroring how `--acm` accepts either an ARN or an export name.

## How

CloudFront applies these headers natively on the response path. No Lambda@Edge and no CloudFront Function is involved, so there is no per-request cost and nothing new to replicate across regions. The existing `--append-index-html` CloudFront Function is untouched.

A cache behavior takes a single `ResponseHeadersPolicyId`, so the three sources are mutually exclusive:

| Input | `ResponseHeadersPolicyId` |
| --- | --- |
| neither option | the managed policy id, as today |
| `--response-headers` | `Fn::GetAtt` of the created policy |
| `--response-headers-policy` | the given id, or `Fn::ImportValue` |

### Preserving the current behavior

A custom policy replaces the managed one rather than extending it, so creating one would silently drop the security and CORS headers every static app deploy has had since CloudFront support was added. The settings of `CORS-with-preflight-and-SecurityHeadersPolicy` are therefore reproduced in `BASELINE_RESPONSE_HEADERS_CONFIG`, transcribed from the AWS docs with the date recorded, and asserted by a test. Note the override flags are not uniform: `X-Content-Type-Options` is the only header the managed policy overrides the origin for.

Deploys that don't define response headers keep referencing the managed policy id unchanged, so nothing existing moves.

Collisions with the baseline are resolved deterministically:

- A **security header** maps 1:1 to an optional `SecurityHeadersConfig` sub-block, so the baseline block is dropped and the given value is the only one sent.
- A **CORS header** cannot be replaced individually, since `CorsConfig` requires its fields as a unit. This is an error pointing at `--response-headers-policy` rather than inventing semantics for the other fields.

### Validation

Both options require `--cloudfront` — the headers are added by CloudFront, so a bucket only deploy has nothing to attach them to — and they are mutually exclusive. Both checks are done with `check` rather than `implies` and `conflicts`, because `cloudfront` and `response-headers` have default values, which yargs considers as provided: neither validator fires. This was caught by testing the real command-line path, since the existing test helpers pass options as the yargs context, which skips `coerce` and validation.

Invalid header names and duplicates (case-insensitively) are also rejected at parse time.

## Tests

`pnpm exec jest` in `packages/carlin`: 361 passed, 44 suites. Typecheck and build clean.

- `tests/unit/deploy/staticApp/responseHeaders.test.ts` (new) — parsing of both forms, validation errors, baseline fidelity and the collision rules. `responseHeaders.ts` is at 100% coverage.
- `staticApp.template.test.ts` — managed policy kept by default, policy created and referenced, id passthrough and export name, no policy without `--cloudfront`.
- `staticApp/command.test.ts` and `cli.test.ts` — default and custom values for both options, plus the checks, parsed from a real command line.

Coverage thresholds in `jest.config.ts` raised to match.

## Notes

- Docs updated in `docs/website/docs/carlin/commands/deploy-static-app.mdx`.
- `AccessControlAllowHeaders` is required by CloudFormation but isn't listed for this policy on the managed policies page. It is set to `['*']`, mirroring the bucket CORS rules already in the template. Worth confirming against `aws cloudfront get-response-headers-policy --id eaab4381-ed33-4a86-88ca-d9558dc6cd63`, which wasn't available from this environment.
- `staticApp.template.ts` got a file-level eslint disable for `complexity`, `max-lines` and `max-lines-per-function`. These are pre-existing violations — the file was already 467 lines against a 400 limit and `getCloudFrontTemplate` already ~290 lines against 80 — that only surface now because the file entered the lint diff. Following the convention used elsewhere in the repo, including `packages/carlin/src/deploy/s3.ts`, rather than refactoring a function this change doesn't restructure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpBnBMcMJPN2GFYeKty5mQ)_