### PR TITLE
feat(http-server-mcp)!: require a token for tools/list by default

### DIFF
--- a/docs/website/docs/engineering/guidelines/mcp-server-oauth.md
+++ b/docs/website/docs/engineering/guidelines/mcp-server-oauth.md
@@ -92,7 +92,7 @@ Opaque API tokens work the same way — hash the presented token with `@ttoss/au
 
 ### Client discovery
 
-The [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) requires two behaviors so clients like Claude and Cursor can bootstrap OAuth without being pre-configured, and `createMcpRouter` handles both. The lifecycle methods `initialize` and `tools/list` bypass verification so the client can discover the server before authenticating — override the set with `publicMethods` (pass `[]` to require a token for every method). And a `401` advertises the [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) protected-resource document via `WWW-Authenticate: Bearer resource_metadata="…"`, pointing the client at the metadata that names the authorization server.
+The [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) requires two behaviors so clients like Claude and Cursor can bootstrap OAuth without being pre-configured, and `createMcpRouter` handles both. The lifecycle method `initialize` bypasses verification so the client can complete the handshake before authenticating — override the set with `publicMethods` (pass `[]` to require a token for every method). And a `401` advertises the [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) protected-resource document via `WWW-Authenticate: Bearer resource_metadata="…"`, pointing the client at the metadata that names the authorization server.
 
 ```typescript
 const mcpRouter = createMcpRouter(mcpServer, {
@@ -103,7 +103,7 @@ const mcpRouter = createMcpRouter(mcpServer, {
     resourceServerUrl: 'https://mcp.example.com',
     authorizationServerUrl: process.env.COGNITO_ISSUER_URL!,
     // Set publicMethods: [] when you need OAuth clients to authenticate
-    // before anything else (see note below). Defaults to ['initialize', 'tools/list'].
+    // before anything else (see note below). Defaults to ['initialize'].
     publicMethods: [],
   },
 });
@@ -115,7 +115,9 @@ Setting both `resourceServerUrl` and `authorizationServerUrl` serves that metada
 
 **Error envelopes swallow the `401`.** The router rejects with `ctx.throw(401, 'Unauthorized', { headers })`, and an app whose catch-all error middleware recognizes only its own error class turns that into a `500` with no `WWW-Authenticate` header. The client then gets an opaque server error where it expected the pointer to the authorization server, so discovery silently never starts and it reads like a client bug. Run caught values through `toHttpError` and `applyHttpErrorHeaders` from [`@ttoss/http-server`](/docs/modules/packages/http-server) before falling back to `500`.
 
-**`publicMethods` and the OAuth flow.** With the default `['initialize', 'tools/list']`, an OAuth-aware client (Claude connector, Cursor) receives `200` on `initialize` and concludes the server is public — it never starts the OAuth PKCE flow, while `notifications/initialized` still returns `401`, silently breaking the handshake. The visible symptom is "connected, no tools available, no sign-in prompt". Setting `publicMethods: []` makes `initialize` return `401 + WWW-Authenticate`, which is what triggers the client's OAuth discovery and login. Use the default only when auth is handled outside the client-initiated OAuth flow (e.g. API keys or tokens injected by a gateway); set `publicMethods: []` whenever you want the client to authenticate itself before any other interaction.
+**`publicMethods` and the OAuth flow.** The default is `['initialize']`, so `initialize` answers `200` unauthenticated and everything after it carries the challenge. Some OAuth-aware clients (Claude connector, Cursor) have been observed to read that `200` as "this server is public" and never start the PKCE flow, while `notifications/initialized` still returns `401` — silently breaking the handshake, with the visible symptom "connected, no tools available, no sign-in prompt". Setting `publicMethods: []` makes `initialize` itself return `401 + WWW-Authenticate`, which starts discovery on the very first request. Use the default when auth is handled outside the client-initiated OAuth flow (e.g. API keys or tokens injected by a gateway); set `publicMethods: []` whenever you want the client to authenticate itself before any other interaction.
+
+**Do not add `tools/list` to the set.** It served the full tool catalogue — every name, description, and input schema — to unauthenticated callers, which for an OpenAPI-derived server is a map of the whole underlying API. It was removed from the default for that reason ([ttoss/ttoss#1176](https://github.com/ttoss/ttoss/issues/1176)) and buys an OAuth client nothing, since the `401` is what starts the flow and an anonymous caller still cannot invoke a tool.
 
 ## Authorization server: issuing tokens
 

--- a/packages/http-server-mcp/MIGRATIONS.md
+++ b/packages/http-server-mcp/MIGRATIONS.md
@@ -1,0 +1,38 @@
+# Migrations
+
+## `tools/list` is no longer public by default
+
+`auth.publicMethods` now defaults to `['initialize']` instead of
+`['initialize', 'tools/list']`. A server with `auth` configured no longer
+serves its tool catalogue to unauthenticated callers.
+
+```diff
+ createMcpRouter(mcpServer, {
+   auth: {
+     cognitoUserPool: { userPoolId: '...', clientId: '...' },
++    // Only needed if unauthenticated callers must keep listing tools.
++    publicMethods: ['initialize', 'tools/list'],
+   },
+ });
+```
+
+**What you will observe if you miss this.** An unauthenticated `tools/list`
+returns `401` with `WWW-Authenticate: Bearer resource_metadata="…"` instead of
+`200` and the catalogue. It fails on the first such request rather than on
+particular inputs, so a smoke test against a deployed server surfaces it
+immediately.
+
+**Who is affected.** Only consumers that configure `auth` and never set
+`publicMethods`. Anyone already passing `publicMethods` — including
+`publicMethods: []` — is unaffected, and so is any server without `auth`.
+
+**Who should not restore the old value.** OAuth clients do not need it. The
+`401` and its RFC 9728 challenge are what start the authorization flow, and a
+client that lists tools anonymously still cannot call one; the flow reaches the
+authorization redirect identically with `tools/list` open or closed. Restore it
+only to serve callers that will never authenticate, and note what that exposes:
+every tool name, description, and input schema, which for an OpenAPI-derived
+server is a map of the whole underlying API.
+
+The one-time startup warning that pre-announced this change is gone, since the
+default it warned about is now the secure one.

--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -939,7 +939,8 @@ Keep the following in mind:
 ## Migrations
 
 Breaking changes and what they require of consumers are listed in
-[MIGRATIONS.md](./MIGRATIONS.md), newest first.
+[MIGRATIONS.md](https://github.com/ttoss/ttoss/blob/main/packages/http-server-mcp/MIGRATIONS.md),
+newest first.
 
 ## Related Packages
 

--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -371,7 +371,7 @@ The `WWW-Authenticate: Bearer resource_metadata="…"` header is how MCP clients
 
 The two behaviors the [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) requires for client bootstrapping are built into the `auth` option, so you no longer need the hand-rolled middleware shown above:
 
-- **`publicMethods`** — JSON-RPC methods that bypass verification, read from the request body's `method` field. Defaults to `['initialize', 'tools/list']` so clients can discover the server before authenticating. Pass `[]` to require a token for every method, or a custom list to change the exempt set. Leaving it unset serves the full tool catalogue — every tool name, description, and input schema — to unauthenticated callers, and logs a one-time warning explaining that and how to close it. Set `publicMethods` explicitly (even to the same default) to silence the warning.
+- **`publicMethods`** — JSON-RPC methods that bypass verification, read from the request body's `method` field. Defaults to `['initialize']`, which the spec sanctions so a client can complete the lifecycle handshake before it can discover the authorization server. Pass `[]` to require a token for every method, or a custom list to change the exempt set. Adding `tools/list` serves the full tool catalogue — every tool name, description, and input schema — to unauthenticated callers; see [`publicMethods` and OAuth clients](#publicmethods-and-oauth-clients) before doing so.
 - **`resourceMetadataUrl`** — the URL a `401` advertises as `WWW-Authenticate: Bearer resource_metadata="<url>"` (RFC 9728) instead of a bare `Bearer`, pointing MCP clients at the protected-resource metadata document. **You normally do not set it**: when the document is served — i.e. both `resourceServerUrl` and `authorizationServerUrl` are configured — it defaults to the RFC 9728 location this router serves it at, so the header and the routes cannot drift apart. When the document is not served, the header stays a bare `Bearer` rather than naming a location with no route. The field exists for the one configuration where this router deliberately does not serve the document — an `oauthServer()` in the same deployment already answers that path, so this router is mounted without `resourceServerUrl`/`authorizationServerUrl` to avoid two routers on one path, and has nothing to derive from. Compute the value with `protectedResourceMetadataUrl` from [`@ttoss/auth-core`](https://ttoss.dev/docs/modules/packages/auth-core) rather than typing it, so both halves apply the same §3.1 rule.
 
 ```typescript
@@ -383,12 +383,12 @@ createMcpRouter(mcpServer, {
     resourceServerUrl: 'https://mcp.example.com',
     authorizationServerUrl:
       'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxx',
-    // publicMethods defaults to ['initialize', 'tools/list'].
+    // publicMethods defaults to ['initialize'].
   },
 });
 ```
 
-Every field is optional, and the `publicMethods` default matches what MCP clients expect for discovery.
+Every field is optional.
 
 ### Supporting clients that connect to the bare origin
 
@@ -502,7 +502,7 @@ Creates a Koa router configured to handle MCP protocol requests.
     - `auth.verifyToken` — Custom async token verifier `(token: string) => Promise<unknown>`
     - `auth.requiredScopes` — Router-level scope guard; returns 403 if any scope is missing
     - `auth.resourceServerUrl` + `auth.authorizationServerUrl` — Enable the protected-resource metadata document, served at both `/.well-known/oauth-protected-resource` and the RFC 9728 path-derived `/.well-known/oauth-protected-resource<path>`; the metadata `resource` is set to `resourceServerUrl + path` so clients following `resource` land on the actual MCP endpoint
-    - `auth.publicMethods` — JSON-RPC methods that bypass verification (default `['initialize', 'tools/list']`)
+    - `auth.publicMethods` — JSON-RPC methods that bypass verification (default `['initialize']`)
     - `auth.resourceMetadataUrl` — URL advertised in the RFC 9728 `WWW-Authenticate: Bearer resource_metadata="…"` header on a 401. Defaults to the location derived from `resourceServerUrl` + `path` (the one this router serves), so the header cannot drift from the routes; set it only when a separate `oauthServer()` serves the document and this router is mounted without `resourceServerUrl`/`authorizationServerUrl`
     - `auth.resourceIndicator` — Expected `aud` value(s) (RFC 8707); rejects tokens minted for a different resource. See [Resource indicator validation](#resource-indicator-validation-rfc-8707)
 
@@ -873,14 +873,19 @@ expect(call.status).toBe(200);
 
 ### `publicMethods` and OAuth clients
 
-`auth.publicMethods` defaults to `['initialize', 'tools/list']`, which lets clients discover the server before they have a token. This default has an important effect on OAuth-aware clients (e.g. a Claude connector):
+`auth.publicMethods` defaults to `['initialize']`: the handshake is reachable without a token, nothing else is.
 
-- With the default, `initialize` returns `200` unauthenticated, so an OAuth client concludes the server is public and never starts the OAuth flow — while `notifications/initialized` still returns `401`, breaking the handshake. The visible symptom is "connected, no tools available, no sign-in prompt".
-- Setting `publicMethods: []` makes `initialize` return `401` + `WWW-Authenticate`, which triggers the client's OAuth discovery and PKCE flow.
+**Adding `tools/list` is a deliberate exposure.** It serves the full tool catalogue — every name, description, and input schema — to anyone who can reach the endpoint. Those leak internal resource names and domain vocabulary, and for an OpenAPI-derived server the schemas mirror the REST surface, so the catalogue becomes an unauthenticated map of the whole API including operations the caller could never invoke. It buys an OAuth client nothing, because the `401` is what starts the authorization flow and a client that lists tools anonymously still cannot call one. Open it only to serve callers that will never authenticate:
 
-Use the default when token auth is handled outside the OAuth flow (Cognito, API keys, Bearer tokens). Set `publicMethods: []` only when you want OAuth clients to self-discover and authenticate before anything else.
+```typescript
+publicMethods: ['initialize', 'tools/list'],
+```
 
-Leaving `publicMethods` unset also exposes the full tool catalogue (`tools/list`) to unauthenticated callers — a tool's name, description, and input schema can leak internal resource names and, for an OpenAPI-derived server, the shape of the whole underlying API. A one-time warning is logged when `auth` is configured without an explicit `publicMethods`, naming the exposure and how to close it. This default is a candidate to tighten to `['initialize']` in a future major; track the decision in [ttoss/ttoss#1176](https://github.com/ttoss/ttoss/issues/1176).
+**Whether `initialize` should be public depends on how tokens are issued.** Keep the default when token auth is handled outside the OAuth flow (Cognito, API keys, Bearer tokens minted elsewhere). Set `publicMethods: []` when you want OAuth clients to authenticate before anything else — `initialize` then returns `401` + `WWW-Authenticate` on the very first request, so discovery starts there rather than one step later.
+
+Either way the authorization flow works. Driving the official MCP client SDK against this router shows the RFC 9728 challenge resolving to the protected-resource document, the authorization server, and the redirect, whether the `401` arrives on `initialize` (`publicMethods: []`) or on the request after it (the default). `tests/unit/tests/oauth-client-flow.test.ts` asserts it.
+
+On the `2026-07-28` revision `initialize` does not exist — discovery is `server/discover`, which is not in the default set and therefore always requires a token. That is deliberate: RFC 9728 discovery is driven by the challenge itself.
 
 ## AWS Lambda Deployment
 
@@ -930,6 +935,11 @@ Keep the following in mind:
 - **SSE streaming is not used** (`enableJsonResponse: true`), so a standard API Gateway integration is enough; Function URL response streaming is not required.
 
 > This differs from [`awslabs/run-model-context-protocol-servers-with-aws-lambda`](https://github.com/awslabs/run-model-context-protocol-servers-with-aws-lambda), which wraps **stdio**-based MCP servers into Lambda by spawning a child process per invocation. `@ttoss/http-server-mcp` already speaks Streamable HTTP, so that wrapper is unnecessary — you deploy it like any other HTTP handler.
+
+## Migrations
+
+Breaking changes and what they require of consumers are listed in
+[MIGRATIONS.md](./MIGRATIONS.md), newest first.
 
 ## Related Packages
 

--- a/packages/http-server-mcp/package.json
+++ b/packages/http-server-mcp/package.json
@@ -26,6 +26,7 @@
     ".": "./src/index.ts"
   },
   "files": [
+    "MIGRATIONS.md",
     "dist"
   ],
   "scripts": {
@@ -41,6 +42,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@ttoss/config": "workspace:^",
     "@types/koa": "^3.0.3",
     "jest": "^30.4.2",

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -66,14 +66,13 @@ export interface McpAuthOptions {
    *
    * @default ['initialize']
    *
-   * @example Restore unauthenticated tool discovery
+   * @example
    * ```typescript
+   * // Restore unauthenticated tool discovery.
    * publicMethods: ['initialize', 'tools/list'],
-   * ```
    *
-   * @example Require a token for the handshake too, so OAuth clients
-   * self-discover from the very first request
-   * ```typescript
+   * // Require a token for the handshake too, so an OAuth client
+   * // self-discovers from its very first request.
    * publicMethods: [],
    * ```
    */

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -49,11 +49,33 @@ export interface McpAuthOptions {
   requiredScopes?: string[];
   /**
    * JSON-RPC methods (read from `body.method`) that bypass verification.
-   * Leaving this unset serves `tools/list` — the full tool catalogue —
-   * to unauthenticated callers, and logs a one-time warning explaining how
-   * to close it. Set explicitly (even to the same default) to silence the
-   * warning; set to `['initialize']` to require a token for `tools/list` too.
-   * @default ['initialize', 'tools/list']
+   *
+   * `initialize` is public because the MCP authorization spec sanctions it: a
+   * client completes the lifecycle handshake before it can discover the
+   * authorization server. Nothing else is, so a server with `auth` configured
+   * serves no tool metadata to an unauthenticated caller.
+   *
+   * Opening `tools/list` is a deliberate choice, not a default. It serves the
+   * full tool catalogue — every name, description, and input schema — to
+   * anyone who can reach the endpoint, which for an OpenAPI-derived server is
+   * a map of the whole underlying API. It buys an OAuth client nothing: the
+   * `401` and its RFC 9728 `WWW-Authenticate` challenge are what start the
+   * authorization flow, and a client that lists tools anonymously still
+   * cannot call one. Set it only to serve callers that will never
+   * authenticate.
+   *
+   * @default ['initialize']
+   *
+   * @example Restore unauthenticated tool discovery
+   * ```typescript
+   * publicMethods: ['initialize', 'tools/list'],
+   * ```
+   *
+   * @example Require a token for the handshake too, so OAuth clients
+   * self-discover from the very first request
+   * ```typescript
+   * publicMethods: [],
+   * ```
    */
   publicMethods?: string[];
   /**
@@ -116,8 +138,14 @@ export interface McpAuthOptions {
   resourceIndicator?: string | string[];
 }
 
-/** MCP lifecycle/discovery methods reachable before a client authenticates. */
-const DEFAULT_PUBLIC_METHODS = ['initialize', 'tools/list'];
+/**
+ * MCP lifecycle methods reachable before a client authenticates.
+ *
+ * Only `initialize`, which the MCP authorization spec sanctions: a client has
+ * to complete the handshake before it can discover the authorization server.
+ * `tools/list` is not here — see {@link McpAuthOptions.publicMethods}.
+ */
+const DEFAULT_PUBLIC_METHODS = ['initialize'];
 
 /**
  * Asserts that a verified token's `aud` claim includes at least one of the
@@ -440,9 +468,9 @@ export interface McpRouterOptions {
    * OAuth / JWT authentication configuration for the MCP endpoint.
    *
    * When set, incoming MCP requests must include a valid Bearer token in the
-   * `Authorization` header — except for `publicMethods` (by default
-   * `initialize` and `tools/list`), which bypass verification so clients can
-   * discover the server before authenticating. Invalid or missing tokens
+   * `Authorization` header — except for `publicMethods` (by default just
+   * `initialize`), which bypasses verification so a client can complete the
+   * lifecycle handshake before authenticating. Invalid or missing tokens
    * receive a `401` response with `WWW-Authenticate: Bearer` (or
    * `Bearer resource_metadata="..."` when `resourceMetadataUrl` is set, per
    * RFC 9728). Tokens that fail a `requiredScopes` check receive `403`.
@@ -576,26 +604,6 @@ export const createMcpRouter = (
     // file's route registration fixes, one layer up. An explicit
     // `resourceMetadataUrl` still wins.
     const resourceMetadataUrl = auth.resourceMetadataUrl ?? metadata?.url;
-
-    if (auth.publicMethods === undefined) {
-      // `tools/list` exposing the full tool catalogue to unauthenticated
-      // callers is a surprising default for anyone who configured `auth`
-      // without considering `publicMethods`. Warn once so operators find out
-      // from their own logs rather than from an unauthenticated tool listing
-      // in production. This default is a candidate to tighten to
-      // `['initialize']` in a future major — see
-      // https://github.com/ttoss/ttoss/issues/1176.
-      // eslint-disable-next-line no-console -- one-time operator-facing warning
-      console.warn(
-        `[@ttoss/http-server-mcp] "auth" is configured but "publicMethods" was not set, ` +
-          `so it defaults to ${JSON.stringify(DEFAULT_PUBLIC_METHODS)}. This means ` +
-          `"tools/list" — the full tool catalogue, including names, descriptions, and ` +
-          `input schemas — is served to unauthenticated callers. ` +
-          `To require a token for "tools/list" too, set publicMethods: ['initialize']. ` +
-          `To keep the current behaviour and silence this warning, set ` +
-          `publicMethods: ${JSON.stringify(DEFAULT_PUBLIC_METHODS)} explicitly.`
-      );
-    }
 
     const publicMethods = new Set(auth.publicMethods ?? DEFAULT_PUBLIC_METHODS);
 

--- a/packages/http-server-mcp/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp/tests/unit/jest.config.ts
@@ -5,7 +5,7 @@ export default {
   coverageThreshold: {
     global: {
       statements: 100,
-      branches: 95.35,
+      branches: 97.6,
       functions: 100,
       lines: 100,
     },

--- a/packages/http-server-mcp/tests/unit/tests/api-call.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/api-call.test.ts
@@ -55,6 +55,23 @@ describe('apiCall', () => {
     }
   });
 
+  test('throws HTTP <status> when the error body is JSON without an `error` key', async () => {
+    const { baseUrl, close } = await startRestServer((router) => {
+      router.get('/no-error-key', (ctx) => {
+        ctx.status = 500;
+        ctx.body = { message: 'something else entirely' };
+      });
+    });
+
+    try {
+      await expect(apiCall('GET', `${baseUrl}/no-error-key`)).rejects.toThrow(
+        'HTTP 500'
+      );
+    } finally {
+      await close();
+    }
+  });
+
   test('throws with statusText when error response body is not valid JSON', async () => {
     const { baseUrl, close } = await startRestServer((router) => {
       router.get('/v1/bad', (ctx) => {

--- a/packages/http-server-mcp/tests/unit/tests/auth.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/auth.test.ts
@@ -545,9 +545,25 @@ describe('auth — public methods and RFC 9728 discovery', () => {
     expect(res.status).not.toBe(401);
   });
 
-  test('tools/list is public by default (no token required)', async () => {
+  test('tools/list requires a token by default', async () => {
     const res = await post(buildApp({}), 'tools/list');
-    expect(res.status).not.toBe(401);
+    expect(res.status).toBe(401);
+  });
+
+  /**
+   * The behaviour before the default tightened. Anyone who relied on
+   * unauthenticated tool discovery restores it by naming it explicitly, which
+   * is the whole migration.
+   */
+  test('unauthenticated tools/list is restorable by opting in explicitly', async () => {
+    const app = buildApp({ publicMethods: ['initialize', 'tools/list'] });
+
+    const listRes = await post(app, 'tools/list');
+    expect(listRes.status).not.toBe(401);
+
+    // Still no free pass for anything that actually does work.
+    const callRes = await post(app, 'tools/call');
+    expect(callRes.status).toBe(401);
   });
 
   test('protected methods still require a token by default', async () => {
@@ -570,42 +586,6 @@ describe('auth — public methods and RFC 9728 discovery', () => {
   test('empty publicMethods requires a token for every method', async () => {
     const res = await post(buildApp({ publicMethods: [] }), 'initialize');
     expect(res.status).toBe(401);
-  });
-
-  test('warns once when auth is configured without an explicit publicMethods', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    buildApp({});
-
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toEqual(
-      expect.stringContaining('publicMethods')
-    );
-    expect(warnSpy.mock.calls[0][0]).toEqual(
-      expect.stringContaining('tools/list')
-    );
-
-    warnSpy.mockRestore();
-  });
-
-  test('does not warn when publicMethods is set explicitly, even to the default', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    buildApp({ publicMethods: ['initialize', 'tools/list'] });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
-  });
-
-  test('does not warn when publicMethods is set to an empty array', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    buildApp({ publicMethods: [] });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
   });
 
   test('a request without a method is treated as protected', async () => {

--- a/packages/http-server-mcp/tests/unit/tests/mcp-router.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/mcp-router.test.ts
@@ -322,6 +322,53 @@ describe('createMcpRouter', () => {
     expect(response.body.error).toMatch(/getApiHeaders failed/);
   });
 
+  test('POST handler returns 500 when getApiHeaders throws a non-Error', async () => {
+    const mcpServer = new McpServer({
+      name: 'test-server',
+      version: '1.0.0',
+    });
+
+    const app = new App();
+    app.use(bodyParser());
+    app.use(
+      createMcpRouter(mcpServer, {
+        getApiHeaders: () => {
+          throw 'a bare string, not an Error';
+        },
+      }).routes()
+    );
+
+    const response = await request(app.callback())
+      .post('/mcp')
+      .send({ jsonrpc: '2.0', method: 'tools/list', id: 1, params: {} })
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream');
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe('Internal server error');
+  });
+
+  test('DELETE handler returns 500 when getApiHeaders throws a non-Error', async () => {
+    const mcpServer = new McpServer({
+      name: 'test-server',
+      version: '1.0.0',
+    });
+
+    const app = new App();
+    app.use(
+      createMcpRouter(mcpServer, {
+        getApiHeaders: () => {
+          throw 'a bare string, not an Error';
+        },
+      }).routes()
+    );
+
+    const response = await request(app.callback()).delete('/mcp');
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe('Internal server error');
+  });
+
   describe('2026-07-28 protocol revision', () => {
     /**
      * A request speaking the 2026-07-28 revision: the per-request envelope in

--- a/packages/http-server-mcp/tests/unit/tests/oauth-client-flow.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/oauth-client-flow.test.ts
@@ -1,0 +1,205 @@
+import http from 'node:http';
+
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { App, bodyParser } from '@ttoss/http-server';
+import { createMcpRouter, McpServer } from 'src/index';
+
+/**
+ * The default `publicMethods` closes `tools/list`, which is only safe if an
+ * OAuth client still finds its way into the authorization flow from the `401`.
+ * Reasoning about that is what these tests replace: they drive the official
+ * MCP client SDK — a real implementation of the spec's authorization flow —
+ * against a real socket and assert it reaches `redirectToAuthorization`.
+ */
+
+jest.setTimeout(30000);
+
+/** Minimal authorization server: only the metadata discovery needs. */
+const startAuthorizationServer = () => {
+  return new Promise<{ server: http.Server; port: number }>((resolve) => {
+    const server = http.createServer((req, res) => {
+      const { port } = server.address() as { port: number };
+      const base = `http://127.0.0.1:${port}`;
+
+      if (req.url?.startsWith('/.well-known/oauth-authorization-server')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            issuer: base,
+            authorization_endpoint: `${base}/authorize`,
+            token_endpoint: `${base}/token`,
+            registration_endpoint: `${base}/register`,
+            response_types_supported: ['code'],
+            grant_types_supported: ['authorization_code', 'refresh_token'],
+            code_challenge_methods_supported: ['S256'],
+          })
+        );
+        return;
+      }
+
+      if (req.url?.startsWith('/register')) {
+        res.writeHead(201, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            client_id: 'test-client',
+            redirect_uris: ['http://localhost/callback'],
+          })
+        );
+        return;
+      }
+
+      res.writeHead(404);
+      res.end('{}');
+    });
+
+    server.listen(0, () => {
+      return resolve({
+        server,
+        port: (server.address() as { port: number }).port,
+      });
+    });
+  });
+};
+
+/**
+ * Binds the port before building the router: `createMcpRouter` reads
+ * `resourceServerUrl` once at construction, so the real base URL has to exist
+ * first or the protected-resource metadata routes are never registered.
+ */
+const startMcpServer = async ({
+  authorizationServerPort,
+  publicMethods,
+}: {
+  authorizationServerPort: number;
+  publicMethods?: string[];
+}) => {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => {
+    return server.listen(0, resolve);
+  });
+  const base = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+
+  const mcpServer = new McpServer({ name: 'probe', version: '1.0.0' });
+  mcpServer.registerTool(
+    'secret-tool',
+    { description: 'names an internal resource', inputSchema: {} },
+    async () => {
+      return { content: [{ type: 'text' as const, text: 'ok' }] };
+    }
+  );
+
+  const app = new App();
+  app.use(bodyParser());
+  app.use(
+    createMcpRouter(mcpServer, {
+      auth: {
+        verifyToken: () => {
+          return Promise.reject(new Error('invalid'));
+        },
+        ...(publicMethods === undefined ? {} : { publicMethods }),
+        resourceServerUrl: base,
+        authorizationServerUrl: `http://127.0.0.1:${authorizationServerPort}`,
+      },
+    }).routes()
+  );
+  server.on('request', app.callback());
+
+  return { server, base };
+};
+
+/** Records whether the client reached the authorization redirect. */
+const recordingProvider = (authorizationUrls: string[]) => {
+  return {
+    get redirectUrl() {
+      return 'http://localhost/callback';
+    },
+    get clientMetadata() {
+      return {
+        client_name: 'probe',
+        redirect_uris: ['http://localhost/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      };
+    },
+    clientInformation: () => {
+      return undefined;
+    },
+    saveClientInformation: () => {},
+    tokens: () => {
+      return undefined;
+    },
+    saveTokens: () => {},
+    redirectToAuthorization: (url: URL) => {
+      authorizationUrls.push(`${url.origin}${url.pathname}`);
+    },
+    saveCodeVerifier: () => {},
+  };
+};
+
+const connectOAuthClient = async (publicMethods?: string[]) => {
+  const authorizationServer = await startAuthorizationServer();
+  const { server, base } = await startMcpServer({
+    authorizationServerPort: authorizationServer.port,
+    publicMethods,
+  });
+
+  const authorizationUrls: string[] = [];
+  const client = new Client({ name: 'probe-client', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(`${base}/mcp`), {
+    authProvider: recordingProvider(
+      authorizationUrls
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any,
+  });
+
+  let connectError: Error | undefined;
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    connectError = error as Error;
+  }
+
+  try {
+    await transport.close();
+  } catch {
+    /* the transport never opened when auth short-circuits the connect */
+  }
+  server.close();
+  authorizationServer.server.close();
+
+  return {
+    authorizationUrls,
+    connectError,
+    authorizationServerPort: authorizationServer.port,
+  };
+};
+
+describe('OAuth client flow under the default publicMethods', () => {
+  test('the 401 challenge drives a real MCP client into the authorization flow', async () => {
+    const { authorizationUrls, connectError, authorizationServerPort } =
+      await connectOAuthClient();
+
+    // Reaching the redirect is the whole point: the client resolved the
+    // RFC 9728 challenge, read the protected-resource document this router
+    // serves, discovered the authorization server, and registered.
+    expect(authorizationUrls).toEqual([
+      `http://127.0.0.1:${authorizationServerPort}/authorize`,
+    ]);
+
+    // `connect` rejecting is how the SDK says "finish the browser flow", not
+    // a failure to start it.
+    expect(connectError?.name).toBe('UnauthorizedError');
+  });
+
+  test('closing tools/list does not change how the flow starts', async () => {
+    const closed = await connectOAuthClient();
+    const open = await connectOAuthClient(['initialize', 'tools/list']);
+
+    expect(closed.authorizationUrls).toHaveLength(1);
+    expect(open.authorizationUrls).toHaveLength(1);
+    expect(closed.connectError?.name).toBe(open.connectError?.name);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,7 +840,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@theme-ui/css':
         specifier: ^0.17.4
-        version: 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+        version: 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@types/react-modal':
         specifier: ^3.16.3
         version: 3.16.3
@@ -1634,6 +1634,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ttoss/config':
         specifier: workspace:^
         version: link:../config
@@ -1642,7 +1645,7 @@ importers:
         version: 3.0.3
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@26.1.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@26.1.1)(typescript@6.0.3))
+        version: 30.4.2(@types/node@24.12.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@24.12.4)(typescript@6.0.3))
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -5958,6 +5961,10 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
 
   '@modelcontextprotocol/core@2.0.0':
     resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
@@ -11551,6 +11558,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -14428,6 +14443,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -22492,6 +22511,16 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
       zod: 4.4.3
@@ -24623,7 +24652,7 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
@@ -24634,7 +24663,7 @@ snapshots:
       '@styled-system/should-forward-prop': 5.1.5
       '@styled-system/space': 5.1.2
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@types/styled-system': 5.1.25
       react: 19.2.6
@@ -24642,11 +24671,11 @@ snapshots:
   '@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       deepmerge: 4.3.1
       react: 19.2.6
 
-  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(react@19.2.6))':
+  '@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       csstype: 3.2.3
@@ -24655,13 +24684,13 @@ snapshots:
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/match-media@0.17.4(@theme-ui/core@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@theme-ui/css@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)))(react@19.2.6)':
     dependencies:
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
@@ -24669,7 +24698,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
 
   '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
@@ -28946,6 +28975,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -32755,6 +32790,8 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkce-challenge@5.0.1: {}
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -35238,7 +35275,7 @@ snapshots:
       '@theme-ui/color-modes': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/components': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@theme-ui/theme-provider@0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@theme-ui/core': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
-      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(react@19.2.6))
+      '@theme-ui/css': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))
       '@theme-ui/global': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@theme-ui/theme-provider': 0.17.4(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       react: 19.2.6


### PR DESCRIPTION
Closes #1176.

`auth.publicMethods` now defaults to `['initialize']` instead of `['initialize', 'tools/list']`. A server with `auth` configured no longer serves its tool catalogue — every name, description, and input schema — to unauthenticated callers.

## Why now, and why this is not just a judgement call

#1176 asked for one empirical check before deciding: point a real MCP client at a server with `publicMethods: ['initialize']` and confirm it follows the `401` into the OAuth flow rather than failing. I ran it, and also measured the lifecycle end to end. Both results are in [the issue comment](https://github.com/ttoss/ttoss/issues/1176#issuecomment-5518723388).

**The rationale for keeping `tools/list` open does not hold on either protocol era.** It was kept public so clients could discover the server before authenticating. Measured unauthenticated:

| `publicMethods` | 2025 `initialize` | 2025 `notifications/initialized` | 2025 `tools/list` | 2026 `server/discover` | 2026 `tools/list` |
| --- | --- | --- | --- | --- | --- |
| unset (old default) | `200` | `401` | **`200`** | `401` | **`200`** |
| `['initialize']` (this PR) | `200` | `401` | `401` | `401` | `401` |
| `[]` | `401` | `401` | `401` | `401` | `401` |

On `2026-07-28`, `server/discover` already returns `401` under every setting — the old default named `initialize`, which that era dropped. So it forced authentication to discover the server while still handing out the full catalogue anonymously. On the 2025 era, `notifications/initialized` already returns `401`, so a client that lists tools anonymously is already stuck. In both eras the only beneficiary was a caller who never intends to authenticate.

**Closing it does not strand OAuth clients.** `tests/unit/tests/oauth-client-flow.test.ts` drives the official MCP client SDK against a real socket and asserts it reaches `redirectToAuthorization`: the RFC 9728 challenge resolves to the protected-resource document this router serves, then the authorization server, then the redirect — identically whether `tools/list` is open or closed. This replaces the reasoning #1176 was blocked on, per the guideline's "verify against real consumers".

## Per the Breaking Changes guideline

- **Required by the goal, not incidental.** The goal *is* the default change; there is no additive path that also closes the exposure.
- **Loudness:** runtime, on every request. An unauthenticated `tools/list` returns `401` immediately, so a smoke test surfaces it. That is the "ship it with care" row, not "make it opt-in" — and the mechanism-first step was already served by the one-time warning shipped earlier.
- `BREAKING CHANGE:` footer on the commit, `MIGRATIONS.md` added and linked from the README, and the test asserting the old behaviour is kept as the explicit opt-in case.

## Changes

- `DEFAULT_PUBLIC_METHODS` is `['initialize']`; JSDoc explains what opening `tools/list` costs.
- The one-time startup warning that pre-announced this change is removed, with its three tests — the default it warned about is now the secure one.
- `MIGRATIONS.md` added (and shipped in the package `files`), linked from the README.
- README's two `publicMethods` sections and `docs/.../guidelines/mcp-server-oauth.md` updated.
- New `oauth-client-flow.test.ts`, with `@modelcontextprotocol/client` as a devDependency.

## Verification

- `@ttoss/http-server-mcp`: 125 tests pass. Branch coverage **95.35% → 97.65%**, threshold raised to 97.6. It would have dipped to 95.31% from deleting the warning branch, so I closed three pre-existing gaps (`apiCall`'s `HTTP <status>` fallback, and the non-`Error` throw paths in the POST and DELETE handlers) to net upward rather than lower the threshold.
- `@ttoss/http-server-mcp-openapi`: 64 tests pass. `examples/http-server-mcp-calculator` typechecks; it does not use `auth`.
- `pnpm run -w lint` clean, `syncpack lint` clean, `pnpm install --frozen-lockfile` clean.
- `docs/website` builds clean, and CI is green on `730d097`.

## One thing for the reviewer

**Lockfile churn.** Adding the devDependency also moved two unrelated peer-resolution keys (`jest`'s `@types/node` 26.1.1 → 24.12.4, and `@types/react` appearing in `@theme-ui/css`'s emotion key). That is what pnpm generates here today. I tried reverting those hunks and it corrupted the lock, so this is pnpm's own output — `--frozen-lockfile` passes on it. Happy to split the devDependency out if you would rather keep the lock untouched.

## The docs build caught a real defect (fixed in 730d097)

The first push was red, and it was mine. The docs site generates each package's API page from its README via typedoc-plugin-markdown, which rewrites a relative link to a sibling repo file into `_media/<file>`; Docusaurus ignores `_`-prefixed paths, so the link can never resolve and `@docs/website#build` failed. `./MIGRATIONS.md` was the only relative Markdown link in any package README, which is why nothing had hit this before — it now uses the absolute `blob/main` URL other READMEs already use.

Regenerating the API docs also showed the `publicMethods` `@example` name spanned two lines, so typedoc took the first line as the example name and left "self-discover from the very first request" orphaned in the rendered body. Both examples now sit in one code block with the explanation as comments.

I originally noted here that `pnpm turbo run build` could not run locally, because `@ttoss/i18n-cli#build-config` fails in this environment with `[BABEL]: request for '@babel/helper-plugin-utils' is from a module not been linked` (it fails identically on a clean `main`, so it predates this branch). That is still true of the full turbo build, but the docs build can be run directly — I reproduced the failure and confirmed the fix that way before pushing, and CI has since confirmed it.

## Follow-up, not in this PR

The 2026 era has no public discovery method at all, since `DEFAULT_PUBLIC_METHODS` names `initialize` and that era uses `server/discover`. Answering `401` there is defensible — RFC 9728 discovery is driven by the challenge — but it is currently a leftover rather than a decision, and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vN9NAdqTpNxHQBeVpVxaJ