### PR TITLE
feat(carlin): add viewer request function option to deploy static-app

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -129,6 +129,11 @@ carlin deploy static-app --append-index-html
 
 **Use case**: Clean URLs without `.html` extension
 
+**Conflicts with**: `--viewer-request-function-code`. A cache behavior takes a
+single viewer request function, and this option associates the shared one carlin
+keeps in the base stack. A function of your own calls the `appendIndexHtml`
+helper instead.
+
 ### --spa
 
 Enable Single Page Application (SPA) mode.
@@ -213,6 +218,56 @@ takes the policy as given and adds nothing to it.
 
 **Requires**: `--cloudfront`. **Conflicts with**: `--response-headers`. A cache
 behavior takes a single response headers policy.
+
+### --viewer-request-function-code
+
+Path to a file whose code runs as the [CloudFront viewer request function](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
+of the distribution, for logic that has to run before CloudFront looks the
+request up in the cache — rewriting a URI, or answering a request outright.
+
+```typescript
+import { defineConfig } from 'carlin/config';
+
+export default defineConfig({
+  cloudfront: true,
+  viewerRequestFunctionCode: './cloudfront/viewerRequest.js',
+});
+```
+
+The file must declare a `function handler(event)`, which is the entry point
+CloudFront calls. carlin injects an `appendIndexHtml(request)` helper into the
+function, holding the same logic as [`--append-index-html`](#--append-index-html),
+so a site that needs both calls it where it belongs:
+
+```javascript
+function handler(event) {
+  var request = event.request;
+  var accept = request.headers.accept ? request.headers.accept.value : '';
+
+  if (accept.includes('text/markdown')) {
+    request.uri = request.uri.replace(/\/$/, '') + '.md';
+    return request;
+  }
+
+  return appendIndexHtml(request);
+}
+```
+
+Order is yours to choose at the call site, and it matters: a function rewriting
+`/docs/guide` to `/docs/guide.md` has to run before the index appending, which
+would otherwise turn the URI into `/docs/guide/index.html` first.
+
+The rewritten URI is what CloudFront looks up in the cache, so each branch gets
+its own cache entry with no cache policy change. Pair the example above with
+`responseHeaders: { vary: 'accept' }` so caches downstream key on the header the
+function reads.
+
+**Requires**: `--cloudfront`. **Conflicts with**: `--append-index-html`.
+
+**Constraints**: CloudFront runs the code on the `cloudfront-js-2.0` runtime,
+with no network, filesystem, timers or dynamic evaluation, and no access to the
+request body. The composed function — your code plus the injected helper — must
+stay under 10 KB, which carlin checks before deploying.
 
 ### --skip-upload
 

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,10 +6,10 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 72.15,
-      branches: 62.9,
-      lines: 72.05,
-      functions: 74.8,
+      statements: 72.7,
+      branches: 63.9,
+      lines: 72.6,
+      functions: 75,
     },
   },
   moduleNameMapper: {

--- a/packages/carlin/src/deploy/staticApp/command.ts
+++ b/packages/carlin/src/deploy/staticApp/command.ts
@@ -94,6 +94,11 @@ export const options = {
     require: false,
     type: 'boolean',
   },
+  'viewer-request-function-code': {
+    describe:
+      'Path to a file whose code runs as the CloudFront viewer request function of the distribution. The file must declare a `function handler(event)`, and may call the `appendIndexHtml(request)` helper carlin injects.',
+    type: 'string',
+  },
 } as const;
 
 export const deployStaticAppCommand: CommandModule<
@@ -132,6 +137,37 @@ export const deployStaticAppCommand: CommandModule<
                   ? 'response-headers'
                   : 'response-headers-policy'
               } option requires the cloudfront option.`
+            );
+          }
+
+          return true;
+        })
+        .check(({ appendIndexHtml, cloudfront, viewerRequestFunctionCode }) => {
+          if (!viewerRequestFunctionCode) {
+            return true;
+          }
+
+          /**
+           * A cache behavior takes a single viewer request function, and the
+           * shared base stack one is what append-index-html associates. The app
+           * supplied function gets the same behavior by calling the
+           * `appendIndexHtml` helper carlin injects.
+           *
+           * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html
+           */
+          if (appendIndexHtml) {
+            throw new Error(
+              'The append-index-html and viewer-request-function-code options are mutually exclusive. A cache behavior takes a single viewer request function. Call `appendIndexHtml(request)` from your function instead, which carlin injects for you.'
+            );
+          }
+
+          /**
+           * The function is associated to a cache behavior, so a bucket only
+           * deploy has nothing to attach it to.
+           */
+          if (!cloudfront) {
+            throw new Error(
+              'The viewer-request-function-code option requires the cloudfront option.'
             );
           }
 

--- a/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
+++ b/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
@@ -5,6 +5,7 @@ import { invalidateCloudFront } from './invalidateCloudFront';
 import { type ResponseHeader } from './responseHeaders';
 import { getStaticAppTemplate } from './staticApp.template';
 import { uploadBuiltAppToS3 } from './uploadBuiltAppToS3';
+import { readViewerRequestFunctionCode } from './viewerRequestFunction';
 
 const logPrefix = 'static-app';
 
@@ -29,6 +30,7 @@ export const deployStaticApp = async ({
   region,
   skipUpload,
   uploadSourceMaps,
+  viewerRequestFunctionCode,
 }: {
   acm?: string;
   aliases?: string[];
@@ -42,6 +44,11 @@ export const deployStaticApp = async ({
   region: string;
   skipUpload?: boolean;
   uploadSourceMaps?: boolean;
+  /**
+   * Path to the file holding the viewer request function code, read here so the
+   * template receives the source.
+   */
+  viewerRequestFunctionCode?: string;
 }) => {
   try {
     const { stackName } = await handleDeployInitialization({ logPrefix });
@@ -58,6 +65,9 @@ export const deployStaticApp = async ({
       spa,
       hostedZoneName,
       region,
+      viewerRequestFunctionCode: viewerRequestFunctionCode
+        ? readViewerRequestFunctionCode({ filePath: viewerRequestFunctionCode })
+        : undefined,
     });
 
     const bucket = await getStaticAppBucket({ stackName });

--- a/packages/carlin/src/deploy/staticApp/staticApp.template.ts
+++ b/packages/carlin/src/deploy/staticApp/staticApp.template.ts
@@ -15,6 +15,10 @@ import {
   getResponseHeadersPolicyConfig,
   type ResponseHeader,
 } from './responseHeaders';
+import {
+  FUNCTION_RUNTIME,
+  getViewerRequestFunctionCode,
+} from './viewerRequestFunction';
 
 const PACKAGE_VERSION = getPackageVersion();
 
@@ -27,6 +31,9 @@ export const CLOUDFRONT_ORIGIN_ACCESS_CONTROL_LOGICAL_ID =
 
 export const CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID =
   'ResponseHeadersPolicy';
+
+export const CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID =
+  'ViewerRequestFunction';
 
 export const ROUTE_53_RECORD_SET_GROUP_LOGICAL_ID = 'Route53RecordSetGroup';
 
@@ -171,6 +178,7 @@ const getCloudFrontTemplate = ({
   responseHeadersPolicy,
   spa,
   hostedZoneName,
+  viewerRequestFunctionCode,
 }: {
   acm?: string;
   aliases?: string[];
@@ -181,6 +189,7 @@ const getCloudFrontTemplate = ({
   spa?: boolean;
   hostedZoneName?: string;
   region: string;
+  viewerRequestFunctionCode?: string;
 }): CloudFormationTemplate => {
   const template: CloudFormationTemplate = {
     AWSTemplateFormatVersion: '2010-09-09',
@@ -453,7 +462,68 @@ const getCloudFrontTemplate = ({
     {}
   );
 
-  if (appendIndexHtml) {
+  /**
+   * A cache behavior takes a single viewer request function, so the app
+   * supplied one replaces the shared base stack one instead of being appended
+   * to it. `appendIndexHtml` is available to the app code as a helper, which is
+   * why the two options are mutually exclusive.
+   *
+   * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html
+   */
+  if (appendIndexHtml && viewerRequestFunctionCode) {
+    throw new Error(
+      'The append-index-html and viewer-request-function-code options are mutually exclusive. A cache behavior takes a single viewer request function. Call `appendIndexHtml(request)` from your function instead, which carlin injects for you.'
+    );
+  }
+
+  if (viewerRequestFunctionCode) {
+    template.Resources[CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID] = {
+      Type: 'AWS::CloudFront::Function',
+      Properties: {
+        /**
+         * Function names must be unique per AWS account. Static app deploys are
+         * always in us-east-1, so the stack name cannot collide with a
+         * same-named stack in another region.
+         */
+        Name: { Ref: 'AWS::StackName' },
+        FunctionConfig: {
+          Comment: {
+            'Fn::Sub': [
+              'Viewer request function for the ${Project} project.',
+              { Project: { Ref: 'Project' } },
+            ],
+          },
+          Runtime: FUNCTION_RUNTIME,
+        },
+        FunctionCode: getViewerRequestFunctionCode({
+          code: viewerRequestFunctionCode,
+        }),
+        AutoPublish: true,
+      },
+    };
+  }
+
+  const viewerRequestFunctionArn = (() => {
+    if (viewerRequestFunctionCode) {
+      return {
+        'Fn::GetAtt': [
+          CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID,
+          'FunctionMetadata.FunctionARN',
+        ],
+      };
+    }
+
+    if (appendIndexHtml) {
+      return {
+        'Fn::ImportValue':
+          BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME,
+      };
+    }
+
+    return undefined;
+  })();
+
+  if (viewerRequestFunctionArn) {
     if (!template.Resources[CLOUDFRONT_DISTRIBUTION_LOGICAL_ID].Properties) {
       template.Resources[CLOUDFRONT_DISTRIBUTION_LOGICAL_ID].Properties = {};
     }
@@ -467,10 +537,7 @@ const getCloudFrontTemplate = ({
          */
         {
           EventType: 'viewer-request',
-          FunctionARN: {
-            'Fn::ImportValue':
-              BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME,
-          },
+          FunctionARN: viewerRequestFunctionArn,
         },
       ];
   }
@@ -517,6 +584,7 @@ export const getStaticAppTemplate = ({
   spa,
   hostedZoneName,
   region,
+  viewerRequestFunctionCode,
 }: {
   acm?: string;
   aliases?: string[];
@@ -527,6 +595,7 @@ export const getStaticAppTemplate = ({
   spa?: boolean;
   hostedZoneName?: string;
   region: string;
+  viewerRequestFunctionCode?: string;
 }): CloudFormationTemplate => {
   if (cloudfront) {
     return getCloudFrontTemplate({
@@ -539,6 +608,7 @@ export const getStaticAppTemplate = ({
       spa,
       hostedZoneName,
       region,
+      viewerRequestFunctionCode,
     });
   }
 

--- a/packages/carlin/src/deploy/staticApp/viewerRequestFunction.ts
+++ b/packages/carlin/src/deploy/staticApp/viewerRequestFunction.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Maximum size of a CloudFront Function, in bytes.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-function-quotas.html
+ */
+export const MAX_FUNCTION_SIZE_BYTES = 10 * 1024;
+
+/**
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/writing-function-code.html
+ */
+export const FUNCTION_RUNTIME = 'cloudfront-js-2.0';
+
+/**
+ * `appendIndexHtml` injected into every app-supplied viewer request function.
+ *
+ * A cache behavior takes a single viewer request function, so an app that
+ * supplies its own cannot also associate the shared `AppendIndexDotHtml` of the
+ * base stack. Composing the two by concatenating their sources would not work
+ * either: both would declare `handler`, and the later declaration would win
+ * silently, dropping one of the behaviors.
+ *
+ * Injecting the logic as a named helper instead leaves a single `handler` in the
+ * composed source and makes the order explicit at the call site, which is where
+ * it matters — a function rewriting `/docs/x` to `/docs/x.md` must run before
+ * the index appending, one rewriting `/docs/x` to `/x/docs` after it.
+ *
+ * The body is the base stack `AppendIndexDotHtml` function
+ * (`getCloudFrontTemplate.ts`) with the event unwrapping removed, so both
+ * behave the same. `tests/unit/deploy/staticApp/viewerRequestFunction.test.ts`
+ * asserts they don't drift.
+ */
+export const APPEND_INDEX_HTML_HELPER = `function appendIndexHtml(request) {
+  var uri = request.uri;
+  if (uri.endsWith('/')) {
+    request.uri += 'index.html';
+  } else if (!uri.includes('.')) {
+    request.uri += '/index.html';
+  }
+  return request;
+}`;
+
+/**
+ * The entry point CloudFront calls. A function whose code doesn't declare it
+ * fails at deploy time with an opaque error, so it's checked at synth time.
+ */
+const HANDLER_DECLARATION_REGEX = /function\s+handler\s*\(/;
+
+/**
+ * Reads the file the `viewerRequestFunctionCode` option points to.
+ */
+export const readViewerRequestFunctionCode = ({
+  filePath,
+}: {
+  filePath: string;
+}): string => {
+  const resolvedPath = path.resolve(filePath);
+
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(
+      `The viewer-request-function-code option points to "${filePath}", which doesn't exist.`
+    );
+  }
+
+  return fs.readFileSync(resolvedPath, 'utf8');
+};
+
+/**
+ * Composes the source of the per-app `AWS::CloudFront::Function`: the
+ * `appendIndexHtml` helper followed by the app code, which owns the `handler`.
+ */
+export const getViewerRequestFunctionCode = ({
+  code,
+}: {
+  code: string;
+}): string => {
+  if (!code.trim()) {
+    throw new Error(
+      'The viewer-request-function-code option points to an empty file.'
+    );
+  }
+
+  if (!HANDLER_DECLARATION_REGEX.test(code)) {
+    throw new Error(
+      'The viewer request function code must declare a `function handler(event)`, which is the entry point CloudFront calls.'
+    );
+  }
+
+  const functionCode = `${APPEND_INDEX_HTML_HELPER}\n\n${code.trim()}\n`;
+
+  /**
+   * The helper counts against the app budget, so the size of the composed
+   * source is what CloudFront rejects.
+   */
+  const size = Buffer.byteLength(functionCode, 'utf8');
+
+  if (size > MAX_FUNCTION_SIZE_BYTES) {
+    throw new Error(
+      `The viewer request function is ${size} bytes, above the ${MAX_FUNCTION_SIZE_BYTES} bytes CloudFront allows. The \`appendIndexHtml\` helper carlin injects counts against this budget.`
+    );
+  }
+
+  return functionCode;
+};

--- a/packages/carlin/tests/unit/cli.test.ts
+++ b/packages/carlin/tests/unit/cli.test.ts
@@ -428,3 +428,21 @@ describe('response headers options', () => {
     expect(argv.responseHeadersPolicy).toEqual(responseHeadersPolicy);
   });
 });
+
+describe('viewer request function option', () => {
+  test('should not define a viewer request function by default', async () => {
+    const argv = await parseCli('deploy static-app', {});
+    expect(argv.viewerRequestFunctionCode).toBeUndefined();
+  });
+
+  test('should accept viewer-request-function-code option', async () => {
+    const viewerRequestFunctionCode = './cloudfront/viewerRequest.js';
+
+    const argv = await parseCli(
+      `deploy static-app --cloudfront --viewer-request-function-code=${viewerRequestFunctionCode}`,
+      {}
+    );
+
+    expect(argv.viewerRequestFunctionCode).toEqual(viewerRequestFunctionCode);
+  });
+});

--- a/packages/carlin/tests/unit/deploy/staticApp/command.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/command.test.ts
@@ -239,3 +239,41 @@ describe('response headers options', () => {
     ).rejects.toThrow('mutually exclusive');
   });
 });
+
+describe('viewer request function option', () => {
+  const viewerRequestFunctionCode = './cloudfront/viewerRequest.js';
+
+  /**
+   * A cache behavior takes a single viewer request function, so a config that
+   * would need two associations must fail before the deploy.
+   */
+  test('should throw when combined with append-index-html', () => {
+    return expect(
+      parseArgs(
+        `static-app --cloudfront --append-index-html --viewer-request-function-code=${viewerRequestFunctionCode}`
+      )
+    ).rejects.toThrow('mutually exclusive');
+  });
+
+  /**
+   * The function is associated to a cache behavior, so a bucket only deploy has
+   * nothing to attach it to.
+   */
+  test('should throw when defined without cloudfront', () => {
+    return expect(
+      parseArgs(
+        `static-app --viewer-request-function-code=${viewerRequestFunctionCode}`
+      )
+    ).rejects.toThrow('requires the cloudfront option');
+  });
+
+  test('should pass the option to deployStaticApp', async () => {
+    await parseArgs(
+      `static-app --cloudfront --viewer-request-function-code=${viewerRequestFunctionCode}`
+    );
+
+    expect(deployStaticApp).toHaveBeenCalledWith(
+      expect.objectContaining({ viewerRequestFunctionCode })
+    );
+  });
+});

--- a/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
@@ -8,11 +8,16 @@ import {
   CLOUDFRONT_DISTRIBUTION_LOGICAL_ID,
   CLOUDFRONT_ORIGIN_ACCESS_CONTROL_LOGICAL_ID,
   CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID,
+  CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID,
   getStaticAppTemplate,
   ORIGIN_RESPONSE_POLICY_ID,
   ROUTE_53_RECORD_SET_GROUP_LOGICAL_ID,
   STATIC_APP_BUCKET_LOGICAL_ID,
 } from 'src/deploy/staticApp/staticApp.template';
+import {
+  APPEND_INDEX_HTML_HELPER,
+  FUNCTION_RUNTIME,
+} from 'src/deploy/staticApp/viewerRequestFunction';
 
 jest.mock('src/utils', () => {
   const PACKAGE_VERSION = '10.40.23';
@@ -260,5 +265,126 @@ describe('response headers', () => {
     expect(template.Resources).not.toHaveProperty(
       CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID
     );
+  });
+});
+
+describe('viewer request function', () => {
+  const viewerRequestFunctionCode = `function handler(event) {
+  return appendIndexHtml(event.request);
+}`;
+
+  const getFunctionAssociations = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    template: any
+  ) => {
+    return template.Resources[CLOUDFRONT_DISTRIBUTION_LOGICAL_ID].Properties
+      .DistributionConfig.DefaultCacheBehavior.FunctionAssociations;
+  };
+
+  test('should create a per app function and associate it', () => {
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      viewerRequestFunctionCode,
+    });
+
+    const resource =
+      template.Resources[CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID];
+
+    expect(resource.Type).toEqual('AWS::CloudFront::Function');
+    expect(resource.Properties?.AutoPublish).toEqual(true);
+    expect(resource.Properties?.Name).toEqual({ Ref: 'AWS::StackName' });
+    expect(resource.Properties?.FunctionConfig.Runtime).toEqual(
+      FUNCTION_RUNTIME
+    );
+
+    expect(getFunctionAssociations(template)).toEqual([
+      {
+        EventType: 'viewer-request',
+        FunctionARN: {
+          'Fn::GetAtt': [
+            CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID,
+            'FunctionMetadata.FunctionARN',
+          ],
+        },
+      },
+    ]);
+  });
+
+  test('should inject the appendIndexHtml helper into the function code', () => {
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      viewerRequestFunctionCode,
+    });
+
+    expect(
+      template.Resources[CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID]
+        .Properties?.FunctionCode
+    ).toEqual(`${APPEND_INDEX_HTML_HELPER}\n\n${viewerRequestFunctionCode}\n`);
+  });
+
+  /**
+   * A cache behavior takes a single viewer request function, so a config that
+   * would need two associations must fail at synth time.
+   */
+  test('should throw when combined with appendIndexHtml', () => {
+    return expect(() => {
+      return getStaticAppTemplate({
+        region,
+        cloudfront: true,
+        appendIndexHtml: true,
+        viewerRequestFunctionCode,
+      });
+    }).toThrow('mutually exclusive');
+  });
+
+  test('should replace the shared base stack function instead of appending to it', () => {
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      viewerRequestFunctionCode,
+    });
+
+    expect(getFunctionAssociations(template)).toHaveLength(1);
+    expect(JSON.stringify(template)).not.toContain(
+      BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME
+    );
+  });
+
+  test('should not create the function nor associate one when unset', () => {
+    const template = getStaticAppTemplate({ region, cloudfront: true });
+
+    expect(template.Resources).not.toHaveProperty(
+      CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID
+    );
+    expect(getFunctionAssociations(template)).toBeUndefined();
+  });
+
+  /**
+   * An appendIndexHtml deploy keeps importing the shared base stack function
+   * and gains no per app resource, so it deploys as it did before this option
+   * existed.
+   */
+  test('should not create a per app function for an appendIndexHtml deploy', () => {
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      appendIndexHtml: true,
+    });
+
+    expect(template.Resources).not.toHaveProperty(
+      CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID
+    );
+
+    expect(getFunctionAssociations(template)).toEqual([
+      {
+        EventType: 'viewer-request',
+        FunctionARN: {
+          'Fn::ImportValue':
+            BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME,
+        },
+      },
+    ]);
   });
 });

--- a/packages/carlin/tests/unit/deploy/staticApp/viewerRequestFunction.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/viewerRequestFunction.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_LOGICAL_NAME } from 'src/deploy/baseStack/config';
+import { getCloudFrontTemplate } from 'src/deploy/baseStack/getCloudFrontTemplate';
+import {
+  APPEND_INDEX_HTML_HELPER,
+  getViewerRequestFunctionCode,
+  MAX_FUNCTION_SIZE_BYTES,
+  readViewerRequestFunctionCode,
+} from 'src/deploy/staticApp/viewerRequestFunction';
+
+const HANDLER = `function handler(event) {
+  return appendIndexHtml(event.request);
+}`;
+
+const writeFixture = (code: string) => {
+  const filePath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'carlin-viewer-request-')),
+    'viewerRequest.js'
+  );
+
+  fs.writeFileSync(filePath, code);
+
+  return filePath;
+};
+
+describe('readViewerRequestFunctionCode', () => {
+  test('should read the file the option points to', () => {
+    const filePath = writeFixture(HANDLER);
+
+    expect(readViewerRequestFunctionCode({ filePath })).toEqual(HANDLER);
+  });
+
+  test('should throw when the file does not exist', () => {
+    return expect(() => {
+      return readViewerRequestFunctionCode({
+        filePath: 'does/not/exist.js',
+      });
+    }).toThrow('points to "does/not/exist.js", which doesn\'t exist');
+  });
+});
+
+describe('getViewerRequestFunctionCode', () => {
+  test('should inject the appendIndexHtml helper before the app code', () => {
+    const code = getViewerRequestFunctionCode({ code: HANDLER });
+
+    expect(code).toEqual(`${APPEND_INDEX_HTML_HELPER}\n\n${HANDLER}\n`);
+    expect(code.indexOf('function appendIndexHtml')).toBeLessThan(
+      code.indexOf('function handler')
+    );
+  });
+
+  /**
+   * The composed source has a single `handler`, which is what makes injecting
+   * the logic as a helper different from concatenating the two functions: two
+   * `handler` declarations would silently drop one of the behaviors.
+   */
+  test('should declare handler exactly once', () => {
+    const code = getViewerRequestFunctionCode({ code: HANDLER });
+
+    expect(code.match(/function\s+handler\s*\(/g)).toHaveLength(1);
+  });
+
+  test('should throw when the app code is empty', () => {
+    return expect(() => {
+      return getViewerRequestFunctionCode({ code: '  \n ' });
+    }).toThrow('points to an empty file');
+  });
+
+  test('should throw when the app code does not declare a handler', () => {
+    return expect(() => {
+      return getViewerRequestFunctionCode({
+        code: 'function viewerRequest(event) { return event.request; }',
+      });
+    }).toThrow('must declare a `function handler(event)`');
+  });
+
+  test('should throw when the composed code is above the CloudFront limit', () => {
+    const padding = '/*'.padEnd(MAX_FUNCTION_SIZE_BYTES, '-') + '*/';
+
+    return expect(() => {
+      return getViewerRequestFunctionCode({ code: `${padding}\n${HANDLER}` });
+    }).toThrow(`above the ${MAX_FUNCTION_SIZE_BYTES} bytes CloudFront allows`);
+  });
+
+  test('should count the injected helper against the size limit', () => {
+    /**
+     * App code that fits on its own but not once the helper is prepended.
+     */
+    const size =
+      MAX_FUNCTION_SIZE_BYTES - Buffer.byteLength(APPEND_INDEX_HTML_HELPER) + 1;
+
+    const code = `${'/*'.padEnd(size - HANDLER.length - 4, '-')}*/\n${HANDLER}`;
+
+    expect(Buffer.byteLength(code)).toBeLessThan(MAX_FUNCTION_SIZE_BYTES);
+
+    return expect(() => {
+      return getViewerRequestFunctionCode({ code });
+    }).toThrow('counts against this budget');
+  });
+});
+
+/**
+ * The helper is a copy of the base stack `AppendIndexDotHtml` function, so the
+ * two are asserted to behave the same instead of trusting they stay in sync.
+ */
+describe('appendIndexHtml helper matches the base stack function', () => {
+  const baseStackFunctionCode = getCloudFrontTemplate().Resources[
+    BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_LOGICAL_NAME
+  ].Properties?.FunctionCode as string;
+
+  const baseStackHandler = new Function(
+    `${baseStackFunctionCode}; return handler;`
+  )();
+
+  const helper = new Function(
+    `${APPEND_INDEX_HTML_HELPER}; return appendIndexHtml;`
+  )();
+
+  test.each([
+    '/',
+    '/docs/',
+    '/docs/guide',
+    '/about',
+    '/index.html',
+    '/docs/guide.md',
+    '/assets/main.js',
+  ])('should rewrite %s the same way', (uri) => {
+    expect(helper({ uri })).toEqual(baseStackHandler({ request: { uri } }));
+  });
+});


### PR DESCRIPTION
Adds `viewerRequestFunctionCode` to `carlin deploy static-app`, the request-side counterpart of the `responseHeaders` options added in 2.1.0.

## The problem

`responseHeaders` / `responseHeadersPolicy` opened up the response side of the distribution, but the request side stayed closed. `FunctionAssociations` was hardcoded to the shared `AppendIndexDotHtml` function the base stack exports, so an app had no way to run its own request-time logic — which is what HTTP content negotiation, URI rewriting, and answering a request outright all need.

A cache behavior takes [a single edge function per event type](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html), so an app-supplied function has to *replace* the shared one. And since `AppendIndexDotHtml` lives in the base stack, the composition cannot happen there without running one app's logic for every other static app in the account. It has to be a per-app `AWS::CloudFront::Function`.

## Why a helper rather than concatenation

The obvious composition — concatenate the append-index source and the app source — does not work. Both declare `function handler(event)`, and function-declaration hoisting means the later one wins silently, dropping one of the behaviors. Not a synth error, not a deploy error: a site that appears to deploy fine and 404s on every directory URL.

So the append-index logic is injected as a named `appendIndexHtml(request)` helper instead. The composed source has exactly one `handler`, which the app owns, and the ordering is explicit at the call site — where it actually matters:

```javascript
function handler(event) {
  var request = event.request;
  var accept = request.headers.accept ? request.headers.accept.value : '';

  if (accept.includes('text/markdown')) {
    request.uri = request.uri.replace(/\/$/, '') + '.md';
    return request;
  }

  return appendIndexHtml(request);
}
```

A function rewriting `/docs/guide` → `/docs/guide.md` has to run *before* the index appending, which would otherwise turn the URI into `/docs/guide/index.html` first. Making that the app's visible choice is better than documenting a fixed order carlin picks.

Because the helper replaces the association rather than adding to it, `appendIndexHtml` and `viewerRequestFunctionCode` are mutually exclusive, checked at synth time (and at CLI parse time) with a message pointing at the helper.

## Changes

- `src/deploy/staticApp/viewerRequestFunction.ts` — reads the app file, composes the source, and validates at synth time: non-empty, declares `handler`, and the composed size (helper included) is within the 10 KB CloudFront allows.
- `staticApp.template.ts` — creates the per-app `AWS::CloudFront::Function` and resolves which ARN to associate. Both options unset means no association and no resource, as before; `appendIndexHtml` alone still imports the shared base-stack function and creates no new resource.
- `command.ts` — the CLI option plus the two checks (mutually exclusive with `append-index-html`, requires `cloudfront`), split into a second `.check()` to stay within the complexity limit.
- `deployStaticApp.ts` — reads the path into source so the template stays pure and testable.

No cache-policy change is needed: a viewer-request URI rewrite is what CloudFront looks up in the cache, so each branch gets its own entry for free — the same thing `AppendIndexDotHtml` already relies on. Pair with `responseHeaders: { vary: 'accept' }` when the function reads a header, so downstream caches key on it.

## Tests

387 passing, 45 suites. New coverage:

- `viewerRequestFunction.test.ts` — read/compose/validate, plus a test asserting the composed source declares `handler` exactly once (the concatenation trap above), and a **drift test** that evaluates both the base-stack `AppendIndexDotHtml` code and the injected helper over the same URIs and asserts identical results, so the copy cannot silently diverge.
- `staticApp.template.test.ts` — resource shape, `Fn::GetAtt` association, helper injection, synth-time mutual-exclusion error, and that an `appendIndexHtml` deploy still gets the `Fn::ImportValue` association with no per-app resource.
- `cli.test.ts` / `command.test.ts` — option default and custom value, both validation errors, and pass-through to `deployStaticApp`.

`viewerRequestFunction.ts` is at 100% coverage; `coverageThreshold` raised accordingly. `pnpm run build`, `tsc --noEmit`, and `pnpm run -w lint` are clean.

Note: `pnpm turbo run build --filter=...carlin` fails on this machine at `@ttoss/i18n-cli#build-config` with a `babel-plugin-formatjs` module-linking error. That is pre-existing and unrelated to this diff — carlin builds, typechecks, and tests clean on its own.

Docs updated in `docs/website/docs/carlin/commands/deploy-static-app.mdx`, next to `--response-headers` since the two are used together for negotiation, with the constraints (`cloudfront-js-2.0`, no body access, 10 KB shared budget) written down.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px5gQApL7MoXZn3jifKr9i)_