### PR TITLE
feat(geovis-workspace): let a filters block hold a variations menu

### DIFF
--- a/docs/storybook/stories/geovis-workspace/GeovisWorkspace.fixtures.ts
+++ b/docs/storybook/stories/geovis-workspace/GeovisWorkspace.fixtures.ts
@@ -209,10 +209,15 @@ export const buildPolicyViolationSpec = (): VisualizationSpec => {
 export { sidebarPreviewConfig } from './GeovisWorkspace.sidebarPreview.fixture';
 
 /**
- * Multi-group variant: a single "Variações" tab whose 20+ variations are split
- * across six groups (Demografia, Renda, Saúde, …). The selection stays a single
- * value shared across every group; `defaultValue` ('renda-media') seeds it.
- * Picking any variation recolors the map.
+ * Two menus in one tab: an "Indicador" block with 30 variations and a "Faixa
+ * etária" block with three, both `variations` controls inside a single
+ * `filters` body.
+ *
+ * The point is the packaging, not the content. Declared as variations *bodies*
+ * these two menus would need a tab each, and comparing them would cost a tab
+ * switch; as blocks they stack in one tab, each collapsible under its own
+ * heading. Both drive the shared selection — `variable` picks the colour scale,
+ * `age` scales the metric — so the map reacts to either.
  */
 export const groupedWorkspaceConfig: GeovisWorkspaceConfig = {
   leftSidebar: {
@@ -222,91 +227,75 @@ export const groupedWorkspaceConfig: GeovisWorkspaceConfig = {
         id: 'variable',
         header: { title: 'Variações do mapa', icon: 'lucide:layout-list' },
         body: {
-          kind: 'variations',
-          menuId: 'variable',
-          defaultValue: 'renda-media',
-          defaultGroupId: 'renda',
-          groups: [
+          kind: 'filters',
+          blocks: [
             {
-              id: 'demografia',
-              label: 'Demografia',
+              // First on purpose: the short menu stays in view beside the long
+              // one, which is the whole thing this story has to show.
+              id: 'age',
+              title: 'Faixa etária',
               icon: 'lucide:users',
-              variations: [
-                { value: 'pop-total', label: 'População total' },
-                { value: 'densidade', label: 'Densidade demográfica' },
-                { value: 'faixa-etaria', label: 'Faixa etária' },
-                { value: 'crescimento', label: 'Crescimento populacional' },
-                { value: 'urbano-rural', label: 'Distribuição urbano/rural' },
-              ],
+              control: {
+                kind: 'variations',
+                menuId: 'age',
+                defaultValue: '65-plus',
+                variations: [
+                  { value: '65-plus', label: '65 anos ou mais' },
+                  { value: '70-plus', label: '70 anos ou mais' },
+                  { value: '75-plus', label: '75 anos ou mais' },
+                ],
+              },
             },
             {
-              id: 'renda',
-              label: 'Renda',
-              icon: 'lucide:dollar-sign',
-              variations: [
-                { value: 'renda-media', label: 'Renda média' },
-                { value: 'renda-mediana', label: 'Renda mediana' },
-                { value: 'gini', label: 'Índice de Gini' },
-                { value: 'pobreza', label: 'Taxa de pobreza' },
-                { value: 'informalidade', label: 'Informalidade' },
-              ],
-            },
-            {
-              id: 'saude',
-              label: 'Saúde',
-              icon: 'lucide:heart-pulse',
-              variations: [
-                { value: 'leitos', label: 'Leitos por mil hab.' },
-                {
-                  value: 'mortalidade-infantil',
-                  label: 'Mortalidade infantil',
-                },
-                {
-                  value: 'cobertura-aps',
-                  label: 'Cobertura de atenção básica',
-                },
-                { value: 'vacinacao', label: 'Cobertura vacinal' },
-                { value: 'expectativa', label: 'Expectativa de vida' },
-              ],
-            },
-            {
-              id: 'educacao',
-              label: 'Educação',
-              icon: 'lucide:graduation-cap',
-              variations: [
-                { value: 'alfabetizacao', label: 'Taxa de alfabetização' },
-                { value: 'ideb', label: 'IDEB' },
-                { value: 'evasao', label: 'Evasão escolar' },
-                {
-                  value: 'ensino-superior',
-                  label: 'Acesso ao ensino superior',
-                },
-                { value: 'matriculas', label: 'Matrículas por mil hab.' },
-              ],
-            },
-            {
-              id: 'trabalho',
-              label: 'Trabalho e emprego',
-              icon: 'lucide:briefcase',
-              variations: [
-                { value: 'desemprego', label: 'Taxa de desemprego' },
-                { value: 'ocupacao', label: 'Nível de ocupação' },
-                { value: 'carteira', label: 'Emprego com carteira' },
-                { value: 'rendimento', label: 'Rendimento do trabalho' },
-                { value: 'jornada', label: 'Jornada média' },
-              ],
-            },
-            {
-              id: 'habitacao',
-              label: 'Habitação',
-              icon: 'lucide:home',
-              variations: [
-                { value: 'deficit', label: 'Déficit habitacional' },
-                { value: 'saneamento', label: 'Acesso a saneamento' },
-                { value: 'agua', label: 'Abastecimento de água' },
-                { value: 'energia', label: 'Acesso à energia' },
-                { value: 'adensamento', label: 'Adensamento excessivo' },
-              ],
+              id: 'variable',
+              title: 'Indicador',
+              icon: 'lucide:layout-list',
+              control: {
+                kind: 'variations',
+                menuId: 'variable',
+                defaultValue: 'renda-media',
+                variations: [
+                  { value: 'pop-total', label: 'População total' },
+                  { value: 'densidade', label: 'Densidade demográfica' },
+                  { value: 'faixa-etaria', label: 'Faixa etária' },
+                  { value: 'crescimento', label: 'Crescimento populacional' },
+                  { value: 'urbano-rural', label: 'Distribuição urbano/rural' },
+                  { value: 'renda-media', label: 'Renda média' },
+                  { value: 'renda-mediana', label: 'Renda mediana' },
+                  { value: 'gini', label: 'Índice de Gini' },
+                  { value: 'pobreza', label: 'Taxa de pobreza' },
+                  { value: 'informalidade', label: 'Informalidade' },
+                  { value: 'leitos', label: 'Leitos por mil hab.' },
+                  {
+                    value: 'mortalidade-infantil',
+                    label: 'Mortalidade infantil',
+                  },
+                  {
+                    value: 'cobertura-aps',
+                    label: 'Cobertura de atenção básica',
+                  },
+                  { value: 'vacinacao', label: 'Cobertura vacinal' },
+                  { value: 'expectativa', label: 'Expectativa de vida' },
+                  { value: 'alfabetizacao', label: 'Taxa de alfabetização' },
+                  { value: 'ideb', label: 'IDEB' },
+                  { value: 'evasao', label: 'Evasão escolar' },
+                  {
+                    value: 'ensino-superior',
+                    label: 'Acesso ao ensino superior',
+                  },
+                  { value: 'matriculas', label: 'Matrículas por mil hab.' },
+                  { value: 'desemprego', label: 'Taxa de desemprego' },
+                  { value: 'ocupacao', label: 'Nível de ocupação' },
+                  { value: 'carteira', label: 'Emprego com carteira' },
+                  { value: 'rendimento', label: 'Rendimento do trabalho' },
+                  { value: 'jornada', label: 'Jornada média' },
+                  { value: 'deficit', label: 'Déficit habitacional' },
+                  { value: 'saneamento', label: 'Acesso a saneamento' },
+                  { value: 'agua', label: 'Abastecimento de água' },
+                  { value: 'energia', label: 'Acesso à energia' },
+                  { value: 'adensamento', label: 'Adensamento excessivo' },
+                ],
+              },
             },
           ],
         },

--- a/docs/storybook/stories/geovis-workspace/GeovisWorkspace.stories.tsx
+++ b/docs/storybook/stories/geovis-workspace/GeovisWorkspace.stories.tsx
@@ -433,11 +433,12 @@ const KNOWN_VARIABLES = [
 ] as const;
 
 /**
- * Drives the grouped/carousel variant: holds the single shared selection and
- * derives the map spec from it. The 20 grouped values are demo labels, so each
- * one is mapped deterministically onto one of the three real color scales
- * `buildSpec` knows — enough to see the map recolor as different variations are
- * picked across groups.
+ * Drives the two-menus-in-one-tab variant: holds the shared selection both
+ * blocks write into, and derives the map spec from both keys. The 30 indicator
+ * values are demo labels, so each is mapped deterministically onto one of the
+ * three real color scales `buildSpec` knows; the age value is real, and scales
+ * the metric. Picking in either block recolors the map, which is how the two
+ * menus can be told apart at a glance.
  */
 const GroupedControlsStory = () => {
   const [selection, setSelection] = React.useState(() => {
@@ -452,7 +453,10 @@ const GroupedControlsStory = () => {
         return sum + char.charCodeAt(0);
       }, 0) % KNOWN_VARIABLES.length;
 
-    return buildSpec({ variable: KNOWN_VARIABLES[index], age: '65-plus' });
+    return buildSpec({
+      variable: KNOWN_VARIABLES[index],
+      age: selection.age ?? '65-plus',
+    });
   }, [selection]);
 
   return (
@@ -466,9 +470,24 @@ const GroupedControlsStory = () => {
 };
 
 /**
- * The left sidebar's "Variações" tab groups 20+ variations across six groups
- * (Demografia, Renda, Saúde, Educação, …). `defaultValue` ('renda-media') seeds
- * the shared selection; picking any variation recolors the map.
+ * **Two menus sharing one tab.** "Faixa etária" (three variations) and
+ * "Indicador" (thirty) are both `variations` controls inside a single `filters`
+ * body, so they stack as collapsible blocks instead of claiming a tab each.
+ *
+ * ## What to check
+ *
+ * 1. One tab in the bar, two headings inside it. Collapse either block — the
+ *    other stays put.
+ * 2. Pick an age: the map recolors, because that block drives `selection.age`.
+ *    Pick an indicator: it recolors again, from `selection.variable`. Two
+ *    independent menus, one shared selection object.
+ * 3. Both defaults are seeded before any click — `getInitialSelection` reads a
+ *    `variations` control the same way it reads a `variations` body.
+ *
+ * Declared as bodies these two menus would need a tab each; the tab bar, the
+ * header and the gate all work per section, so comparing them would cost a
+ * switch. The body form is unchanged and still the right shape for a tab given
+ * over to one long menu — `RichLeftSidebar` and `PerVariationFilters` show it.
  */
 export const GroupedControls: Story = {
   render: () => {

--- a/packages/geovis-workspace/README.md
+++ b/packages/geovis-workspace/README.md
@@ -328,8 +328,19 @@ then: not on pause, the steppers, or each auto-advance tick),
 `chips` (`{ kind, menuId?, options, multiple?, defaultSelected? }` — with a
 `menuId` the active ids reach `selection[menuId]` joined by commas, `''` when
 none are active, which is both what the one-string-per-key selection holds and
-what a permalink needs; without one the selection stays visual-only), or
-`locator` (`{ kind, placeholder?, minChars?, options }`).
+what a permalink needs; without one the selection stays visual-only),
+`locator` (`{ kind, placeholder?, minChars?, options }`), or
+`variations` (`{ kind, menuId, variations, defaultValue?, closeOnSelect? }`).
+
+A `variations` **control** is the same menu a `variations` **body** renders —
+the same rows, the same shared selection, seeded the same way by
+`getInitialSelection` — but as a block rather than as a whole tab. That is the
+difference worth choosing between: a body is one menu per tab, so two menus cost
+the user a tab switch; as blocks, several menus stack in one tab, each under its
+own collapsible heading. Reach for the body when a tab belongs to one long menu,
+and for blocks when the menus are read together — an indicator and the age band
+it applies to, say. Both remain available, and a menu behaves identically either
+way, `enabledWhen` gates included.
 
 ### `GeovisWorkspaceRightSidebarState`
 

--- a/packages/geovis-workspace/src/GeovisWorkspaceProvider.tsx
+++ b/packages/geovis-workspace/src/GeovisWorkspaceProvider.tsx
@@ -73,12 +73,16 @@ export interface GeovisWorkspaceProviderProps {
 }
 
 /**
- * Builds the initial selection from the left sidebar's `variations` sections:
- * each seeds `selection[menuId]` with its `defaultValue`. Timeline filters are
- * intentionally NOT seeded here — `useTimeline` publishes a timeline's default
- * to the shared selection on mount, so seeding it here would suppress that
- * publish and leave uncontrolled consumers unaware of the initial value.
- * Use it to seed the parent's selection state when controlling the workspace.
+ * Builds the initial selection from every menu the left sidebar declares: a
+ * `variations` section body, and a `variations` control inside a `filters`
+ * body. Each seeds `selection[menuId]` with its `defaultValue`, so a menu is
+ * seeded the same way whichever of the two surfaces it is declared on.
+ *
+ * Timeline filters are intentionally NOT seeded here — `useTimeline` publishes a
+ * timeline's default to the shared selection on mount, so seeding it here would
+ * suppress that publish and leave uncontrolled consumers unaware of the initial
+ * value. Use it to seed the parent's selection state when controlling the
+ * workspace.
  */
 export const getInitialSelection = ({
   config,
@@ -92,6 +96,13 @@ export const getInitialSelection = ({
 
     if (body.kind === 'variations') {
       selection[body.menuId] = body.defaultValue;
+      continue;
+    }
+
+    for (const block of body.blocks) {
+      if (block.control.kind === 'variations') {
+        selection[block.control.menuId] = block.control.defaultValue;
+      }
     }
   }
 

--- a/packages/geovis-workspace/src/components/LeftSidebar/FiltersTab.tsx
+++ b/packages/geovis-workspace/src/components/LeftSidebar/FiltersTab.tsx
@@ -1,15 +1,87 @@
 import { Flex } from '@ttoss/ui';
 
-import type { GeovisWorkspaceSidebarFilterBlock } from '../../context/GeovisWorkspaceContext';
+import type {
+  GeovisWorkspaceSidebarFilterBlock,
+  GeovisWorkspaceSidebarFilterControl,
+} from '../../context/GeovisWorkspaceContext';
 import { ChipsControl } from './ChipsControl';
 import { CollapsibleSection } from './CollapsibleSection';
 import { LocatorControl } from './LocatorControl';
 import { TimelineControl } from './TimelineControl';
+import { VariationsControl } from './VariationsControl';
+
+/** The lifted state a block's control may need, passed straight through. */
+type LiftedState = {
+  value: number;
+  onValueChange: (next: number) => void;
+  playing: boolean;
+  onTogglePlay: () => void;
+  intervalSeconds: number;
+  onIntervalChange: (next: number) => void;
+  chipSelected: string[];
+  onChipToggle: (id: string) => void;
+  onChipClear: () => void;
+};
 
 /**
- * The "Filtros" tab: a stack of collapsible blocks (timeline, chips, locator).
- * Timeline value and play/pause are lifted; the chips selection is lifted so
- * the tab-bar badge can count it.
+ * Renders one block's control.
+ *
+ * Each kind is matched by name and the locator is left to exhaustion, so the
+ * final `control` is narrowed to it: adding a kind to
+ * {@link GeovisWorkspaceSidebarFilterControl} turns that last line into a type
+ * error instead of silently routing the new kind into the locator.
+ *
+ * @param params.control - The block's control.
+ * @param params.lifted - State owned above the tab (timeline, chips).
+ * @returns The control's element.
+ *
+ * @example
+ * <BlockControl control={{ kind: 'locator', options: [] }} lifted={lifted} />
+ */
+const BlockControl = ({
+  control,
+  lifted,
+}: {
+  control: GeovisWorkspaceSidebarFilterControl;
+  lifted: LiftedState;
+}) => {
+  if (control.kind === 'timeline') {
+    return (
+      <TimelineControl
+        control={control}
+        value={lifted.value}
+        onChange={lifted.onValueChange}
+        playing={lifted.playing}
+        onTogglePlay={lifted.onTogglePlay}
+        intervalSeconds={lifted.intervalSeconds}
+        onIntervalChange={lifted.onIntervalChange}
+      />
+    );
+  }
+
+  if (control.kind === 'chips') {
+    return (
+      <ChipsControl
+        control={control}
+        selected={lifted.chipSelected}
+        onToggle={lifted.onChipToggle}
+        onClear={lifted.onChipClear}
+      />
+    );
+  }
+
+  if (control.kind === 'variations') {
+    return <VariationsControl control={control} />;
+  }
+
+  return <LocatorControl control={control} />;
+};
+
+/**
+ * The "Filtros" tab: a stack of collapsible blocks (timeline, chips, locator,
+ * variations). Timeline value and play/pause are lifted; the chips selection is
+ * lifted so the tab-bar badge can count it. A variations block reads the shared
+ * selection directly, so several of them can share one tab.
  */
 export const FiltersTab = ({
   blocks,
@@ -24,16 +96,19 @@ export const FiltersTab = ({
   onChipClear,
 }: {
   blocks: GeovisWorkspaceSidebarFilterBlock[];
-  value: number;
-  onValueChange: (next: number) => void;
-  playing: boolean;
-  onTogglePlay: () => void;
-  intervalSeconds: number;
-  onIntervalChange: (next: number) => void;
-  chipSelected: string[];
-  onChipToggle: (id: string) => void;
-  onChipClear: () => void;
-}) => {
+} & LiftedState) => {
+  const lifted: LiftedState = {
+    value,
+    onValueChange,
+    playing,
+    onTogglePlay,
+    intervalSeconds,
+    onIntervalChange,
+    chipSelected,
+    onChipToggle,
+    onChipClear,
+  };
+
   return (
     <Flex
       sx={{
@@ -45,8 +120,6 @@ export const FiltersTab = ({
       }}
     >
       {blocks.map((block) => {
-        const { control } = block;
-
         return (
           <CollapsibleSection
             key={block.id}
@@ -54,26 +127,7 @@ export const FiltersTab = ({
             icon={block.icon}
             defaultOpen={block.defaultOpen ?? true}
           >
-            {control.kind === 'timeline' ? (
-              <TimelineControl
-                control={control}
-                value={value}
-                onChange={onValueChange}
-                playing={playing}
-                onTogglePlay={onTogglePlay}
-                intervalSeconds={intervalSeconds}
-                onIntervalChange={onIntervalChange}
-              />
-            ) : control.kind === 'chips' ? (
-              <ChipsControl
-                control={control}
-                selected={chipSelected}
-                onToggle={onChipToggle}
-                onClear={onChipClear}
-              />
-            ) : (
-              <LocatorControl control={control} />
-            )}
+            <BlockControl control={block.control} lifted={lifted} />
           </CollapsibleSection>
         );
       })}

--- a/packages/geovis-workspace/src/components/LeftSidebar/VariationRow.tsx
+++ b/packages/geovis-workspace/src/components/LeftSidebar/VariationRow.tsx
@@ -1,0 +1,99 @@
+import { Box, Text } from '@ttoss/ui';
+
+import type { GeovisWorkspaceSidebarVariation } from '../../context/GeovisWorkspaceContext';
+import { IconChip } from './IconChip';
+import { COLOR } from './theme';
+
+const ACCENT = COLOR.primary;
+
+/**
+ * One selectable variation row: icon chip, label, and an active dot.
+ *
+ * Shared by the two surfaces a menu can be rendered on — the "Variações" tab
+ * and a `variations` filter block — so a menu looks the same whichever one it
+ * is declared as, and a change to the row reaches both.
+ *
+ * @param params.variation - The variation this row selects.
+ * @param params.on - Whether it is the menu's current value.
+ * @param params.onSelect - Called when the row is pressed.
+ * @returns The row.
+ *
+ * @example
+ * <VariationRow variation={{ value: 'renda', label: 'Renda' }} on onSelect={pick} />
+ */
+export const VariationRow = ({
+  variation,
+  on,
+  onSelect,
+}: {
+  variation: GeovisWorkspaceSidebarVariation;
+  on: boolean;
+  onSelect: () => void;
+}) => {
+  const rowSx = on
+    ? {
+        borderLeft: `3px solid ${ACCENT}`,
+        backgroundColor: COLOR.primaryTint,
+        '&:hover': { backgroundColor: COLOR.primaryTint },
+      }
+    : {
+        borderLeft: '3px solid transparent',
+        backgroundColor: 'transparent',
+        '&:hover': { backgroundColor: COLOR.fill },
+      };
+
+  return (
+    <Box
+      as="button"
+      {...({ type: 'button' } as object)}
+      aria-pressed={on}
+      onClick={onSelect}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        width: '100%',
+        paddingX: '16px',
+        paddingY: '10px',
+        textAlign: 'left',
+        border: 'none',
+        cursor: 'pointer',
+        transition: 'background-color 0.15s ease',
+        ...rowSx,
+      }}
+    >
+      <IconChip
+        icon={variation.icon ?? 'lucide:circle'}
+        color={on ? ACCENT : COLOR.textFaint}
+        background={on ? `${ACCENT}1a` : COLOR.fillAlt}
+        size={28}
+        iconSize={13}
+      />
+
+      <Text
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: '13px',
+          fontWeight: on ? 500 : 400,
+          lineHeight: 1.3,
+          color: on ? COLOR.textStrong : COLOR.textMuted,
+        }}
+      >
+        {variation.label}
+      </Text>
+
+      {on ? (
+        <Box
+          sx={{
+            flexShrink: 0,
+            width: '6px',
+            height: '6px',
+            borderRadius: '9999px',
+            backgroundColor: ACCENT,
+          }}
+        />
+      ) : null}
+    </Box>
+  );
+};

--- a/packages/geovis-workspace/src/components/LeftSidebar/VariationsControl.tsx
+++ b/packages/geovis-workspace/src/components/LeftSidebar/VariationsControl.tsx
@@ -1,0 +1,64 @@
+import { Box } from '@ttoss/ui';
+
+import type { GeovisWorkspaceSidebarVariationsFilter } from '../../context/GeovisWorkspaceContext';
+import { useGeovisWorkspace } from '../../hooks/useGeovisWorkspace';
+import { VariationRow } from './VariationRow';
+
+/**
+ * A menu of variations rendered inside a filter block: the same rows as the
+ * "Variações" tab, driving the same shared selection, but scoped to one block so
+ * a tab can stack several menus.
+ *
+ * The selection is read from the provider rather than lifted into `FiltersTab`
+ * the way the timeline and chips are. Those two are lifted because something
+ * outside their block needs them — the HUD drives the timeline, the tab badge
+ * counts the chips. A menu has no such reader: its value already lives in the
+ * shared selection, which is where every consumer looks for it. Keeping it there
+ * is also what lets a tab hold any number of menus, since none of them needs a
+ * slot of its own above the tab.
+ *
+ * @param params.control - The control's declaration.
+ * @returns The menu's rows.
+ *
+ * @example
+ * <VariationsControl control={{ kind: 'variations', menuId: 'indicator', variations }} />
+ */
+export const VariationsControl = ({
+  control,
+}: {
+  control: GeovisWorkspaceSidebarVariationsFilter;
+}) => {
+  const { selection, setSelection, setLeftSidebarOpen } = useGeovisWorkspace();
+  const { menuId } = control;
+
+  const selectedValue = selection[menuId] ?? control.defaultValue;
+
+  return (
+    <Box
+      role="group"
+      sx={{
+        // Cancels the block's own horizontal padding: the rows carry their own,
+        // and their active state is a full-bleed tint with a left border, which
+        // reads as a stripe down the block rather than a floating bar only when
+        // it reaches the card's edges — the same way it does in the tab.
+        marginX: '-16px',
+      }}
+    >
+      {control.variations.map((variation) => {
+        return (
+          <VariationRow
+            key={variation.value}
+            variation={variation}
+            on={variation.value === selectedValue}
+            onSelect={() => {
+              setSelection({ menuId, value: variation.value });
+              if (control.closeOnSelect) {
+                setLeftSidebarOpen({ open: false });
+              }
+            }}
+          />
+        );
+      })}
+    </Box>
+  );
+};

--- a/packages/geovis-workspace/src/components/LeftSidebar/VariationsTab.tsx
+++ b/packages/geovis-workspace/src/components/LeftSidebar/VariationsTab.tsx
@@ -1,92 +1,8 @@
-import { Box, Text } from '@ttoss/ui';
+import { Box } from '@ttoss/ui';
 
 import type { GeovisWorkspaceSidebarVariationsBody } from '../../context/GeovisWorkspaceContext';
 import { useGeovisWorkspace } from '../../hooks/useGeovisWorkspace';
-import { IconChip } from './IconChip';
-import { COLOR } from './theme';
-
-type Variation =
-  GeovisWorkspaceSidebarVariationsBody['groups'][number]['variations'][number];
-
-const ACCENT = COLOR.primary;
-
-/** One selectable variation row: icon chip, label, and an active dot. */
-const VariationRow = ({
-  variation,
-  on,
-  onSelect,
-}: {
-  variation: Variation;
-  on: boolean;
-  onSelect: () => void;
-}) => {
-  const rowSx = on
-    ? {
-        borderLeft: `3px solid ${ACCENT}`,
-        backgroundColor: COLOR.primaryTint,
-        '&:hover': { backgroundColor: COLOR.primaryTint },
-      }
-    : {
-        borderLeft: '3px solid transparent',
-        backgroundColor: 'transparent',
-        '&:hover': { backgroundColor: COLOR.fill },
-      };
-
-  return (
-    <Box
-      as="button"
-      {...({ type: 'button' } as object)}
-      aria-pressed={on}
-      onClick={onSelect}
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '12px',
-        width: '100%',
-        paddingX: '16px',
-        paddingY: '10px',
-        textAlign: 'left',
-        border: 'none',
-        cursor: 'pointer',
-        transition: 'background-color 0.15s ease',
-        ...rowSx,
-      }}
-    >
-      <IconChip
-        icon={variation.icon ?? 'lucide:circle'}
-        color={on ? ACCENT : COLOR.textFaint}
-        background={on ? `${ACCENT}1a` : COLOR.fillAlt}
-        size={28}
-        iconSize={13}
-      />
-
-      <Text
-        sx={{
-          flex: 1,
-          minWidth: 0,
-          fontSize: '13px',
-          fontWeight: on ? 500 : 400,
-          lineHeight: 1.3,
-          color: on ? COLOR.textStrong : COLOR.textMuted,
-        }}
-      >
-        {variation.label}
-      </Text>
-
-      {on ? (
-        <Box
-          sx={{
-            flexShrink: 0,
-            width: '6px',
-            height: '6px',
-            borderRadius: '9999px',
-            backgroundColor: ACCENT,
-          }}
-        />
-      ) : null}
-    </Box>
-  );
-};
+import { VariationRow } from './VariationRow';
 
 /**
  * The flat "Variações" list: every variation across all groups, one per row,
@@ -97,6 +13,10 @@ const VariationRow = ({
  *
  * With `body.closeOnSelect`, picking a row also closes the sidebar, so the map
  * it just recolored is visible without a second tap.
+ *
+ * This is the whole-tab surface for a single menu. For several menus sharing one
+ * tab, declare each as a `variations` control inside a `filters` body instead:
+ * the rows are the same, and blocks give every menu its own heading.
  */
 export const VariationsTab = ({
   body,

--- a/packages/geovis-workspace/src/components/LeftSidebar/useSections.ts
+++ b/packages/geovis-workspace/src/components/LeftSidebar/useSections.ts
@@ -69,11 +69,14 @@ const findChips = (
 
 /**
  * Resolves a menu's effective value: the shared selection, falling back to the
- * `defaultValue` of the variations body that drives that menu.
+ * `defaultValue` of whichever declaration drives that menu — a variations body,
+ * or a variations control inside a `filters` body.
  *
  * The fallback is what keeps a gate stable on first paint — a consumer that
  * does not seed through `getInitialSelection` would otherwise read `undefined`
- * and flash every gated section as disabled before the first pick.
+ * and flash every gated section as disabled before the first pick. Both
+ * surfaces are searched so `enabledWhen` can gate on either kind of menu; a gate
+ * naming a menu declared as a block would otherwise never resolve.
  *
  * @param params.sections - The sidebar's sections.
  * @param params.selection - The shared selection.
@@ -96,6 +99,15 @@ export const resolveMenuValue = ({
 
   if (selected !== undefined) {
     return selected;
+  }
+
+  for (const { block } of findFilterBlocks(sections)) {
+    if (
+      block.control.kind === 'variations' &&
+      block.control.menuId === menuId
+    ) {
+      return block.control.defaultValue;
+    }
   }
 
   for (const section of sections) {

--- a/packages/geovis-workspace/src/context/GeovisWorkspaceContext.ts
+++ b/packages/geovis-workspace/src/context/GeovisWorkspaceContext.ts
@@ -263,11 +263,48 @@ export interface GeovisWorkspaceSidebarLocatorFilter {
   options: GeovisWorkspaceSidebarLocatorOption[];
 }
 
+/**
+ * A variations control: one menu of variations driving `selection[menuId]`,
+ * rendered as the same rows the "Variações" tab uses.
+ *
+ * What this adds over {@link GeovisWorkspaceSidebarVariationsBody} is how many
+ * menus one tab can hold. A variations *body* is a single menu filling its tab —
+ * its `groups` share one `menuId` and flatten into one list — so two menus mean
+ * two tabs, and crossing between them costs a tab switch. As a filter *control*
+ * a menu becomes a block instead, and `filters` bodies stack blocks: several
+ * menus then share one tab, each under its own collapsible heading, exactly as
+ * the timeline and chips already do.
+ *
+ * Neither replaces the other. A tab given over to one long menu is still better
+ * as a body; menus read together — an indicator and the age band it applies to,
+ * say — are better as blocks.
+ */
+export interface GeovisWorkspaceSidebarVariationsFilter {
+  kind: 'variations';
+  /** Keys the shared selection this control drives (`selection[menuId]`). */
+  menuId: string;
+  /** The selectable variations, in the order they are rendered. */
+  variations: GeovisWorkspaceSidebarVariation[];
+  /**
+   * Variation selected on first render, seeded into the shared selection by
+   * `getInitialSelection` the same way a variations body's default is.
+   */
+  defaultValue?: string;
+  /**
+   * Closes the left sidebar right after a variation is picked. Defaults to
+   * `false`, and the default earns its keep here more than on a body: blocks
+   * sharing a tab are usually read together, so closing on the first pick would
+   * take the sibling menus away mid-decision.
+   */
+  closeOnSelect?: boolean;
+}
+
 /** A filter control, discriminated by `kind`. */
 export type GeovisWorkspaceSidebarFilterControl =
   | GeovisWorkspaceSidebarTimelineFilter
   | GeovisWorkspaceSidebarChipsFilter
-  | GeovisWorkspaceSidebarLocatorFilter;
+  | GeovisWorkspaceSidebarLocatorFilter
+  | GeovisWorkspaceSidebarVariationsFilter;
 
 /** A collapsible block wrapping one filter control. */
 export interface GeovisWorkspaceSidebarFilterBlock {

--- a/packages/geovis-workspace/src/index.ts
+++ b/packages/geovis-workspace/src/index.ts
@@ -22,6 +22,7 @@ export {
   type GeovisWorkspaceSidebarVariation,
   type GeovisWorkspaceSidebarVariationGroup,
   type GeovisWorkspaceSidebarVariationsBody,
+  type GeovisWorkspaceSidebarVariationsFilter,
   type GeovisWorkspaceSlotConfig,
   type GeovisWorkspaceSlotName,
   type GeovisWorkspaceSource,

--- a/packages/geovis-workspace/tests/unit/tests/LeftSidebar.variationsBlock.test.tsx
+++ b/packages/geovis-workspace/tests/unit/tests/LeftSidebar.variationsBlock.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * The `variations` filter control: a menu declared as a block rather than as a
+ * whole tab, so several menus can share one tab. The body form and the rest of
+ * the sidebar are covered in LeftSidebar.test.tsx.
+ */
+
+import { render, screen } from '@ttoss/test-utils/react';
+import type * as React from 'react';
+import { GeovisWorkspace, getInitialSelection } from 'src';
+
+import {
+  click,
+  type Preview,
+  Provider,
+  visualizationSpec,
+} from './leftSidebarTestUtils';
+
+jest.mock('@ttoss/geovis', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- the factory is hoisted above imports
+  return require('./leftSidebarTestUtils').createGeoVisMock();
+});
+
+/** One tab holding two independent menus, the shape this control exists for. */
+const twoMenus: Preview = {
+  sections: [
+    {
+      id: 'controles',
+      header: { title: 'Controles', icon: 'lucide:sliders-horizontal' },
+      body: {
+        kind: 'filters',
+        blocks: [
+          {
+            id: 'faixa',
+            title: 'Faixa etária',
+            control: {
+              kind: 'variations',
+              menuId: 'age',
+              defaultValue: '65',
+              variations: [
+                { value: '65', label: '65 ou mais' },
+                { value: '75', label: '75 ou mais' },
+              ],
+            },
+          },
+          {
+            id: 'indicador',
+            title: 'Indicador',
+            control: {
+              kind: 'variations',
+              menuId: 'variable',
+              defaultValue: 'renda',
+              variations: [
+                { value: 'renda', label: 'Renda média', icon: 'lucide:map' },
+                { value: 'gini', label: 'Índice de Gini' },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const renderPreview = (
+  props: Partial<React.ComponentProps<typeof GeovisWorkspace>> = {},
+  previewConfig: Preview = twoMenus
+) => {
+  return render(
+    <GeovisWorkspace
+      config={{ leftSidebar: { initialState: 'open', ...previewConfig } }}
+      visualizationSpec={visualizationSpec}
+      {...props}
+    />,
+    { wrapper: Provider }
+  );
+};
+
+test('renders both menus in a single tab, each under its own heading', () => {
+  renderPreview();
+
+  // One tab, not two: the whole point of declaring the menus as blocks.
+  expect(screen.getAllByRole('button', { name: 'Controles' })).toHaveLength(1);
+  expect(
+    screen.getByRole('button', { name: 'Faixa etária' })
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Indicador' })).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: '65 ou mais' })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Renda média' })
+  ).toBeInTheDocument();
+});
+
+test('marks each menu default as pressed before any pick', () => {
+  renderPreview();
+
+  expect(screen.getByRole('button', { name: '65 ou mais' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  expect(screen.getByRole('button', { name: 'Renda média' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  expect(
+    screen.getByRole('button', { name: 'Índice de Gini' })
+  ).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('each block writes to its own menu and leaves the other alone', async () => {
+  const onVariableChange = jest.fn();
+  renderPreview({ onVariableChange });
+
+  await click(screen.getByRole('button', { name: '75 ou mais' }));
+
+  expect(onVariableChange).toHaveBeenCalledWith(
+    expect.objectContaining({ age: '75', variable: 'renda' })
+  );
+
+  await click(screen.getByRole('button', { name: 'Índice de Gini' }));
+
+  expect(onVariableChange).toHaveBeenLastCalledWith(
+    expect.objectContaining({ age: '75', variable: 'gini' })
+  );
+});
+
+test('reflects a controlled selection instead of its own default', () => {
+  renderPreview({ variables: { age: '75', variable: 'gini' } });
+
+  expect(screen.getByRole('button', { name: '75 ou mais' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  expect(screen.getByRole('button', { name: '65 ou mais' })).toHaveAttribute(
+    'aria-pressed',
+    'false'
+  );
+});
+
+test('falls back to its own default when the selection has no value yet', () => {
+  // A controlled consumer that did not seed through `getInitialSelection`: the
+  // shared selection carries nothing, so the control has to read its own
+  // `defaultValue` or the block would render with no row marked.
+  renderPreview({ variables: {} });
+
+  expect(screen.getByRole('button', { name: '65 ou mais' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+});
+
+test('closeOnSelect collapses the sidebar once a variation is picked', async () => {
+  const closing: Preview = {
+    sections: [
+      {
+        ...twoMenus.sections[0],
+        body: {
+          kind: 'filters',
+          blocks: [
+            {
+              id: 'faixa',
+              title: 'Faixa etária',
+              control: {
+                kind: 'variations',
+                menuId: 'age',
+                defaultValue: '65',
+                closeOnSelect: true,
+                variations: [
+                  { value: '65', label: '65 ou mais' },
+                  { value: '75', label: '75 ou mais' },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  renderPreview({}, closing);
+
+  await click(screen.getByRole('button', { name: '75 ou mais' }));
+
+  expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
+});
+
+test('the sidebar stays open on a pick without closeOnSelect', async () => {
+  renderPreview();
+
+  await click(screen.getByRole('button', { name: '75 ou mais' }));
+
+  expect(screen.queryByRole('button', { name: 'Open menu' })).toBeNull();
+});
+
+test('getInitialSelection seeds a menu declared as a block', () => {
+  expect(
+    getInitialSelection({
+      config: { leftSidebar: { initialState: 'open', ...twoMenus } },
+    })
+  ).toEqual({ age: '65', variable: 'renda' });
+});
+
+test('enabledWhen gates on a menu declared as a block', async () => {
+  const gated: Preview = {
+    sections: [
+      ...twoMenus.sections,
+      {
+        id: 'detalhe',
+        header: { title: 'Detalhe', icon: 'lucide:info' },
+        // Reads the block menu's default before anything is picked, which only
+        // resolves because `resolveMenuValue` searches filter blocks too.
+        enabledWhen: { menuId: 'age', values: ['75'] },
+        body: {
+          kind: 'variations',
+          menuId: 'detail',
+          groups: [
+            {
+              id: 'g',
+              label: 'G',
+              variations: [{ value: 'd1', label: 'Detalhe 1' }],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  renderPreview({}, gated);
+
+  expect(screen.getByRole('button', { name: 'Detalhe' })).toBeDisabled();
+
+  await click(screen.getByRole('button', { name: '75 ou mais' }));
+
+  expect(screen.getByRole('button', { name: 'Detalhe' })).toBeEnabled();
+});
+
+test('resolves a block menu default for a gate before anything is selected', () => {
+  // The unseeded case, which is the one the block scan exists for: with an empty
+  // controlled selection the gate can only be answered by finding the menu's
+  // declaration among the filter blocks. Gating on the *second* block's menu
+  // also walks past the first, which is not the menu being resolved.
+  const gated: Preview = {
+    sections: [
+      ...twoMenus.sections,
+      {
+        id: 'detalhe',
+        header: { title: 'Detalhe', icon: 'lucide:info' },
+        enabledWhen: { menuId: 'variable', values: ['gini'] },
+        body: {
+          kind: 'variations',
+          menuId: 'detail',
+          groups: [
+            {
+              id: 'g',
+              label: 'G',
+              variations: [{ value: 'd1', label: 'Detalhe 1' }],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  renderPreview({ variables: {} }, gated);
+
+  // 'renda' is the block's default and the gate wants 'gini', so resolving it
+  // at all is what this asserts — an unresolved menu would read `undefined` and
+  // disable the tab for the wrong reason.
+  expect(screen.getByRole('button', { name: 'Detalhe' })).toBeDisabled();
+});


### PR DESCRIPTION
A menu of variations could only be a whole tab. `GeovisWorkspaceSidebarVariationsBody` takes one `menuId` and flattens its `groups` into a single list driving it, so two menus meant two tabs and comparing them cost the user a tab switch — which is what a consumer with an indicator menu and an age-band menu runs into.

`variations` joins `timeline`, `chips` and `locator` as a filter control, so a menu can be declared as a block instead. Blocks stack, so several menus share one tab, each collapsible under its own heading and each keyed to its own `menuId`.

Nothing about the body form changes: this is a second way to declare the same menu, not a replacement. The rows are literally the same component, extracted to `VariationRow` so a change to one reaches both; the shared selection is the same; `getInitialSelection` seeds a control's `defaultValue` exactly as it seeds a body's; and `enabledWhen` gates on either, since `resolveMenuValue` now searches filter blocks as well as bodies.

Unlike the timeline and the chips, a variations control keeps no lifted state. Those two are lifted because something outside their block reads them — the HUD drives the timeline, the tab badge counts the chips — and a menu has no such reader: its value already lives in the shared selection. That is what lets one tab hold any number of menus.

`FiltersTab` now matches each kind by name and leaves the locator to exhaustion, so adding a kind to the union becomes a type error on that line instead of silently routing the new kind into whichever control happened to be last.

The GroupedControls story is the demonstration: the six groups it flattened into one tab become an "Indicador" block beside a "Faixa etária" one, both driving the map — `variable` picks the colour scale, `age` scales the metric.