### PR TITLE
fix(i18n): invalidate a package's i18n task when a dependency's messages change

### DIFF
--- a/terezinha-farm/vite-app/i18n/lang/en.json
+++ b/terezinha-farm/vite-app/i18n/lang/en.json
@@ -171,6 +171,11 @@
     "defaultMessage": "Sign up",
     "description": "Sign up"
   },
+  "F//XE4": {
+    "module": "@ttoss/react-auth-core",
+    "defaultMessage": "or",
+    "description": "Divider between the password form and the social buttons."
+  },
   "HT4tSM": {
     "module": "@ttoss/react-auth-core",
     "defaultMessage": "Reset Password",
@@ -254,6 +259,11 @@
     "module": "@ttoss/react-auth-core",
     "defaultMessage": "New Password",
     "description": "New Password"
+  },
+  "ehCEm+": {
+    "module": "@ttoss/react-auth-core",
+    "defaultMessage": "Continue with {provider}",
+    "description": "Label of the button that signs in with a social provider."
   },
   "kdFYba": {
     "module": "@ttoss/react-auth-core",

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "outputs": ["dist/**"]
     },
     "i18n": {
-      "dependsOn": ["@ttoss/i18n-cli#build-config"],
+      "dependsOn": ["^i18n", "@ttoss/i18n-cli#build-config"],
       "outputs": ["i18n/**"]
     },
     "build": {


### PR DESCRIPTION
Fixes the red `main` build ([run #1840](https://github.com/ttoss/ttoss/actions/runs/33557184667)), which failed the post-build cleanliness check with `terezinha-farm/vite-app/i18n/lang/en.json` modified.

## What was actually stale

Two keys, both from `@ttoss/react-auth-core`, added by the social sign-in work in ttoss/ttoss#1214:

```
F//XE4: 'or'
ehCEm+: 'Continue with {provider}'
```

## Root cause is the turbo graph, not the file

`ttoss-i18n` merges every `@ttoss` dependency's own `i18n/lang/en.json` into the consuming package's `en.json` (`getTtossExtractedTranslations` in `packages/i18n-cli/src/index.ts`). So a package's i18n output depends on its dependencies' i18n output — but the task declared neither that edge nor those files as inputs:

```json
"i18n": { "dependsOn": ["@ttoss/i18n-cli#build-config"], "outputs": ["i18n/**"] }
```

Two consequences, both verified locally:

**No invalidation.** Injecting a key into `packages/react-auth-cognito/i18n/lang/en.json` left the consumer's task hash unchanged at `d4e2e32cd212c0a6`. A dependency gaining messages never invalidated its consumers.

**Cache hits overwrite tracked files.** `outputs: ["i18n/**"]` covers `i18n/lang/*.json`, which are tracked in git, so a cache hit restores them over the working tree. The failing run was **70 cached of 71 tasks** — no i18n task executed at all, so turbo replayed a pre-#1214 artifact on top of the committed file.

Ordering was unconstrained too: a consumer could extract before its dependencies had regenerated.

This is why the failure looked non-deterministic and would not reproduce locally: #1214 passed because changing `en.json` changed that package's own hash, forcing a miss; the drift only surfaced later on a run where every i18n task hit cache.

## The fix

```json
"i18n": { "dependsOn": ["^i18n", "@ttoss/i18n-cli#build-config"], "outputs": ["i18n/**"] }
```

The dependency edge is now part of the hash — the same injection changes the consumer's hash (`504acbbaadf8be2e` → `743e8e6dfc1e992b`) — and dependencies always extract first.

`en.json` was regenerated with `pnpm run -w i18n`, not edited by hand.

## Verification

- `pnpm run -w i18n` reproduces the missing keys on the pre-fix tree, and a second run is a no-op (idempotent, same md5).
- `pnpm run -w lint` clean with no reformatting; `pnpm run syncpack:lint` clean.
- `i18n/missing/` is gitignored, so the two now-untranslated `pt-BR` keys need no committed bookkeeping.

## Note for reviewers

Worth considering as follow-up, out of scope here: tracked `i18n/lang/*.json` files being declared as cacheable `outputs` means turbo will overwrite committed files from cache whenever a hash collides with reality. `^i18n` closes the known hole, but the general hazard remains as long as generated-and-committed files are cache artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D7TCvPzd2DLuh8CZB1PAY

---
_Generated by [Claude Code](https://claude.ai/code/session_019D7TCvPzd2DLuh8CZB1PAY)_