### PR TITLE
fix(carlin): honor a caller-defined Vary in static app response headers

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -194,6 +194,12 @@ of the security headers above replaces the managed value with yours. The CORS
 headers are configured as a unit and cannot be replaced individually — use
 `--response-headers-policy` when you need to change them.
 
+Defining `vary` is the exception. CloudFront's CORS handling manages `Vary`
+itself and would discard yours, so carlin sends the same CORS headers as custom
+headers instead and your `Vary` reaches the viewer. The distribution then stops
+answering `OPTIONS` preflight requests on its own, which the simple cross-origin
+requests a static app serves never send.
+
 Changing headers updates the distribution, which takes a few minutes to reach
 every edge location. No invalidation is needed: the headers are applied to
 cache hits too.

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,10 +6,10 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 72.7,
-      branches: 63.9,
-      lines: 72.6,
-      functions: 75,
+      statements: 72.8,
+      branches: 64.1,
+      lines: 72.7,
+      functions: 75.2,
     },
   },
   moduleNameMapper: {

--- a/packages/carlin/src/deploy/staticApp/responseHeaders.ts
+++ b/packages/carlin/src/deploy/staticApp/responseHeaders.ts
@@ -101,9 +101,34 @@ export const BASELINE_RESPONSE_HEADERS_CONFIG = {
   },
 } as const;
 
+/**
+ * The headers of `BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig` expressed as
+ * custom headers.
+ *
+ * CloudFront's CORS handling owns `Vary`: with a `CorsConfig` in the policy it
+ * sends `Vary: Origin` on a plain request and removes `Vary` altogether on a
+ * cross-origin one, so a caller-defined `Vary` only survives when the policy
+ * has no `CorsConfig`. The baseline allows a static `*`, which nothing varies
+ * by, so the same headers can be emitted as custom headers and the caller's
+ * `Vary` becomes both true and stable.
+ *
+ * `Access-Control-Allow-Credentials` is omitted because the baseline sets it
+ * to `false`, which is the absence of the header, and `Access-Control-Max-Age`
+ * because the baseline doesn't set it.
+ */
+const CORS_AS_CUSTOM_HEADERS = [
+  { header: 'access-control-allow-origin', value: '*' },
+  {
+    header: 'access-control-allow-methods',
+    value: 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT',
+  },
+  { header: 'access-control-allow-headers', value: '*' },
+  { header: 'access-control-expose-headers', value: '*' },
+];
+
 type ResponseHeadersPolicyConfig = {
   Comment: unknown;
-  CorsConfig: unknown;
+  CorsConfig?: unknown;
   CustomHeadersConfig: {
     Items: { Header: string; Override: boolean; Value: string }[];
   };
@@ -206,6 +231,26 @@ export const getResponseHeadersPolicyConfig = ({
     }
   }
 
+  /**
+   * A `CorsConfig` makes CloudFront manage `Vary` itself, which silently
+   * discards a user-defined one, so the CORS headers move to
+   * `CustomHeadersConfig` when `vary` is defined. The one behavior lost is the
+   * automatic `OPTIONS` preflight response of `CorsConfig`; simple
+   * cross-origin requests, which is what a static app serves, don't preflight.
+   */
+  const definesVary = responseHeaders.some(({ header }) => {
+    return header.toLowerCase() === 'vary';
+  });
+
+  const customHeaders = definesVary
+    ? [
+        ...responseHeaders,
+        ...CORS_AS_CUSTOM_HEADERS.map(({ header, value }) => {
+          return { header, override: true, value };
+        }),
+      ]
+    : responseHeaders;
+
   return {
     Comment: {
       'Fn::Sub': [
@@ -213,9 +258,11 @@ export const getResponseHeadersPolicyConfig = ({
         { Project: { Ref: 'Project' } },
       ],
     },
-    CorsConfig: BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig,
+    ...(definesVary
+      ? {}
+      : { CorsConfig: BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig }),
     CustomHeadersConfig: {
-      Items: responseHeaders.map(({ header, value, override }) => {
+      Items: customHeaders.map(({ header, value, override }) => {
         return {
           Header: header,
           Override: override,

--- a/packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts
@@ -132,6 +132,79 @@ describe('getResponseHeadersPolicyConfig', () => {
     }
   );
 
+  /**
+   * CloudFront's CORS handling owns Vary, so a user-defined one only reaches
+   * the viewer when the policy has no CorsConfig.
+   */
+  test('should express CORS as custom headers when vary is defined', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders({ vary: 'Accept' }),
+    });
+
+    expect(config).not.toHaveProperty('CorsConfig');
+
+    expect(config.CustomHeadersConfig.Items).toEqual([
+      { Header: 'vary', Override: true, Value: 'Accept' },
+      { Header: 'access-control-allow-origin', Override: true, Value: '*' },
+      {
+        Header: 'access-control-allow-methods',
+        Override: true,
+        Value: 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT',
+      },
+      { Header: 'access-control-allow-headers', Override: true, Value: '*' },
+      { Header: 'access-control-expose-headers', Override: true, Value: '*' },
+    ]);
+  });
+
+  test('should match vary case-insensitively', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders({ Vary: 'Accept' }),
+    });
+
+    expect(config).not.toHaveProperty('CorsConfig');
+  });
+
+  /**
+   * The regression guard for every deploy that doesn't define vary.
+   */
+  test('should keep CorsConfig when vary is not defined', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders({ 'x-robots-tag': 'noindex' }),
+    });
+
+    expect(config.CorsConfig).toEqual(
+      BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig
+    );
+
+    expect(config.CustomHeadersConfig.Items).toEqual([
+      { Header: 'x-robots-tag', Override: true, Value: 'noindex' },
+    ]);
+  });
+
+  test('should keep the security headers when vary is defined', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders({ vary: 'Accept' }),
+    });
+
+    expect(config.SecurityHeadersConfig).toEqual(
+      BASELINE_RESPONSE_HEADERS_CONFIG.SecurityHeadersConfig
+    );
+  });
+
+  test('should keep the defined override of a vary in the array form', () => {
+    const config = getResponseHeadersPolicyConfig({
+      responseHeaders: parseResponseHeaders([
+        { header: 'vary', override: false, value: 'Accept' },
+      ]),
+    });
+
+    expect(config.CustomHeadersConfig.Items[0]).toEqual({
+      Header: 'vary',
+      Override: false,
+      Value: 'Accept',
+    });
+  });
+
   test('should not add SecurityHeadersConfig when every baseline header is replaced', () => {
     const config = getResponseHeadersPolicyConfig({
       responseHeaders: parseResponseHeaders({


### PR DESCRIPTION
## Problem

A static app that defines `vary` through `responseHeaders` deploys successfully and the header never reaches the viewer.

`getResponseHeadersPolicyConfig` always emitted `CorsConfig` (reproduced from the managed `CORS-with-preflight-and-SecurityHeadersPolicy`). CloudFront's CORS handling manages `Vary` itself, so with a `CorsConfig` in the policy it sends `Vary: Origin` on a plain request and drops `Vary` altogether on a cross-origin one — the `CustomHeadersConfig` entry loses, silently. `CORS_CONFIG_HEADERS` already rejects the `access-control-*` headers for this reason; `Vary` is the header CORS owns that the list doesn't mention.

## Change

When the caller defines `vary` (case-insensitively), the policy omits `CorsConfig` and emits the baseline CORS headers as custom headers instead (`Override: true`). The baseline allows a static `*`, which nothing varies by, so the CORS behavior is preserved as a set of fixed headers and the caller's `Vary` becomes both true and stable.

| Deploy | Policy |
|---|---|
| No `responseHeaders` | managed policy — unchanged |
| `responseHeaders` without `vary` | created policy with `CorsConfig` — unchanged |
| `responseHeaders` with `vary` | created policy, CORS as custom headers, caller's `Vary` honored |

The one behavioral difference: dropping `CorsConfig` also drops CloudFront's automatic `OPTIONS` preflight response. Simple cross-origin GETs — what a static asset host serves — never preflight, and every app that doesn't define `vary` keeps `CorsConfig` untouched. Documented under `--response-headers`.

## Tests

`packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts`:

- `vary: 'Accept'` → no `CorsConfig`; `CustomHeadersConfig` carries `vary` plus the four `access-control-*` headers
- `Vary` matched case-insensitively
- `x-robots-tag: 'noindex'` → `CorsConfig` still present (regression guard for existing consumers)
- security headers unaffected when `vary` is defined
- array form keeps a per-header `override: false` on `vary`

Full carlin suite passes (392 tests); `responseHeaders.ts` stays at 100% coverage and `coverageThreshold` is raised to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8vVcK4eU4YgFAzihUy12K)_