### PR TITLE
fix(carlin): upload dot files and directories to S3

### DIFF
--- a/docs/website/docs/carlin/commands/deploy-static-app.mdx
+++ b/docs/website/docs/carlin/commands/deploy-static-app.mdx
@@ -18,6 +18,13 @@ This command:
 4. Uploads files to S3
 5. Configures caching and CDN
 
+Everything in the build folder is uploaded, including dot files and dot
+directories. That is what makes `/.well-known/` work: [RFC 8615](https://www.rfc-editor.org/rfc/rfc8615)
+puts the documents agents and clients fetch by convention there — an
+`ard.json` catalog, OAuth authorization server metadata, `security.txt` — and
+they have to answer on that exact path. Source maps are the one exception, and
+they have [an option](#--upload-source-maps).
+
 ## Quick Start
 
 Build and deploy a Vite app:

--- a/packages/carlin/jest.config.ts
+++ b/packages/carlin/jest.config.ts
@@ -6,9 +6,9 @@ const config = jestConfig({
   coveragePathIgnorePatterns: ['<rootDir>/tests/'],
   coverageThreshold: {
     global: {
-      statements: 73.2,
-      branches: 65.3,
-      lines: 73.1,
+      statements: 73.23,
+      branches: 65.33,
+      lines: 73.16,
       functions: 75.3,
     },
   },

--- a/packages/carlin/src/deploy/s3.ts
+++ b/packages/carlin/src/deploy/s3.ts
@@ -100,13 +100,19 @@ export const uploadFileToS3 = async ({
 
 /**
  * Get all files inside $directory.
+ *
+ * `dot: true` because a static site's dot directories are content: RFC 8615
+ * puts the files agents and clients fetch by convention under `.well-known/`,
+ * and glob skips a segment starting with a dot by default. Without it those
+ * files are absent from the deployed site and nothing reports it — the deploy
+ * succeeds, the path 404s.
  */
 export const getAllFilesInsideADirectory = async ({
   directory,
 }: {
   directory: string;
 }) => {
-  const allFilesAndDirectories = await glob(`${directory}/**/*`);
+  const allFilesAndDirectories = await glob(`${directory}/**/*`, { dot: true });
 
   const allFiles = allFilesAndDirectories
     /**

--- a/packages/carlin/tests/unit/s3.test.ts
+++ b/packages/carlin/tests/unit/s3.test.ts
@@ -404,6 +404,26 @@ describe('S3 Utils', () => {
     });
 
     /**
+     * RFC 8615 puts the files agents and clients fetch by convention under
+     * `.well-known/` — an ARD catalog, OAuth authorization server metadata,
+     * `security.txt`. glob skips any path segment starting with a dot unless
+     * told otherwise, so these would be absent from the deployed site with
+     * nothing failing to say so.
+     */
+    test('should upload files inside a dot directory', async () => {
+      fs.mkdirSync(path.join(directory, '.well-known'));
+      fs.writeFileSync(path.join(directory, '.well-known', 'ard.json'), 'x');
+      writeFiles(['index.html']);
+
+      await uploadDirectoryToS3({ bucket: 'test-bucket', directory });
+
+      expect(uploadedKeys().sort()).toEqual([
+        '.well-known/ard.json',
+        'index.html',
+      ]);
+    });
+
+    /**
      * "Directory has no files" means the build folder is probably wrong. A
      * directory holding only source maps is a different situation and must not
      * borrow that error, so the filter runs after the emptiness check.


### PR DESCRIPTION
## The bug

`getAllFilesInsideADirectory` globs `${directory}/**/*`, and glob skips any path segment starting with a dot unless `dot: true` is passed. A build folder's `.well-known/` therefore never reaches the bucket.

Verified against the glob the lockfile pins (`glob@10.5.0`), on a fixture of `dist/index.html`, `dist/sub/a.txt`, `dist/.well-known/ard.json`:

```
DEFAULT : ["dist/index.html","dist/sub","dist/sub/a.txt"]
DOT     : ["dist/.well-known","dist/.well-known/ard.json","dist/index.html","dist/sub","dist/sub/a.txt"]
```

**Nothing reports it.** The deploy succeeds, the file count looks plausible, the empty-directory guard is satisfied — and the path 404s in production. That silence is what makes this worth fixing rather than documenting: the failure surfaces as a third party saying your site does not implement a standard.

## Why `.well-known/` in particular

[RFC 8615](https://www.rfc-editor.org/rfc/rfc8615) makes it the place a site answers the documents agents and clients fetch by convention, each on an exact path with no alternative location:

- `/.well-known/ard.json` — an [Agentic Resource Discovery](https://agenticresourcediscovery.org/) catalog, how an AI client finds your MCP servers, agents and APIs
- `/.well-known/oauth-authorization-server` — RFC 8414 metadata, which must be served from the issuer origin
- `/.well-known/security.txt` — RFC 9116

A static app deployed by carlin could not publish any of them. That is how this was found: a site tried to publish an ARD catalog and the file simply was not there after a green deploy.

## The change

One argument, plus the comment explaining why it is not incidental:

```ts
const allFilesAndDirectories = await glob(`${directory}/**/*`, { dot: true });
```

Source maps stay excluded — that filter is deliberate, lives downstream in `uploadDirectoryToS3`, and has its own `--upload-source-maps` option. This changes only what the walk *sees*.

`findDefaultBuildFolder` shares the walk and only counts files to decide whether a folder is a real build output, so a dot file now counts toward that too. That is the correct reading: a folder containing only `.well-known/ard.json` is a build output, not an empty directory.

## Tests

New case in `tests/unit/s3.test.ts`, alongside the existing source-map cases and using the same tmpdir fixture:

```ts
test('should upload files inside a dot directory', async () => {
  fs.mkdirSync(path.join(directory, '.well-known'));
  fs.writeFileSync(path.join(directory, '.well-known', 'ard.json'), 'x');
  writeFiles(['index.html']);

  await uploadDirectoryToS3({ bucket: 'test-bucket', directory });

  expect(uploadedKeys().sort()).toEqual(['.well-known/ard.json', 'index.html']);
});
```

Red before the fix (`Expected - 1 / Received + 0`, the `.well-known` key missing), green after.

```
pnpm run test          45 suites, 421 tests, 4 snapshots — all passing
pnpm run build         clean; dist/index.mjs carries `{ dot: true }`
pnpm run -w lint       exit 0 (eslint, prettier, syncpack)
```

Coverage thresholds updated per the package workflow: statements 73.2 → 73.23, branches 65.3 → 65.33, lines 73.1 → 73.16. `functions` stays at 75.3 — actual is 75.33 and a threshold never decreases.

## Docs

`docs/website/docs/carlin/commands/deploy-static-app.mdx` gains a short paragraph under Overview stating that everything in the build folder is uploaded, dot files included, with source maps named as the one exception and linked to their option.

## Note on the environment

This was developed on Node 22 / pnpm 11.4 against a filtered install (`pnpm install --filter "carlin..."`), so `turbo run build --filter=carlin` could not run its `build-config` stage — `@ttoss/i18n-cli` is in that graph but outside the filter and has no `node_modules`. The package's own `pnpm run build` and `pnpm run test` both run clean, and CI covers the full graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxf7SX53yo9n9KbNJGbctn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jxf7SX53yo9n9KbNJGbctn)_