### PR TITLE
fix(carlin): build a valid response headers policy when vary is defined

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -195,10 +195,14 @@ headers are configured as a unit and cannot be replaced individually — use
 `--response-headers-policy` when you need to change them.
 
 Defining `vary` is the exception. CloudFront's CORS handling manages `Vary`
-itself and would discard yours, so carlin sends the same CORS headers as custom
-headers instead and your `Vary` reaches the viewer. The distribution then stops
-answering `OPTIONS` preflight requests on its own, which the simple cross-origin
-requests a static app serves never send.
+itself — it sends `Vary: Origin` on a plain request and drops `Vary` on a
+cross-origin one — so the policy carlin creates leaves the CORS configuration
+out and your `Vary` reaches the viewer as written. CORS keeps working: the
+bucket the distribution serves from is configured for CORS, and the
+`Managed-CORS-S3Origin` origin request policy forwards `Origin` and the
+`Access-Control-Request-*` headers to it, so S3 answers both simple and
+preflight requests. It allows `GET` and `HEAD`, the methods it can serve, rather
+than the full set the managed policy advertises.
 
 Changing headers updates the distribution, which takes a few minutes to reach
 every edge location. No invalidation is needed: the headers are applied to

--- a/packages/carlin/src/deploy/staticApp/responseHeaders.ts
+++ b/packages/carlin/src/deploy/staticApp/responseHeaders.ts
@@ -101,31 +101,6 @@ export const BASELINE_RESPONSE_HEADERS_CONFIG = {
   },
 } as const;
 
-/**
- * The headers of `BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig` expressed as
- * custom headers.
- *
- * CloudFront's CORS handling owns `Vary`: with a `CorsConfig` in the policy it
- * sends `Vary: Origin` on a plain request and removes `Vary` altogether on a
- * cross-origin one, so a caller-defined `Vary` only survives when the policy
- * has no `CorsConfig`. The baseline allows a static `*`, which nothing varies
- * by, so the same headers can be emitted as custom headers and the caller's
- * `Vary` becomes both true and stable.
- *
- * `Access-Control-Allow-Credentials` is omitted because the baseline sets it
- * to `false`, which is the absence of the header, and `Access-Control-Max-Age`
- * because the baseline doesn't set it.
- */
-const CORS_AS_CUSTOM_HEADERS = [
-  { header: 'access-control-allow-origin', value: '*' },
-  {
-    header: 'access-control-allow-methods',
-    value: 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT',
-  },
-  { header: 'access-control-allow-headers', value: '*' },
-  { header: 'access-control-expose-headers', value: '*' },
-];
-
 type ResponseHeadersPolicyConfig = {
   Comment: unknown;
   CorsConfig?: unknown;
@@ -232,24 +207,23 @@ export const getResponseHeadersPolicyConfig = ({
   }
 
   /**
-   * A `CorsConfig` makes CloudFront manage `Vary` itself, which silently
-   * discards a user-defined one, so the CORS headers move to
-   * `CustomHeadersConfig` when `vary` is defined. The one behavior lost is the
-   * automatic `OPTIONS` preflight response of `CorsConfig`; simple
-   * cross-origin requests, which is what a static app serves, don't preflight.
+   * A `CorsConfig` makes CloudFront manage `Vary` itself — it sends
+   * `Vary: Origin` on a plain request and drops `Vary` on a cross-origin one —
+   * so a user-defined `Vary` only reaches the viewer when the policy has none.
+   *
+   * The CORS headers then come from the bucket, which the static app template
+   * configures for CORS on both of its branches, reached through the
+   * `Managed-CORS-S3Origin` origin request policy that forwards `Origin` and
+   * the `Access-Control-Request-*` headers. S3 answers preflight itself, so
+   * `OPTIONS` keeps working too.
+   *
+   * They cannot be synthesized in `CustomHeadersConfig` instead: CloudFront
+   * rejects a policy that names a header it manages itself, failing the deploy
+   * with a 400.
    */
   const definesVary = responseHeaders.some(({ header }) => {
     return header.toLowerCase() === 'vary';
   });
-
-  const customHeaders = definesVary
-    ? [
-        ...responseHeaders,
-        ...CORS_AS_CUSTOM_HEADERS.map(({ header, value }) => {
-          return { header, override: true, value };
-        }),
-      ]
-    : responseHeaders;
 
   return {
     Comment: {
@@ -262,7 +236,7 @@ export const getResponseHeadersPolicyConfig = ({
       ? {}
       : { CorsConfig: BASELINE_RESPONSE_HEADERS_CONFIG.CorsConfig }),
     CustomHeadersConfig: {
-      Items: customHeaders.map(({ header, value, override }) => {
+      Items: responseHeaders.map(({ header, value, override }) => {
         return {
           Header: header,
           Override: override,

--- a/packages/carlin/src/deploy/staticApp/staticApp.template.ts
+++ b/packages/carlin/src/deploy/staticApp/staticApp.template.ts
@@ -40,6 +40,27 @@ export const ROUTE_53_RECORD_SET_GROUP_LOGICAL_ID = 'Route53RecordSetGroup';
 export const ERROR_DOCUMENT = '404/index.html';
 
 /**
+ * CORS of the bucket the distribution serves from.
+ *
+ * The origin is what answers CORS whenever the response headers policy has no
+ * `CorsConfig` — which is the case when the `responseHeaders` option defines
+ * `vary`, since CloudFront's CORS handling owns `Vary`. `AllowedMethods` is
+ * limited to what the bucket can serve; advertising the write methods of the
+ * managed policy would be fiction.
+ */
+export const BUCKET_CORS_CONFIGURATION = {
+  CorsRules: [
+    {
+      AllowedHeaders: ['*'],
+      AllowedMethods: ['GET', 'HEAD'],
+      AllowedOrigins: ['*'],
+      Id: 'OpenCors',
+      MaxAge: 600,
+    },
+  ],
+} as const;
+
+/**
  * Name: Managed-CachingDisabled
  * ID: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
@@ -113,17 +134,7 @@ const getBucketStaticWebsiteTemplate = ({
       [STATIC_APP_BUCKET_LOGICAL_ID]: {
         Type: 'AWS::S3::Bucket',
         Properties: {
-          CorsConfiguration: {
-            CorsRules: [
-              {
-                AllowedHeaders: ['*'],
-                AllowedMethods: ['GET'],
-                AllowedOrigins: ['*'],
-                Id: 'OpenCors',
-                MaxAge: 600,
-              },
-            ],
-          },
+          CorsConfiguration: BUCKET_CORS_CONFIGURATION,
           PublicAccessBlockConfiguration: {
             BlockPublicPolicy: false,
           },
@@ -197,6 +208,7 @@ const getCloudFrontTemplate = ({
       [STATIC_APP_BUCKET_LOGICAL_ID]: {
         Type: 'AWS::S3::Bucket',
         Properties: {
+          CorsConfiguration: BUCKET_CORS_CONFIGURATION,
           PublicAccessBlockConfiguration: {
             BlockPublicPolicy: false,
           },

--- a/packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/responseHeaders.test.ts
@@ -134,9 +134,10 @@ describe('getResponseHeadersPolicyConfig', () => {
 
   /**
    * CloudFront's CORS handling owns Vary, so a user-defined one only reaches
-   * the viewer when the policy has no CorsConfig.
+   * the viewer when the policy has no CorsConfig. The CORS headers then come
+   * from the bucket, which the static app template configures for CORS.
    */
-  test('should express CORS as custom headers when vary is defined', () => {
+  test('should drop CorsConfig when vary is defined', () => {
     const config = getResponseHeadersPolicyConfig({
       responseHeaders: parseResponseHeaders({ vary: 'Accept' }),
     });
@@ -145,16 +146,30 @@ describe('getResponseHeadersPolicyConfig', () => {
 
     expect(config.CustomHeadersConfig.Items).toEqual([
       { Header: 'vary', Override: true, Value: 'Accept' },
-      { Header: 'access-control-allow-origin', Override: true, Value: '*' },
-      {
-        Header: 'access-control-allow-methods',
-        Override: true,
-        Value: 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT',
-      },
-      { Header: 'access-control-allow-headers', Override: true, Value: '*' },
-      { Header: 'access-control-expose-headers', Override: true, Value: '*' },
     ]);
   });
+
+  /**
+   * CloudFront rejects a policy whose CustomHeadersConfig names a header it
+   * manages itself, so synthesizing the CORS headers there fails the deploy
+   * with a 400 rather than replacing CorsConfig.
+   */
+  test.each([[{ vary: 'Accept' }], [{ 'x-custom': 'some-value' }]])(
+    'should never put a CORS header in CustomHeadersConfig for %p',
+    (responseHeaders) => {
+      const config = getResponseHeadersPolicyConfig({
+        responseHeaders: parseResponseHeaders(responseHeaders),
+      });
+
+      const corsHeaders = config.CustomHeadersConfig.Items.filter(
+        ({ Header }) => {
+          return Header.toLowerCase().startsWith('access-control-');
+        }
+      );
+
+      expect(corsHeaders).toEqual([]);
+    }
+  );
 
   test('should match vary case-insensitively', () => {
     const config = getResponseHeadersPolicyConfig({

--- a/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
@@ -5,6 +5,7 @@ import {
   parseResponseHeaders,
 } from 'src/deploy/staticApp/responseHeaders';
 import {
+  BUCKET_CORS_CONFIGURATION,
   CLOUDFRONT_DISTRIBUTION_LOGICAL_ID,
   CLOUDFRONT_ORIGIN_ACCESS_CONTROL_LOGICAL_ID,
   CLOUDFRONT_RESPONSE_HEADERS_POLICY_LOGICAL_ID,
@@ -386,5 +387,95 @@ describe('viewer request function', () => {
         },
       },
     ]);
+  });
+});
+
+/**
+ * A policy that defines `vary` has no CorsConfig, so CloudFront stops
+ * synthesizing the CORS headers and forwards whatever the origin sends. The
+ * bucket has to answer CORS itself for that to be a wash, on both template
+ * branches.
+ */
+test.each([[true], [false]])(
+  'should configure the bucket for CORS with cloudfront=%p',
+  (cloudfront) => {
+    const template = getStaticAppTemplate({ region, cloudfront });
+
+    expect(
+      template.Resources[STATIC_APP_BUCKET_LOGICAL_ID].Properties
+        .CorsConfiguration
+    ).toEqual(BUCKET_CORS_CONFIGURATION);
+  }
+);
+
+/**
+ * The origin can only serve reads, so advertising the write methods of the
+ * managed policy would be fiction.
+ */
+test('should allow only the methods the bucket serves', () => {
+  expect(BUCKET_CORS_CONFIGURATION.CorsRules[0].AllowedMethods).toEqual([
+    'GET',
+    'HEAD',
+  ]);
+});
+
+describe('acm', () => {
+  const getDistributionConfig = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    template: any
+  ) => {
+    return template.Resources[CLOUDFRONT_DISTRIBUTION_LOGICAL_ID].Properties
+      .DistributionConfig;
+  };
+
+  const acmArn =
+    'arn:aws:acm:us-east-1:123456789012:certificate/abcdef01-2345-6789-abcd-ef0123456789';
+
+  test('should take the certificate arn as given', () => {
+    const aliases = [faker.internet.domainName()];
+
+    const distributionConfig = getDistributionConfig(
+      getStaticAppTemplate({ region, cloudfront: true, acm: acmArn, aliases })
+    );
+
+    expect(distributionConfig.Aliases).toEqual(aliases);
+    expect(distributionConfig.ViewerCertificate).toEqual({
+      AcmCertificateArn: acmArn,
+      MinimumProtocolVersion: 'TLSv1.2_2021',
+      SslSupportMethod: 'sni-only',
+    });
+  });
+
+  test('should import the certificate arn when it is an exported name', () => {
+    const acm = faker.word.words().replace(/\s/g, '');
+
+    const distributionConfig = getDistributionConfig(
+      getStaticAppTemplate({ region, cloudfront: true, acm })
+    );
+
+    expect(distributionConfig.ViewerCertificate.AcmCertificateArn).toEqual({
+      'Fn::ImportValue': acm,
+    });
+  });
+
+  /**
+   * `aliases` defaults to an empty list, which is truthy, so the
+   * `AWS::NoValue` fallback of the template is unreachable and the
+   * distribution gets an empty `Aliases`.
+   */
+  test('should set an empty aliases list when none are defined', () => {
+    const distributionConfig = getDistributionConfig(
+      getStaticAppTemplate({ region, cloudfront: true, acm: acmArn })
+    );
+
+    expect(distributionConfig.Aliases).toEqual([]);
+  });
+
+  test('should not set a certificate without acm', () => {
+    const distributionConfig = getDistributionConfig(
+      getStaticAppTemplate({ region, cloudfront: true })
+    );
+
+    expect(distributionConfig).not.toHaveProperty('ViewerCertificate');
   });
 });


### PR DESCRIPTION
## The bug

`responseHeaders` cannot be used with `vary` — the option that shipped in 2.2.1 for exactly that case. When `vary` is defined, `getResponseHeadersPolicyConfig` drops `CorsConfig` and synthesizes the CORS headers in `CustomHeadersConfig` instead. CloudFront rejects a policy whose `CustomHeadersConfig` names a header it manages itself:

```
Invalid custom header: access-control-allow-origin  (400)
```

So the `AWS::CloudFront::ResponseHeadersPolicy` never creates, and the whole `deploy static-app` fails. Reproduced on a real deploy (ttoss/soat#1111); the workaround there was to drop the option entirely.

## The fix

Keep dropping `CorsConfig` — that part is right, and it is what lets a caller-defined `Vary` reach the viewer (verified at the edge: with no `CorsConfig` and `vary` as a custom header, `vary: Accept, Origin` arrives on every response; with the managed policy attached, only `vary: Origin` does). Serve CORS from the origin instead of faking it at the edge:

- the bucket declares `CorsConfiguration` on the **CloudFront branch** too — it only ever had it on the bucket-only branch, so a distribution deploy had a bucket answering `NoSuchCORSConfiguration`;
- the `Managed-CORS-S3Origin` origin request policy the template already attaches forwards `Origin` and `Access-Control-Request-*`, so S3 sees them and answers both simple and preflight requests. `OPTIONS` keeps working, which the old approach gave up;
- `AllowedMethods` is `GET, HEAD` — what the bucket can serve. The managed policy advertises `DELETE/PATCH/POST/PUT` against an origin that cannot serve them.

Both template branches now share one exported `BUCKET_CORS_CONFIGURATION` so they cannot drift apart again.

## Tests

Red before, green after:

- `getResponseHeadersPolicyConfig` puts **no** `access-control-*` header in `CustomHeadersConfig`, for any input — the guard for the 400 above.
- `vary` still drops `CorsConfig` and emits only the caller's header.
- the bucket declares CORS with `cloudfront: true` **and** `false`.
- `AllowedMethods` is exactly `GET, HEAD`.

Also adds coverage for the `acm` branch of the static app template, which had none: certificate arn taken as given, an exported name imported, and no `ViewerCertificate` without `acm`. That test documents one thing worth a look separately — `aliases` defaults to `[]`, which is truthy, so the template's `AWS::NoValue` fallback is unreachable and a deploy with `acm` and no `aliases` renders `Aliases: []`.

`packages/carlin`: 401 tests pass, `tsc --noEmit` clean, eslint clean. Branch coverage 64.65% (64.16% on main).

## Docs

`deploy-static-app.mdx` described the CORS-as-custom-headers behavior and the lost preflight. Rewritten to describe what the code now does.

## Not in this PR

Two adjacent defects found while tracing this, left out deliberately so the fix stays reviewable:

1. **`handleEnvironments` skips `coerce`.** `cli.ts` assigns `argv[key] = value` for every per-environment option after yargs has run its coercions, so `responseHeaders` declared under `environments.<Name>` arrives as the raw object, and `responseHeaders.length > 0` is `undefined > 0` — the option is silently ignored, with no error. The array form works by accident (it is already the parsed shape) but skips `validateResponseHeaders`. This affects every coerced option on every command, so it wants its own change.
2. `--response-headers` and `--response-headers-policy` are mutually exclusive, which means there is no way to add one header to a policy you otherwise control. Not a bug, just a gap worth noting.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fMy9iKHCqY3qedUEuvWBv)_