### PR TITLE
feat(carlin): add redirect-to-trailing-slash to static app deploys

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -134,6 +134,48 @@ single viewer request function, and this option associates the shared one carlin
 keeps in the base stack. A function of your own calls the `appendIndexHtml`
 helper instead.
 
+:::note
+On its own, this option answers `/docs/guide` and `/docs/guide/` with the same
+page, so every page of the site has a duplicate URL. Add
+[`--redirect-to-trailing-slash`](#--redirect-to-trailing-slash) to serve each
+page on a single URL.
+:::
+
+### --redirect-to-trailing-slash
+
+Answer an extension-less request URI with a `301` to its trailing slash form
+instead of serving the page on both.
+
+```bash
+carlin deploy static-app --cloudfront --append-index-html --redirect-to-trailing-slash
+```
+
+**Behavior**:
+
+- Request: `/docs/guide` → `301` to `/docs/guide/`, query string carried over
+- Request: `/docs/guide/` → Serves: `/docs/guide/index.html`
+- Request: `/assets/main.js` → Serves: `/assets/main.js`
+
+Without it both forms answer `200` with the same HTML, so search engines crawl
+and de-duplicate a twin of every page, inbound links split between two URLs, and
+a link written without the trailing slash works — which is what makes the
+mistake impossible to notice. The redirect closes all three: there is one URL
+per page, and the other form says so.
+
+The redirect is served by a CloudFront function carlin creates for this
+distribution, rather than by the shared one in the base stack that
+`--append-index-html` associates. That function is imported by every static app
+of the account, so redirecting through it would change the behavior of all of
+them on a version bump.
+
+**Requires**: `--append-index-html`. The redirect is a mode of the index
+appending — the trailing slash form it redirects to is still served by it.
+
+**Conflicts with**: `--spa`. An extension-less URI of a single page application
+is a client route rather than a directory, so redirecting `/user/profile` to
+`/user/profile/` would move every route of the app to a URL its router doesn't
+produce.
+
 ### --spa
 
 Enable Single Page Application (SPA) mode.
@@ -247,7 +289,9 @@ export default defineConfig({
 The file must declare a `function handler(event)`, which is the entry point
 CloudFront calls. carlin injects an `appendIndexHtml(request)` helper into the
 function, holding the same logic as [`--append-index-html`](#--append-index-html),
-so a site that needs both calls it where it belongs:
+and a `redirectToTrailingSlash(request)` helper holding that of
+[`--redirect-to-trailing-slash`](#--redirect-to-trailing-slash), so a site that
+needs both calls the one it wants where it belongs:
 
 ```javascript
 function handler(event) {
@@ -276,7 +320,7 @@ function reads.
 
 **Constraints**: CloudFront runs the code on the `cloudfront-js-2.0` runtime,
 with no network, filesystem, timers or dynamic evaluation, and no access to the
-request body. The composed function — your code plus the injected helper — must
+request body. The composed function — your code plus the injected helpers — must
 stay under 10 KB, which carlin checks before deploying.
 
 ### --skip-upload
@@ -349,6 +393,7 @@ pnpm build
 carlin deploy static-app \
   --cloudfront \
   --append-index-html \
+  --redirect-to-trailing-slash \
   --aliases docs.example.com \
   --acm arn:aws:acm:us-east-1:123456789012:certificate/abc123
 ```

--- a/docs/website/docs/carlin/core-concepts/base-stack.mdx
+++ b/docs/website/docs/carlin/core-concepts/base-stack.mdx
@@ -76,6 +76,11 @@ carlin deploy static-app --append-index-html
 # Uses CloudFront function from base stack
 ```
 
+Every static app in the account associates this same function by ARN, so a
+change to it changes all of them at once. Options that alter this behavior for a
+single app — such as [`--redirect-to-trailing-slash`](/docs/carlin/commands/deploy-static-app#--redirect-to-trailing-slash)
+— deploy a CloudFront function of their own instead.
+
 ### Lambda Layer Builder
 
 CodeBuild project for creating Lambda layers from `package.json` dependencies.

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,10 +6,10 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 72.8,
-      branches: 64.1,
-      lines: 72.7,
-      functions: 75.2,
+      statements: 73.2,
+      branches: 65.3,
+      lines: 73.1,
+      functions: 75.3,
     },
   },
   moduleNameMapper: {

--- a/packages/carlin/src/deploy/staticApp/command.ts
+++ b/packages/carlin/src/deploy/staticApp/command.ts
@@ -56,6 +56,12 @@ export const options = {
     hidden: true,
     type: 'string',
   },
+  'redirect-to-trailing-slash': {
+    default: false,
+    describe:
+      'Answer an extension-less request URI with a `301` to its trailing slash form instead of serving the page on both, so each page of the site has a single URL. Requires the `append-index-html` option.',
+    type: 'boolean',
+  },
   'response-headers': {
     coerce: parseResponseHeaders,
     default: [],
@@ -136,6 +142,36 @@ export const deployStaticAppCommand: CommandModule<
                   ? 'response-headers'
                   : 'response-headers-policy'
               } option requires the cloudfront option.`
+            );
+          }
+
+          return true;
+        })
+        .check(({ appendIndexHtml, redirectToTrailingSlash, spa }) => {
+          if (!redirectToTrailingSlash) {
+            return true;
+          }
+
+          /**
+           * The redirect is a mode of the index appending, not a behavior of
+           * its own: it still serves `/docs/guide/` as
+           * `/docs/guide/index.html`, and only changes what answers
+           * `/docs/guide`.
+           */
+          if (!appendIndexHtml) {
+            throw new Error(
+              'The redirect-to-trailing-slash option requires the append-index-html option. It changes how an extension-less URI is answered, so the index appending it redirects to has to be on.'
+            );
+          }
+
+          /**
+           * An extension-less URI of a SPA is a client route rather than a
+           * directory, so redirecting it to a trailing slash would move every
+           * route of the app to a URL its router doesn't produce.
+           */
+          if (spa) {
+            throw new Error(
+              'The redirect-to-trailing-slash and spa options are mutually exclusive. An extension-less URI of a SPA is a client route, not a directory, so redirecting it to a trailing slash changes the URL of every route.'
             );
           }
 

--- a/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
+++ b/packages/carlin/src/deploy/staticApp/deployStaticApp.ts
@@ -23,6 +23,7 @@ export const deployStaticApp = async ({
   appendIndexHtml,
   buildFolder,
   cloudfront,
+  redirectToTrailingSlash,
   responseHeaders,
   responseHeadersPolicy,
   spa,
@@ -37,6 +38,7 @@ export const deployStaticApp = async ({
   appendIndexHtml?: boolean;
   buildFolder?: string;
   cloudfront?: boolean;
+  redirectToTrailingSlash?: boolean;
   responseHeaders?: ResponseHeader[];
   responseHeadersPolicy?: string;
   spa?: boolean;
@@ -60,6 +62,7 @@ export const deployStaticApp = async ({
       aliases,
       appendIndexHtml,
       cloudfront,
+      redirectToTrailingSlash,
       responseHeaders,
       responseHeadersPolicy,
       spa,

--- a/packages/carlin/src/deploy/staticApp/staticApp.template.ts
+++ b/packages/carlin/src/deploy/staticApp/staticApp.template.ts
@@ -18,6 +18,7 @@ import {
 import {
   FUNCTION_RUNTIME,
   getViewerRequestFunctionCode,
+  REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE,
 } from './viewerRequestFunction';
 
 const PACKAGE_VERSION = getPackageVersion();
@@ -185,6 +186,7 @@ const getCloudFrontTemplate = ({
   acm,
   aliases = [],
   appendIndexHtml,
+  redirectToTrailingSlash,
   responseHeaders = [],
   responseHeadersPolicy,
   spa,
@@ -195,6 +197,7 @@ const getCloudFrontTemplate = ({
   aliases?: string[];
   appendIndexHtml?: boolean;
   cloudfront: true;
+  redirectToTrailingSlash?: boolean;
   responseHeaders?: ResponseHeader[];
   responseHeadersPolicy?: string;
   spa?: boolean;
@@ -488,7 +491,46 @@ const getCloudFrontTemplate = ({
     );
   }
 
-  if (viewerRequestFunctionCode) {
+  /**
+   * The redirect is a mode of the index appending, not a behavior of its own:
+   * it still serves `/docs/guide/` as `/docs/guide/index.html`, and only
+   * changes what answers `/docs/guide`.
+   */
+  if (redirectToTrailingSlash && !appendIndexHtml) {
+    throw new Error(
+      'The redirect-to-trailing-slash option requires the append-index-html option. It changes how an extension-less URI is answered, so the index appending it redirects to has to be on.'
+    );
+  }
+
+  /**
+   * An extension-less URI of a SPA is a client route rather than a directory,
+   * so redirecting it to a trailing slash would move every route of the app to
+   * a URL its router doesn't produce.
+   */
+  if (redirectToTrailingSlash && spa) {
+    throw new Error(
+      'The redirect-to-trailing-slash and spa options are mutually exclusive. An extension-less URI of a SPA is a client route, not a directory, so redirecting it to a trailing slash changes the URL of every route.'
+    );
+  }
+
+  /**
+   * The redirect cannot go into the shared base stack function, which every
+   * static app of the account imports by ARN, so it is deployed as a function
+   * of this app instead.
+   */
+  const perAppFunctionCode = (() => {
+    if (viewerRequestFunctionCode) {
+      return getViewerRequestFunctionCode({ code: viewerRequestFunctionCode });
+    }
+
+    if (redirectToTrailingSlash) {
+      return REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE;
+    }
+
+    return undefined;
+  })();
+
+  if (perAppFunctionCode) {
     template.Resources[CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID] = {
       Type: 'AWS::CloudFront::Function',
       Properties: {
@@ -507,16 +549,14 @@ const getCloudFrontTemplate = ({
           },
           Runtime: FUNCTION_RUNTIME,
         },
-        FunctionCode: getViewerRequestFunctionCode({
-          code: viewerRequestFunctionCode,
-        }),
+        FunctionCode: perAppFunctionCode,
         AutoPublish: true,
       },
     };
   }
 
   const viewerRequestFunctionArn = (() => {
-    if (viewerRequestFunctionCode) {
+    if (perAppFunctionCode) {
       return {
         'Fn::GetAtt': [
           CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID,
@@ -591,6 +631,7 @@ export const getStaticAppTemplate = ({
   aliases,
   appendIndexHtml,
   cloudfront,
+  redirectToTrailingSlash,
   responseHeaders,
   responseHeadersPolicy,
   spa,
@@ -602,6 +643,7 @@ export const getStaticAppTemplate = ({
   aliases?: string[];
   appendIndexHtml?: boolean;
   cloudfront?: boolean;
+  redirectToTrailingSlash?: boolean;
   responseHeaders?: ResponseHeader[];
   responseHeadersPolicy?: string;
   spa?: boolean;
@@ -615,6 +657,7 @@ export const getStaticAppTemplate = ({
       aliases,
       appendIndexHtml,
       cloudfront,
+      redirectToTrailingSlash,
       responseHeaders,
       responseHeadersPolicy,
       spa,

--- a/packages/carlin/src/deploy/staticApp/viewerRequestFunction.ts
+++ b/packages/carlin/src/deploy/staticApp/viewerRequestFunction.ts
@@ -43,6 +43,82 @@ export const APPEND_INDEX_HTML_HELPER = `function appendIndexHtml(request) {
 }`;
 
 /**
+ * `redirectToTrailingSlash` injected into every app-supplied viewer request
+ * function, and the whole behavior of the `redirectToTrailingSlash` option.
+ *
+ * `appendIndexHtml` answers `/docs/guide` and `/docs/guide/` with the same
+ * object, so every page of a site has a duplicate that search engines crawl and
+ * have to de-duplicate, and nothing signals a link written without the trailing
+ * slash. This helper serves the trailing slash form as `appendIndexHtml` does
+ * and redirects the extension-less one to it, so a page answers on one URL.
+ *
+ * The query string is carried over verbatim — the values CloudFront exposes are
+ * the ones the viewer sent, so re-encoding them would double-encode a
+ * `?utm_content=a%20b`, and dropping them would break attribution on the
+ * redirected request. A parameter sent without a value (`?flag`) is rebuilt as
+ * `?flag=`, which every query string parser reads the same way.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html
+ */
+export const REDIRECT_TO_TRAILING_SLASH_HELPER = `function redirectToTrailingSlash(request) {
+  var uri = request.uri;
+
+  if (uri.endsWith('/')) {
+    request.uri += 'index.html';
+    return request;
+  }
+
+  if (uri.includes('.')) {
+    return request;
+  }
+
+  var querystring = '';
+
+  for (var name in request.querystring) {
+    var parameter = request.querystring[name];
+    var values = parameter.multiValue || [parameter];
+
+    for (var i = 0; i < values.length; i++) {
+      querystring += (querystring ? '&' : '?') + name + '=' + values[i].value;
+    }
+  }
+
+  return {
+    statusCode: 301,
+    statusDescription: 'Moved Permanently',
+    headers: { location: { value: uri + '/' + querystring } },
+  };
+}`;
+
+/**
+ * Code of the per-app function the `redirectToTrailingSlash` option creates.
+ *
+ * The redirect cannot go into the shared base stack function the
+ * `appendIndexHtml` option associates: that one is imported by ARN by every
+ * static app in the account, so changing it would redirect all of them at once,
+ * on someone else's version bump. A per-app function keeps the choice with the
+ * app, and costs no base stack update before the option can be used.
+ */
+export const REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE = `${REDIRECT_TO_TRAILING_SLASH_HELPER}
+
+function handler(event) {
+  return redirectToTrailingSlash(event.request);
+}
+`;
+
+/**
+ * Helpers carlin makes available to an app-supplied function, in the order they
+ * are injected. They count against the size budget of every function, so a
+ * helper is added here only when it holds behavior an option of carlin also
+ * provides — an app that supplies its own function can reach for it instead of
+ * losing the option.
+ */
+const INJECTED_HELPERS = [
+  APPEND_INDEX_HTML_HELPER,
+  REDIRECT_TO_TRAILING_SLASH_HELPER,
+].join('\n\n');
+
+/**
  * The entry point CloudFront calls. A function whose code doesn't declare it
  * fails at deploy time with an opaque error, so it's checked at synth time.
  */
@@ -68,8 +144,8 @@ export const readViewerRequestFunctionCode = ({
 };
 
 /**
- * Composes the source of the per-app `AWS::CloudFront::Function`: the
- * `appendIndexHtml` helper followed by the app code, which owns the `handler`.
+ * Composes the source of the per-app `AWS::CloudFront::Function`: the injected
+ * helpers followed by the app code, which owns the `handler`.
  */
 export const getViewerRequestFunctionCode = ({
   code,
@@ -88,17 +164,17 @@ export const getViewerRequestFunctionCode = ({
     );
   }
 
-  const functionCode = `${APPEND_INDEX_HTML_HELPER}\n\n${code.trim()}\n`;
+  const functionCode = `${INJECTED_HELPERS}\n\n${code.trim()}\n`;
 
   /**
-   * The helper counts against the app budget, so the size of the composed
+   * The helpers count against the app budget, so the size of the composed
    * source is what CloudFront rejects.
    */
   const size = Buffer.byteLength(functionCode, 'utf8');
 
   if (size > MAX_FUNCTION_SIZE_BYTES) {
     throw new Error(
-      `The viewer request function is ${size} bytes, above the ${MAX_FUNCTION_SIZE_BYTES} bytes CloudFront allows. The \`appendIndexHtml\` helper carlin injects counts against this budget.`
+      `The viewer request function is ${size} bytes, above the ${MAX_FUNCTION_SIZE_BYTES} bytes CloudFront allows. The helpers carlin injects count against this budget.`
     );
   }
 

--- a/packages/carlin/tests/unit/cli.test.ts
+++ b/packages/carlin/tests/unit/cli.test.ts
@@ -429,6 +429,22 @@ describe('response headers options', () => {
   });
 });
 
+describe('redirect-to-trailing-slash option', () => {
+  test('should not redirect by default', async () => {
+    const argv = await parseCli('deploy static-app', {});
+    expect(argv.redirectToTrailingSlash).toEqual(false);
+  });
+
+  test('should accept redirect-to-trailing-slash option', async () => {
+    const argv = await parseCli(
+      'deploy static-app --cloudfront --append-index-html --redirect-to-trailing-slash',
+      {}
+    );
+
+    expect(argv.redirectToTrailingSlash).toEqual(true);
+  });
+});
+
 describe('viewer request function option', () => {
   test('should not define a viewer request function by default', async () => {
     const argv = await parseCli('deploy static-app', {});

--- a/packages/carlin/tests/unit/deploy/staticApp/command.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/command.test.ts
@@ -61,6 +61,41 @@ describe('aliases implies acm', () => {
   });
 });
 
+describe('redirect to trailing slash', () => {
+  test('should throw without append-index-html', () => {
+    return expect(
+      parse({ cloudfront: true, redirectToTrailingSlash: true })
+    ).rejects.toThrow('requires the append-index-html option');
+  });
+
+  /**
+   * An extension-less URI of a SPA is a client route, so redirecting it would
+   * move every route of the app to a URL its router doesn't produce.
+   */
+  test('should throw with spa', () => {
+    return expect(
+      parse({
+        cloudfront: true,
+        appendIndexHtml: true,
+        redirectToTrailingSlash: true,
+        spa: true,
+      })
+    ).rejects.toThrow('mutually exclusive');
+  });
+
+  test('should not throw with append-index-html', () => {
+    const options = {
+      cloudfront: true,
+      appendIndexHtml: true,
+      redirectToTrailingSlash: true,
+    };
+
+    return expect(parse(options)).resolves.toEqual(
+      expect.objectContaining(options)
+    );
+  });
+});
+
 describe('handling methods', () => {
   test.each([
     {

--- a/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/staticApp.template.test.ts
@@ -18,6 +18,8 @@ import {
 import {
   APPEND_INDEX_HTML_HELPER,
   FUNCTION_RUNTIME,
+  REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE,
+  REDIRECT_TO_TRAILING_SLASH_HELPER,
 } from 'src/deploy/staticApp/viewerRequestFunction';
 
 jest.mock('src/utils', () => {
@@ -312,7 +314,7 @@ describe('viewer request function', () => {
     ]);
   });
 
-  test('should inject the appendIndexHtml helper into the function code', () => {
+  test('should inject the helpers into the function code', () => {
     const template = getStaticAppTemplate({
       region,
       cloudfront: true,
@@ -322,7 +324,9 @@ describe('viewer request function', () => {
     expect(
       template.Resources[CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID]
         .Properties?.FunctionCode
-    ).toEqual(`${APPEND_INDEX_HTML_HELPER}\n\n${viewerRequestFunctionCode}\n`);
+    ).toEqual(
+      `${APPEND_INDEX_HTML_HELPER}\n\n${REDIRECT_TO_TRAILING_SLASH_HELPER}\n\n${viewerRequestFunctionCode}\n`
+    );
   });
 
   /**
@@ -387,6 +391,79 @@ describe('viewer request function', () => {
         },
       },
     ]);
+  });
+});
+
+describe('redirect to trailing slash', () => {
+  const getFunctionAssociations = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    template: any
+  ) => {
+    return template.Resources[CLOUDFRONT_DISTRIBUTION_LOGICAL_ID].Properties
+      .DistributionConfig.DefaultCacheBehavior.FunctionAssociations;
+  };
+
+  /**
+   * The shared base stack function is imported by ARN by every static app of
+   * the account, so redirecting this one cannot go through it.
+   */
+  test('should create a per app function instead of importing the shared one', () => {
+    const template = getStaticAppTemplate({
+      region,
+      cloudfront: true,
+      appendIndexHtml: true,
+      redirectToTrailingSlash: true,
+    });
+
+    const resource =
+      template.Resources[CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID];
+
+    expect(resource.Type).toEqual('AWS::CloudFront::Function');
+    expect(resource.Properties?.FunctionCode).toEqual(
+      REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE
+    );
+
+    expect(getFunctionAssociations(template)).toEqual([
+      {
+        EventType: 'viewer-request',
+        FunctionARN: {
+          'Fn::GetAtt': [
+            CLOUDFRONT_VIEWER_REQUEST_FUNCTION_LOGICAL_ID,
+            'FunctionMetadata.FunctionARN',
+          ],
+        },
+      },
+    ]);
+
+    expect(JSON.stringify(template)).not.toContain(
+      BASE_STACK_CLOUDFRONT_FUNCTION_APPEND_INDEX_HTML_ARN_EXPORTED_NAME
+    );
+  });
+
+  test('should throw without appendIndexHtml', () => {
+    return expect(() => {
+      return getStaticAppTemplate({
+        region,
+        cloudfront: true,
+        redirectToTrailingSlash: true,
+      });
+    }).toThrow('requires the append-index-html option');
+  });
+
+  /**
+   * An extension-less URI of a SPA is a client route, so redirecting it would
+   * move every route of the app to a URL its router doesn't produce.
+   */
+  test('should throw with spa', () => {
+    return expect(() => {
+      return getStaticAppTemplate({
+        region,
+        cloudfront: true,
+        appendIndexHtml: true,
+        redirectToTrailingSlash: true,
+        spa: true,
+      });
+    }).toThrow('mutually exclusive');
   });
 });
 

--- a/packages/carlin/tests/unit/deploy/staticApp/viewerRequestFunction.test.ts
+++ b/packages/carlin/tests/unit/deploy/staticApp/viewerRequestFunction.test.ts
@@ -9,6 +9,8 @@ import {
   getViewerRequestFunctionCode,
   MAX_FUNCTION_SIZE_BYTES,
   readViewerRequestFunctionCode,
+  REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE,
+  REDIRECT_TO_TRAILING_SLASH_HELPER,
 } from 'src/deploy/staticApp/viewerRequestFunction';
 
 const HANDLER = `function handler(event) {
@@ -42,14 +44,19 @@ describe('readViewerRequestFunctionCode', () => {
   });
 });
 
+const INJECTED_HELPERS = `${APPEND_INDEX_HTML_HELPER}\n\n${REDIRECT_TO_TRAILING_SLASH_HELPER}`;
+
 describe('getViewerRequestFunctionCode', () => {
-  test('should inject the appendIndexHtml helper before the app code', () => {
+  test('should inject the helpers before the app code', () => {
     const code = getViewerRequestFunctionCode({ code: HANDLER });
 
-    expect(code).toEqual(`${APPEND_INDEX_HTML_HELPER}\n\n${HANDLER}\n`);
-    expect(code.indexOf('function appendIndexHtml')).toBeLessThan(
-      code.indexOf('function handler')
-    );
+    expect(code).toEqual(`${INJECTED_HELPERS}\n\n${HANDLER}\n`);
+
+    for (const helper of ['appendIndexHtml', 'redirectToTrailingSlash']) {
+      expect(code.indexOf(`function ${helper}`)).toBeLessThan(
+        code.indexOf('function handler')
+      );
+    }
   });
 
   /**
@@ -85,12 +92,12 @@ describe('getViewerRequestFunctionCode', () => {
     }).toThrow(`above the ${MAX_FUNCTION_SIZE_BYTES} bytes CloudFront allows`);
   });
 
-  test('should count the injected helper against the size limit', () => {
+  test('should count the injected helpers against the size limit', () => {
     /**
-     * App code that fits on its own but not once the helper is prepended.
+     * App code that fits on its own but not once the helpers are prepended.
      */
     const size =
-      MAX_FUNCTION_SIZE_BYTES - Buffer.byteLength(APPEND_INDEX_HTML_HELPER) + 1;
+      MAX_FUNCTION_SIZE_BYTES - Buffer.byteLength(INJECTED_HELPERS) + 1;
 
     const code = `${'/*'.padEnd(size - HANDLER.length - 4, '-')}*/\n${HANDLER}`;
 
@@ -98,7 +105,7 @@ describe('getViewerRequestFunctionCode', () => {
 
     return expect(() => {
       return getViewerRequestFunctionCode({ code });
-    }).toThrow('counts against this budget');
+    }).toThrow('count against this budget');
   });
 });
 
@@ -129,5 +136,106 @@ describe('appendIndexHtml helper matches the base stack function', () => {
     '/assets/main.js',
   ])('should rewrite %s the same way', (uri) => {
     expect(helper({ uri })).toEqual(baseStackHandler({ request: { uri } }));
+  });
+});
+
+/**
+ * The redirect is what the function does in production, so it is asserted by
+ * running the code carlin deploys rather than by matching its source.
+ */
+describe('redirectToTrailingSlash function', () => {
+  const handler = new Function(
+    `${REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE}; return handler;`
+  )();
+
+  const request = ({
+    uri,
+    querystring = {},
+  }: {
+    uri: string;
+    querystring?: Record<string, unknown>;
+  }) => {
+    return handler({ request: { uri, querystring } });
+  };
+
+  test.each([
+    ['/', '/index.html'],
+    ['/docs/', '/docs/index.html'],
+  ])('should serve %p as %p', (uri, served) => {
+    expect(request({ uri })).toEqual(expect.objectContaining({ uri: served }));
+  });
+
+  test.each(['/index.html', '/docs/guide.md', '/assets/main.js'])(
+    'should serve %p untouched',
+    (uri) => {
+      expect(request({ uri })).toEqual(expect.objectContaining({ uri }));
+    }
+  );
+
+  test.each(['/docs/guide', '/about'])(
+    'should redirect %p to its trailing slash form',
+    (uri) => {
+      expect(request({ uri })).toEqual({
+        statusCode: 301,
+        statusDescription: 'Moved Permanently',
+        headers: { location: { value: `${uri}/` } },
+      });
+    }
+  );
+
+  /**
+   * A redirect that dropped the query string would break the attribution of
+   * every campaign link pointing at a page without the trailing slash.
+   */
+  test('should carry the query string over', () => {
+    const response = request({
+      uri: '/docs/guide',
+      querystring: {
+        utm_source: { value: 'newsletter' },
+        utm_content: { value: 'a%20b' },
+        flag: { value: '' },
+      },
+    });
+
+    expect(response.headers.location.value).toEqual(
+      '/docs/guide/?utm_source=newsletter&utm_content=a%20b&flag='
+    );
+  });
+
+  /**
+   * A parameter sent more than once is collapsed into a single field whose
+   * `multiValue` holds every value, the first of them repeated in `value`.
+   */
+  test('should carry duplicate parameters over', () => {
+    const response = request({
+      uri: '/docs/guide',
+      querystring: {
+        tag: {
+          value: 'a',
+          multiValue: [{ value: 'a' }, { value: 'b' }],
+        },
+      },
+    });
+
+    expect(response.headers.location.value).toEqual('/docs/guide/?tag=a&tag=b');
+  });
+
+  test('should fit the CloudFront function size limit', () => {
+    expect(
+      Buffer.byteLength(REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE, 'utf8')
+    ).toBeLessThan(MAX_FUNCTION_SIZE_BYTES);
+  });
+
+  /**
+   * The helper is the whole body of the function, so the two cannot drift.
+   */
+  test('should be the injected helper called by a handler', () => {
+    expect(REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE).toContain(
+      REDIRECT_TO_TRAILING_SLASH_HELPER
+    );
+
+    expect(
+      REDIRECT_TO_TRAILING_SLASH_FUNCTION_CODE.match(/function\s+handler\s*\(/g)
+    ).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem

`appendIndexHtml` rewrites an extension-less URI by appending `/index.html` to it, so `/docs/guide` and `/docs/guide/` both answer `200` with the same page. Every page of a carlin static site therefore has a duplicate URL: search engines crawl and de-duplicate the twin, inbound links split across the two forms, and a link written without the trailing slash works — which is what makes the mistake impossible to catch.

## Change

A new `--redirect-to-trailing-slash` option answers the extension-less form with a `301` to the canonical one instead:

- `/docs/guide` → `301` to `/docs/guide/`, query string carried over
- `/docs/guide/` → serves `/docs/guide/index.html`
- `/assets/main.js` → served untouched

## Answers to the three open questions of the report

**Query string.** Carried over, values copied exactly as the viewer sent them. Re-encoding with `encodeURIComponent` would double-encode a `?utm_content=a%20b`, and the values CloudFront exposes are the ones that came in on the request line, so they are already valid in a `Location`. Duplicate parameters (`multiValue`) are rebuilt as repeated pairs. A parameter sent without a value (`?flag`) is rebuilt as `?flag=`.

**Blast radius.** Opt-in, and not through the shared function. The base stack `AppendIndexDotHtml` is imported by ARN by every static app of an account, so changing it would redirect all of them at once on someone else's version bump. The option deploys a CloudFront function of the app instead, which also means the base stack does not have to be updated before the option can be used. An `--append-index-html` deploy that doesn't opt in synthesizes byte-for-byte the template it did before.

**`spa`.** The two are now mutually exclusive, checked at parse time and at synth time. An extension-less URI of a SPA is a client route rather than a directory, so redirecting `/user/profile` to `/user/profile/` would move every route of the app to a URL its router doesn't produce.

The option also requires `--append-index-html`: it changes only what answers the extension-less form, and the trailing-slash form it redirects to is still served by the index appending.

## Also

The same logic is injected into app-supplied viewer request functions as a `redirectToTrailingSlash(request)` helper, next to the existing `appendIndexHtml(request)` one, so a site with its own function isn't cut off from the fix. Both helpers count against the 10 KB function budget, which carlin already checks.

## Tests

`pnpm run test` in `packages/carlin` — 420 passing. The redirect is asserted by running the code carlin deploys (`new Function`), covering the rewrite, the redirect, untouched asset URIs, query string preservation and duplicate parameters. Coverage thresholds raised to match. Docs updated in `docs/website/docs/carlin/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hyfr8QZz9QuNisrjqHBLuu