### PR TITLE
feat(http-server-mcp): serve MCP Apps views with registerAppResource

### DIFF
--- a/packages/http-server-mcp/README.md
+++ b/packages/http-server-mcp/README.md
@@ -478,6 +478,78 @@ register({
 
 **`buildContext`** injects request-scoped values (DB clients, tenant IDs) into every handler call without threading them through each individual tool. It receives the full `ToolCallContext` so context can vary by identity or by call args.
 
+## MCP Apps (interactive UIs)
+
+The [`io.modelcontextprotocol/ui`](https://github.com/modelcontextprotocol/ext-apps) extension lets a tool result render as an interactive view instead of text. The view is a `ui://` resource holding an HTML document, which the host loads into a sandboxed iframe and talks to over `postMessage`; the tool points at it through its `_meta`.
+
+The extension asks nothing of the transport, so `createMcpRouter` serves it as-is on both protocol revisions. `registerAppResource` owns the parts that are easy to get wrong — the `ui://` scheme, the exact MIME type, `_meta.ui` on both the declaration and the read result, and the deprecated flat linkage key that is still legal until the extension reaches GA.
+
+```typescript
+import {
+  McpServer,
+  registerAppResource,
+  UI_EXTENSION_ID,
+  UI_RESOURCE_MIME_TYPE,
+  z,
+} from '@ttoss/http-server-mcp';
+
+const server = new McpServer(
+  { name: 'weather', version: '1.0.0' },
+  {
+    capabilities: {
+      extensions: { [UI_EXTENSION_ID]: { mimeTypes: [UI_RESOURCE_MIME_TYPE] } },
+    },
+  }
+);
+
+const dashboard = registerAppResource({
+  server,
+  name: 'weather_dashboard',
+  uri: 'ui://weather/dashboard',
+  description: 'Interactive weather dashboard',
+  html: dashboardHtml, // a string, or ({ uri }) => string built per read
+  ui: {
+    csp: { connectDomains: ['https://api.openweathermap.org'] },
+    prefersBorder: true,
+  },
+});
+
+server.registerTool(
+  'get-weather',
+  {
+    description: 'Get the weather for a location',
+    inputSchema: { location: z.string() },
+    _meta: dashboard.toolMeta(),
+  },
+  async ({ location }) => {
+    const forecast = await fetchForecast(location);
+    return {
+      // Text stays meaningful: it is what a host without Apps renders.
+      content: [{ type: 'text', text: summarise(forecast) }],
+      structuredContent: forecast,
+    };
+  }
+);
+```
+
+`toolMeta()` is the linkage for **every** registration path — `registerTool`, [`registerToolFromSchema`](#registertoolfromschemaserver-params), and a [`GatedToolDef`](#creategatedtoolregistraroptions) all take `_meta`:
+
+```typescript
+registerToolFromSchema(server, {
+  name: 'refresh-dashboard',
+  description: 'Refresh dashboard data',
+  // Callable by the view, hidden from the model.
+  _meta: dashboard.toolMeta({ visibility: ['app'] }),
+  handler: async () => ({ content: [{ type: 'text', text: 'refreshed' }] }),
+});
+```
+
+### Register the linkage unconditionally
+
+The spec suggests checking the client's declared capability before registering UI-enabled tools. Do not: that read is only reliable on the `2026-07-28` revision, where the capability arrives in each request's envelope. In this package's default [stateless mode](#stateless-vs-stateful-mode) there is no remembered `initialize` for a 2025-era client, so a capability-gated registration silently drops the view for every one of them.
+
+Declaring it always is also strictly more compatible — a host without Apps support ignores `_meta` and renders the tool's `content`, which is the extension's own graceful-degradation contract. Keep every tool's text result meaningful on its own and the fallback takes care of itself.
+
 ## Issuing tokens for MCP clients
 
 The `auth` option above covers the **resource-server** half of MCP authorization — it verifies tokens issued by an external authorization server (Cognito, Auth0, …). To make your own first-party server _issue_ the tokens an MCP client runs the full OAuth flow against, add the [`@ttoss/http-server-auth`](https://ttoss.dev/docs/modules/packages/http-server-auth) plugin's `oauthServer()` and pair it with `createMcpRouter({ auth: { verifyToken } })` so one deployment both issues and verifies tokens. See the [OAuth Authorization Server](https://ttoss.dev/docs/engineering/guidelines/oauth-authorization-server) guideline.
@@ -582,6 +654,7 @@ The `GatedToolDef` passed to `register` has:
 - `requiredScope` — Single scope that must appear in `identity.scopes`.
 - `inputSchema` — Zod field map or `ZodObject`, forwarded to `server.registerTool`.
 - `gates` (`Array<(ctx: ToolCallContext) => void | Promise<void>>`, optional) — Per-tool guards appended after the global `gates`. Receive the full `ToolCallContext` enabling arg-conditional authorization.
+- `_meta` (`Record<string, unknown>`, optional) — Tool metadata forwarded verbatim on `tools/list`; how a gated tool links to an [MCP Apps](#mcp-apps-interactive-uis) view.
 - `method` — Async handler. Receives merged call args + `buildContext` output.
 
 **`ToolCallContext`** is the object passed to gates, `buildContext`, and `onError`:
@@ -589,6 +662,33 @@ The `GatedToolDef` passed to `register` has:
 - `identity` (`ToolIdentity`) — The resolved caller identity (`{ userId, scopes? }`).
 - `args` (`Record<string, unknown>`) — The validated tool input (post SDK parse).
 - `handler` (`string`) — The tool name, for error attribution.
+
+### `registerAppResource(params)`
+
+Registers an [MCP Apps](#mcp-apps-interactive-uis) view: a `ui://` resource whose HTML a host renders for a linked tool's result.
+
+**Parameters (`params`):**
+
+- `server` (`McpServer`) — The MCP server to register the resource on.
+- `name` (`string`) — Resource name, as listed by `resources/list`.
+- `uri` (`string`) — Resource URI. Must use the `ui://` scheme, or the call throws.
+- `description` (`string`, optional) — What the view does and when a host should render it.
+- `html` (`string | ({ uri: URL }) => string | Promise<string>`) — The view's HTML5 document, or a builder invoked per `resources/read`.
+- `ui` (`UiResourceMeta`, optional) — Rendering and security configuration relayed to the host as `_meta.ui`:
+  - `csp` (`UiResourceCsp`) — Origins the view may reach, mapped onto the iframe's Content Security Policy: `connectDomains` (`connect-src`), `resourceDomains` (scripts/styles/images/fonts/media), `frameDomains` (`frame-src`), `baseUriDomains` (`base-uri`). An omitted list is the restrictive default, not "no restriction".
+  - `permissions` (`UiResourcePermissions`) — Browser capabilities requested for the view (`camera`, `microphone`, `geolocation`, `clipboardWrite`), each as `{}`. A host _may_ grant them, so feature-detect in the view rather than assuming.
+  - `domain` (`string`) — Dedicated sandbox origin, for views needing a stable one (OAuth callbacks, CORS, API key allowlists). The format is host-specific.
+  - `prefersBorder` (`boolean`) — Whether the host should draw a border and background around the view.
+
+**Returns:** `RegisteredAppResource`
+
+- `uri` (`string`) — The URI tools link to.
+- `resource` (`RegisteredResource`) — The SDK's registration handle, for `update`/`disable`/`remove`.
+- `toolMeta(params?)` — Builds the `_meta` bag linking a tool to this view, writing both `_meta.ui.resourceUri` and the deprecated flat `_meta['ui/resourceUri']`. Takes `visibility` (`Array<'model' | 'app'>`, optional — the spec's default is both) and `_meta` (`Record<string, unknown>`, optional) to merge further entries in.
+
+### `UI_EXTENSION_ID` / `UI_RESOURCE_MIME_TYPE`
+
+`'io.modelcontextprotocol/ui'` and `'text/html;profile=mcp-app'`. Use the first as the `capabilities.extensions` key when advertising Apps support on the `McpServer`, and the second as the MIME type a host negotiates.
 
 ### `registerToolFromSchema(server, params)`
 
@@ -603,6 +703,7 @@ Use this when tool definitions are shared between the MCP server and an AI SDK a
 - `params.description` (`string`, optional) — Human-readable description
 - `params.inputSchema` (`JsonObjectSchema`, optional) — Plain JSON Schema object (defaults to `{ type: 'object', properties: {} }`)
 - `params.validateArguments` (`boolean`, optional) — Enforce `inputSchema` on `tools/call` (default: `false`); see [Argument validation](#argument-validation)
+- `params._meta` (`Record<string, unknown>`, optional) — Tool metadata forwarded verbatim on `tools/list`; how a tool links to an [MCP Apps](#mcp-apps-interactive-uis) view
 - `params.handler` (`(args: Record<string, unknown>) => CallToolResult | Promise<CallToolResult>`) — Tool handler receiving the raw request arguments
 
 **Returns:** `void`
@@ -954,3 +1055,4 @@ newest first.
 - [MCP Documentation](https://modelcontextprotocol.io)
 - [MCP Specification](https://spec.modelcontextprotocol.io/)
 - [MCP SDK TypeScript](https://github.com/modelcontextprotocol/typescript-sdk)
+- [MCP Apps extension (`io.modelcontextprotocol/ui`)](https://github.com/modelcontextprotocol/ext-apps)

--- a/packages/http-server-mcp/src/createGatedToolRegistrar.ts
+++ b/packages/http-server-mcp/src/createGatedToolRegistrar.ts
@@ -40,6 +40,11 @@ export type GatedToolDef = {
    * Throw to reject the call; return (or resolve) to continue.
    */
   gates?: Array<(ctx: ToolCallContext) => void | Promise<void>>;
+  /**
+   * Tool metadata forwarded verbatim on `tools/list` — how a gated tool links
+   * to an MCP Apps view (`registerAppResource(...).toolMeta()`).
+   */
+  _meta?: Record<string, unknown>;
   /** The tool handler. Receives merged call args + `buildContext` output. */
   method: (args: Record<string, unknown>) => Promise<unknown>;
 };
@@ -204,6 +209,7 @@ export const createGatedToolRegistrar = ({
       {
         description: def.description,
         inputSchema: def.inputSchema as RegisterToolArgs[1]['inputSchema'],
+        _meta: def._meta,
       },
       handler as unknown as RegisterToolArgs[2]
     );

--- a/packages/http-server-mcp/src/index.ts
+++ b/packages/http-server-mcp/src/index.ts
@@ -737,6 +737,18 @@ export const createMcpRouter = (
 };
 
 export {
+  registerAppResource,
+  type RegisterAppResourceParams,
+  type RegisteredAppResource,
+  type ToolMetaParams,
+  UI_EXTENSION_ID,
+  UI_RESOURCE_MIME_TYPE,
+  type UiResourceCsp,
+  type UiResourceMeta,
+  type UiResourcePermissions,
+  type UiToolVisibility,
+} from './registerAppResource';
+export {
   type JsonObjectSchema,
   registerToolFromSchema,
   type RegisterToolFromSchemaParams,

--- a/packages/http-server-mcp/src/registerAppResource.ts
+++ b/packages/http-server-mcp/src/registerAppResource.ts
@@ -1,0 +1,254 @@
+import type {
+  McpServer,
+  RegisteredResource,
+} from '@modelcontextprotocol/server';
+
+/**
+ * Identifier of the MCP Apps extension (`io.modelcontextprotocol/ui`), used as
+ * the key under `capabilities.extensions` on both sides of the handshake.
+ *
+ * A client declares Apps support with it; a server may advertise the same key
+ * so a host can discover the support without inspecting tool metadata:
+ *
+ * ```typescript
+ * new McpServer(
+ *   { name: 'weather', version: '1.0.0' },
+ *   {
+ *     capabilities: {
+ *       extensions: {
+ *         [UI_EXTENSION_ID]: { mimeTypes: [UI_RESOURCE_MIME_TYPE] },
+ *       },
+ *     },
+ *   }
+ * );
+ * ```
+ */
+export const UI_EXTENSION_ID = 'io.modelcontextprotocol/ui';
+
+/** MIME type every MCP Apps HTML resource is served as. */
+export const UI_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
+
+/**
+ * Deprecated flat tool metadata key for the linked resource URI. Written
+ * alongside `_meta.ui.resourceUri` because both forms are legal until the
+ * extension reaches GA, at which point this key is removed from the spec.
+ */
+const LEGACY_RESOURCE_URI_KEY = 'ui/resourceUri';
+
+/**
+ * Origins an app's view is allowed to reach, mapped by the host onto the
+ * iframe's Content Security Policy. Anything not declared is blocked: an
+ * omitted list is the restrictive default, not "no restriction".
+ */
+export interface UiResourceCsp {
+  /** Origins for network requests (`connect-src`). */
+  connectDomains?: string[];
+  /**
+   * Origins for scripts, styles, images, fonts and media (`script-src`,
+   * `style-src`, `img-src`, `font-src`, `media-src`).
+   */
+  resourceDomains?: string[];
+  /** Origins for nested iframes (`frame-src`). */
+  frameDomains?: string[];
+  /** Allowed document base URIs (`base-uri`). */
+  baseUriDomains?: string[];
+}
+
+/**
+ * Browser capabilities the view asks for. A host *may* grant them, so a view
+ * should feature-detect rather than assume: each key is a request, not a
+ * guarantee.
+ */
+export interface UiResourcePermissions {
+  camera?: Record<string, never>;
+  microphone?: Record<string, never>;
+  geolocation?: Record<string, never>;
+  clipboardWrite?: Record<string, never>;
+}
+
+/** Rendering and security configuration for an app's view (`_meta.ui`). */
+export interface UiResourceMeta {
+  /** Origins the view may reach; omitted means none. */
+  csp?: UiResourceCsp;
+  /** Browser capabilities requested for the view. */
+  permissions?: UiResourcePermissions;
+  /**
+   * Dedicated sandbox origin for the view, for cases needing a stable origin
+   * (OAuth callbacks, CORS, API key allowlists). The accepted format is
+   * host-specific; consult the host's documentation rather than deriving one.
+   */
+  domain?: string;
+  /** Whether the host should draw a border and background around the view. */
+  prefersBorder?: boolean;
+}
+
+/** Who may reach a tool. Defaults to both when left unset. */
+export type UiToolVisibility = 'model' | 'app';
+
+/** Parameters for {@link registerAppResource}. */
+export interface RegisterAppResourceParams {
+  /** The `McpServer` instance to register the app resource on. */
+  server: McpServer;
+  /** Resource name, as listed by `resources/list`. */
+  name: string;
+  /** Resource URI. Must use the `ui://` scheme. */
+  uri: string;
+  /** What the view does and when a host should render it. */
+  description?: string;
+  /**
+   * The view's HTML5 document, or a builder invoked per `resources/read`.
+   * A builder receives the requested URI so one registration can serve
+   * variants of a document.
+   */
+  html: string | ((args: { uri: URL }) => string | Promise<string>);
+  /** Rendering and security configuration relayed to the host as `_meta.ui`. */
+  ui?: UiResourceMeta;
+}
+
+/** Parameters for {@link RegisteredAppResource.toolMeta}. */
+export interface ToolMetaParams {
+  /**
+   * Who may reach the tool. Left unset, the spec's default applies — visible
+   * to the model *and* callable by the app.
+   */
+  visibility?: UiToolVisibility[];
+  /** Further `_meta` entries to merge in, e.g. vendor-namespaced keys. */
+  _meta?: Record<string, unknown>;
+}
+
+/** An app resource registered by {@link registerAppResource}. */
+export interface RegisteredAppResource {
+  /** The URI tools link to. */
+  uri: string;
+  /** The SDK's registration handle, for `update`/`disable`/`remove`. */
+  resource: RegisteredResource;
+  /**
+   * Builds the `_meta` bag that links a tool to this view. Pass it to
+   * `registerTool`, {@link registerToolFromSchema}, or a `GatedToolDef` —
+   * whichever registration path the tool uses.
+   */
+  toolMeta: (params?: ToolMetaParams) => Record<string, unknown>;
+}
+
+/**
+ * Registers an MCP Apps view: a `ui://` resource a tool result is rendered
+ * with, per the `io.modelcontextprotocol/ui` extension.
+ *
+ * The extension asks nothing of the transport — a view is an ordinary MCP
+ * resource, and the tool linkage is ordinary tool `_meta` — so this is
+ * registration sugar over `registerResource`, not new protocol surface. What
+ * it owns is the part that is easy to get wrong: the `ui://` scheme, the exact
+ * MIME type, `_meta.ui` on both the declaration and the read result, and
+ * writing the deprecated flat linkage key alongside the current one.
+ *
+ * **Register the linkage unconditionally.** The extension's negotiation is
+ * per-request and only reliably readable on the `2026-07-28` revision; in this
+ * package's default stateless 2025-era mode there is no remembered
+ * `initialize` to read a client capability from. Gating registration on that
+ * capability would therefore silently drop the view for every 2025-era client.
+ * A host without Apps support simply ignores `_meta`, so keep each tool's
+ * `content` meaningful on its own and let the text result be the fallback.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   McpServer,
+ *   registerAppResource,
+ *   UI_EXTENSION_ID,
+ *   UI_RESOURCE_MIME_TYPE,
+ *   z,
+ * } from '@ttoss/http-server-mcp';
+ *
+ * const server = new McpServer(
+ *   { name: 'weather', version: '1.0.0' },
+ *   {
+ *     capabilities: {
+ *       extensions: { [UI_EXTENSION_ID]: { mimeTypes: [UI_RESOURCE_MIME_TYPE] } },
+ *     },
+ *   }
+ * );
+ *
+ * const dashboard = registerAppResource({
+ *   server,
+ *   name: 'weather_dashboard',
+ *   uri: 'ui://weather/dashboard',
+ *   description: 'Interactive weather dashboard',
+ *   html: dashboardHtml,
+ *   ui: {
+ *     csp: { connectDomains: ['https://api.openweathermap.org'] },
+ *     prefersBorder: true,
+ *   },
+ * });
+ *
+ * server.registerTool(
+ *   'get-weather',
+ *   {
+ *     description: 'Get the weather for a location',
+ *     inputSchema: { location: z.string() },
+ *     _meta: dashboard.toolMeta(),
+ *   },
+ *   async ({ location }) => {
+ *     const forecast = await fetchForecast(location);
+ *     return {
+ *       // Text stays meaningful: it is what a host without Apps renders.
+ *       content: [{ type: 'text', text: summarise(forecast) }],
+ *       structuredContent: forecast,
+ *     };
+ *   }
+ * );
+ * ```
+ */
+export const registerAppResource = ({
+  server,
+  name,
+  uri,
+  description,
+  html,
+  ui,
+}: RegisterAppResourceParams): RegisteredAppResource => {
+  if (!uri.startsWith('ui://')) {
+    throw new Error(
+      `An MCP Apps resource URI must use the ui:// scheme (received "${uri}").`
+    );
+  }
+
+  const meta = ui === undefined ? undefined : { ui };
+
+  const resource = server.registerResource(
+    name,
+    uri,
+    {
+      description,
+      mimeType: UI_RESOURCE_MIME_TYPE,
+      ...(meta === undefined ? {} : { _meta: meta }),
+    },
+    async (requestedUri: URL) => {
+      const text =
+        typeof html === 'string' ? html : await html({ uri: requestedUri });
+
+      return {
+        contents: [
+          {
+            uri: requestedUri.href,
+            mimeType: UI_RESOURCE_MIME_TYPE,
+            text,
+            ...(meta === undefined ? {} : { _meta: meta }),
+          },
+        ],
+      };
+    }
+  );
+
+  const toolMeta = ({ visibility, _meta }: ToolMetaParams = {}) => {
+    return {
+      ..._meta,
+      ui: {
+        resourceUri: uri,
+        ...(visibility === undefined ? {} : { visibility }),
+      },
+      [LEGACY_RESOURCE_URI_KEY]: uri,
+    };
+  };
+
+  return { uri, resource, toolMeta };
+};

--- a/packages/http-server-mcp/src/registerToolFromSchema.ts
+++ b/packages/http-server-mcp/src/registerToolFromSchema.ts
@@ -53,6 +53,19 @@ export interface RegisterToolFromSchemaParams {
    */
   validateArguments?: boolean;
   /**
+   * Tool metadata forwarded verbatim on `tools/list`.
+   *
+   * The MCP Apps extension links a tool to the view its result is rendered
+   * with through this field; build the bag with `toolMeta()` from
+   * `registerAppResource` rather than writing the keys by hand.
+   *
+   * @example
+   * ```typescript
+   * _meta: dashboard.toolMeta({ visibility: ['app'] }),
+   * ```
+   */
+  _meta?: Record<string, unknown>;
+  /**
    * Tool handler invoked when the AI client calls the tool.
    * Receives the request arguments, validated against `inputSchema` only when
    * `validateArguments` is enabled.
@@ -113,7 +126,7 @@ const toStandardSchema = ({
  *
  * @param server - The `McpServer` instance to register the tool on.
  * @param params - Tool configuration including name, description, inputSchema,
- *   validateArguments, and handler.
+ *   validateArguments, `_meta`, and handler.
  *
  * @example
  * ```typescript
@@ -145,6 +158,7 @@ export const registerToolFromSchema = (
     inputSchema = { type: 'object', properties: {} },
     validateArguments = false,
     handler,
+    _meta,
   } = params;
 
   server.registerTool(
@@ -152,6 +166,7 @@ export const registerToolFromSchema = (
     {
       description,
       inputSchema: toStandardSchema({ inputSchema, validateArguments }),
+      _meta,
     },
     async (args) => {
       return handler(args as Record<string, unknown>);

--- a/packages/http-server-mcp/tests/unit/jest.config.ts
+++ b/packages/http-server-mcp/tests/unit/jest.config.ts
@@ -5,7 +5,7 @@ export default {
   coverageThreshold: {
     global: {
       statements: 100,
-      branches: 97.6,
+      branches: 97.8,
       functions: 100,
       lines: 100,
     },

--- a/packages/http-server-mcp/tests/unit/tests/createGatedToolRegistrar.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/createGatedToolRegistrar.test.ts
@@ -614,4 +614,52 @@ describe('createGatedToolRegistrar', () => {
       expect(handler).not.toHaveBeenCalled();
     });
   });
+  describe('tool metadata', () => {
+    test('forwards _meta to registerTool, e.g. an MCP Apps view linkage', () => {
+      const { server } = patchServer();
+      const { register } = createGatedToolRegistrar({
+        server,
+        resolveIdentity: () => {
+          return makeIdentity();
+        },
+      });
+
+      register({
+        name: 'gated-tool',
+        description: 'gated',
+        requiredScope: 'read',
+        inputSchema: {},
+        _meta: { ui: { resourceUri: 'ui://app/view' } },
+        method: jest.fn(),
+      });
+
+      expect(jest.mocked(server.registerTool).mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          _meta: { ui: { resourceUri: 'ui://app/view' } },
+        })
+      );
+    });
+
+    test('passes _meta as undefined when the tool declares none', () => {
+      const { server } = patchServer();
+      const { register } = createGatedToolRegistrar({
+        server,
+        resolveIdentity: () => {
+          return makeIdentity();
+        },
+      });
+
+      register({
+        name: 'gated-tool',
+        description: 'gated',
+        requiredScope: 'read',
+        inputSchema: {},
+        method: jest.fn(),
+      });
+
+      expect(
+        jest.mocked(server.registerTool).mock.calls[0][1]._meta
+      ).toBeUndefined();
+    });
+  });
 });

--- a/packages/http-server-mcp/tests/unit/tests/register-tool-from-schema.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/register-tool-from-schema.test.ts
@@ -474,4 +474,58 @@ describe('registerToolFromSchema', () => {
     expect(router).toBeDefined();
     expect(typeof router.routes).toBe('function');
   });
+  describe('tool metadata', () => {
+    test('forwards _meta verbatim on tools/list', async () => {
+      const server = new McpServer({ name: 'test', version: '1.0.0' });
+      registerToolFromSchema(server, {
+        name: 'get-project',
+        description: 'Get a project by ID',
+        _meta: {
+          ui: { resourceUri: 'ui://projects/detail', visibility: ['app'] },
+        },
+        handler: async () => {
+          return { content: [{ type: 'text', text: 'ok' }] };
+        },
+      });
+
+      const app = new App();
+      app.use(bodyParser());
+      app.use(createMcpRouter(server).routes());
+
+      const response = await sendMcpRequest(app.callback(), {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {},
+      });
+
+      expect(response.body.result.tools[0]._meta).toEqual({
+        ui: { resourceUri: 'ui://projects/detail', visibility: ['app'] },
+      });
+    });
+
+    test('publishes no _meta when the tool declares none', async () => {
+      const server = new McpServer({ name: 'test', version: '1.0.0' });
+      registerToolFromSchema(server, {
+        name: 'get-project',
+        description: 'Get a project by ID',
+        handler: async () => {
+          return { content: [{ type: 'text', text: 'ok' }] };
+        },
+      });
+
+      const app = new App();
+      app.use(bodyParser());
+      app.use(createMcpRouter(server).routes());
+
+      const response = await sendMcpRequest(app.callback(), {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {},
+      });
+
+      expect(response.body.result.tools[0]).not.toHaveProperty('_meta');
+    });
+  });
 });

--- a/packages/http-server-mcp/tests/unit/tests/registerAppResource.test.ts
+++ b/packages/http-server-mcp/tests/unit/tests/registerAppResource.test.ts
@@ -1,0 +1,352 @@
+import { App, bodyParser } from '@ttoss/http-server';
+import {
+  createMcpRouter,
+  McpServer,
+  registerAppResource,
+  registerToolFromSchema,
+  UI_EXTENSION_ID,
+  UI_RESOURCE_MIME_TYPE,
+  z,
+} from 'src/index';
+import request from 'supertest';
+
+const UI_URI = 'ui://weather-server/dashboard';
+const HTML = '<!DOCTYPE html><html><body>dashboard</body></html>';
+
+const mount = (server: McpServer) => {
+  const app = new App();
+  app.use(bodyParser());
+  app.use(createMcpRouter(server).routes());
+  return app.callback();
+};
+
+/** A 2025-era call — no per-request envelope. */
+const legacy = (server: McpServer, method: string, params: unknown = {}) => {
+  return request(mount(server))
+    .post('/mcp')
+    .send({ jsonrpc: '2.0', id: 1, method, params })
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json, text/event-stream');
+};
+
+/**
+ * A `2026-07-28` call. Name-carrying methods must repeat the selector in the
+ * `Mcp-Name` header, or the revision's own guard rejects the request before it
+ * reaches a handler.
+ */
+const modern = (
+  server: McpServer,
+  method: string,
+  params: Record<string, unknown> = {}
+) => {
+  const name = (params.name ?? params.uri) as string | undefined;
+  return request(mount(server))
+    .post('/mcp')
+    .send({
+      jsonrpc: '2.0',
+      id: 1,
+      method,
+      params: {
+        ...params,
+        _meta: {
+          'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+          'io.modelcontextprotocol/clientCapabilities': {
+            extensions: {
+              [UI_EXTENSION_ID]: { mimeTypes: [UI_RESOURCE_MIME_TYPE] },
+            },
+          },
+        },
+      },
+    })
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json, text/event-stream')
+    .set({
+      'Mcp-Method': method,
+      ...(name === undefined ? {} : { 'Mcp-Name': name }),
+    });
+};
+
+const buildServer = () => {
+  return new McpServer({ name: 'test-server', version: '1.0.0' });
+};
+
+describe('registerAppResource', () => {
+  describe('constants', () => {
+    test('exports the extension id and the app resource mime type', () => {
+      expect(UI_EXTENSION_ID).toBe('io.modelcontextprotocol/ui');
+      expect(UI_RESOURCE_MIME_TYPE).toBe('text/html;profile=mcp-app');
+    });
+  });
+
+  describe('resource registration', () => {
+    test('serves the HTML with the app mime type over resources/read', async () => {
+      const server = buildServer();
+      registerAppResource({
+        server,
+        name: 'weather_dashboard',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      const response = await legacy(server, 'resources/read', { uri: UI_URI });
+
+      expect(response.status).toBe(200);
+      expect(response.body.result.contents).toEqual([
+        { uri: UI_URI, mimeType: UI_RESOURCE_MIME_TYPE, text: HTML },
+      ]);
+    });
+
+    test('serves the same content on the 2026-07-28 revision', async () => {
+      const server = buildServer();
+      registerAppResource({
+        server,
+        name: 'weather_dashboard',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      const response = await modern(server, 'resources/read', { uri: UI_URI });
+
+      expect(response.status).toBe(200);
+      expect(response.body.result.contents[0]).toEqual({
+        uri: UI_URI,
+        mimeType: UI_RESOURCE_MIME_TYPE,
+        text: HTML,
+      });
+    });
+
+    test('relays _meta.ui on the read contents', async () => {
+      const server = buildServer();
+      registerAppResource({
+        server,
+        name: 'weather_dashboard',
+        uri: UI_URI,
+        html: HTML,
+        ui: {
+          csp: {
+            connectDomains: ['https://api.openweathermap.org'],
+            resourceDomains: ['https://cdn.jsdelivr.net'],
+          },
+          permissions: { geolocation: {} },
+          domain: 'a904794854a047f6.claudemcpcontent.com',
+          prefersBorder: true,
+        },
+      });
+
+      const response = await legacy(server, 'resources/read', { uri: UI_URI });
+
+      expect(response.body.result.contents[0]._meta).toEqual({
+        ui: {
+          csp: {
+            connectDomains: ['https://api.openweathermap.org'],
+            resourceDomains: ['https://cdn.jsdelivr.net'],
+          },
+          permissions: { geolocation: {} },
+          domain: 'a904794854a047f6.claudemcpcontent.com',
+          prefersBorder: true,
+        },
+      });
+    });
+
+    test('omits _meta from the read contents when no ui config is given', async () => {
+      const server = buildServer();
+      registerAppResource({
+        server,
+        name: 'weather_dashboard',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      const response = await legacy(server, 'resources/read', { uri: UI_URI });
+
+      expect(response.body.result.contents[0]).not.toHaveProperty('_meta');
+    });
+
+    test('declares the resource on resources/list, carrying _meta.ui', async () => {
+      const server = buildServer();
+      registerAppResource({
+        server,
+        name: 'weather_dashboard',
+        uri: UI_URI,
+        description: 'Interactive weather dashboard view',
+        html: HTML,
+        ui: { prefersBorder: false },
+      });
+
+      const response = await legacy(server, 'resources/list');
+
+      expect(response.body.result.resources).toEqual([
+        {
+          uri: UI_URI,
+          name: 'weather_dashboard',
+          description: 'Interactive weather dashboard view',
+          mimeType: UI_RESOURCE_MIME_TYPE,
+          _meta: { ui: { prefersBorder: false } },
+        },
+      ]);
+    });
+
+    test('builds the HTML per request when html is a function', async () => {
+      const server = buildServer();
+      const html = jest.fn(({ uri }: { uri: URL }) => {
+        return `<!DOCTYPE html><html><body>${uri.href}</body></html>`;
+      });
+      registerAppResource({ server, name: 'dash', uri: UI_URI, html });
+
+      const response = await legacy(server, 'resources/read', { uri: UI_URI });
+
+      expect(response.body.result.contents[0].text).toContain(UI_URI);
+      expect(html).toHaveBeenCalledWith({ uri: expect.any(URL) });
+    });
+
+    test('awaits an async html builder', async () => {
+      const server = buildServer();
+      registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: async () => {
+          return HTML;
+        },
+      });
+
+      const response = await legacy(server, 'resources/read', { uri: UI_URI });
+
+      expect(response.body.result.contents[0].text).toBe(HTML);
+    });
+
+    test('returns the SDK resource handle, so it can be disabled', async () => {
+      const server = buildServer();
+      const app = registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      app.resource.disable();
+
+      const response = await legacy(server, 'resources/list');
+
+      expect(response.body.result.resources).toEqual([]);
+    });
+
+    test.each([
+      ['https://example.com/dashboard.html'],
+      ['ui:/weather/dashboard'],
+      ['dashboard'],
+    ])('throws when the uri is not a ui:// URI (%s)', (uri) => {
+      const server = buildServer();
+
+      expect(() => {
+        return registerAppResource({ server, name: 'dash', uri, html: HTML });
+      }).toThrow(/ui:\/\//);
+    });
+  });
+
+  describe('toolMeta', () => {
+    test('carries the resource URI in both the current and deprecated keys', () => {
+      const server = buildServer();
+      const app = registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      expect(app.toolMeta()).toEqual({
+        ui: { resourceUri: UI_URI },
+        'ui/resourceUri': UI_URI,
+      });
+    });
+
+    test('includes visibility when given', () => {
+      const server = buildServer();
+      const app = registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      expect(app.toolMeta({ visibility: ['app'] })).toEqual({
+        ui: { resourceUri: UI_URI, visibility: ['app'] },
+        'ui/resourceUri': UI_URI,
+      });
+    });
+
+    test('merges extra _meta entries without letting them shadow the linkage', () => {
+      const server = buildServer();
+      const app = registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: HTML,
+      });
+
+      expect(app.toolMeta({ _meta: { 'dev.ttoss/audit': 'yes' } })).toEqual({
+        'dev.ttoss/audit': 'yes',
+        ui: { resourceUri: UI_URI },
+        'ui/resourceUri': UI_URI,
+      });
+    });
+
+    test('links a tool registered with registerTool, on both revisions', async () => {
+      const server = buildServer();
+      const app = registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: HTML,
+      });
+      server.registerTool(
+        'get_weather',
+        {
+          description: 'Get the weather',
+          inputSchema: { location: z.string() },
+          _meta: app.toolMeta(),
+        },
+        async ({ location }) => {
+          return { content: [{ type: 'text', text: location }] };
+        }
+      );
+
+      const expected = {
+        ui: { resourceUri: UI_URI },
+        'ui/resourceUri': UI_URI,
+      };
+
+      expect(
+        (await legacy(server, 'tools/list')).body.result.tools[0]._meta
+      ).toEqual(expected);
+      expect(
+        (await modern(server, 'tools/list')).body.result.tools[0]._meta
+      ).toEqual(expected);
+    });
+
+    test('links a tool registered with registerToolFromSchema', async () => {
+      const server = buildServer();
+      const app = registerAppResource({
+        server,
+        name: 'dash',
+        uri: UI_URI,
+        html: HTML,
+      });
+      registerToolFromSchema(server, {
+        name: 'get_weather',
+        description: 'Get the weather',
+        _meta: app.toolMeta({ visibility: ['model', 'app'] }),
+        handler: async () => {
+          return { content: [{ type: 'text', text: 'sunny' }] };
+        },
+      });
+
+      const response = await legacy(server, 'tools/list');
+
+      expect(response.body.result.tools[0]._meta).toEqual({
+        ui: { resourceUri: UI_URI, visibility: ['model', 'app'] },
+        'ui/resourceUri': UI_URI,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implements items 1–3 of #1231 — the server half of the [`io.modelcontextprotocol/ui`](https://github.com/modelcontextprotocol/ext-apps) extension (MCP Apps, spec **Stable 2026-01-26**).

The extension asks nothing of the transport: a view is an ordinary MCP resource, and the tool linkage is ordinary tool `_meta`. `createMcpRouter` therefore already served all of it on both protocol revisions, measured before writing any code (the table on #1224). What this PR adds is the part that is easy to get wrong by hand.

## What's new

**`registerAppResource({ server, name, uri, description?, html, ui? })`** — registers a `ui://` resource with the exact Apps MIME type, relays `_meta.ui` (CSP domains, requested permissions, dedicated sandbox domain, border preference) on **both** the `resources/list` declaration and the `resources/read` result, and throws on a URI that is not `ui://`. `html` is a string or a `({ uri }) => string | Promise<string>` builder invoked per read. It returns the SDK's own `RegisteredResource` handle alongside:

**`toolMeta({ visibility?, _meta? })`** — the linkage bag, writing both `_meta.ui.resourceUri` and the deprecated flat `_meta['ui/resourceUri']` while the spec still accepts either, so there is one place to delete when that key is removed before GA.

**`UI_EXTENSION_ID` / `UI_RESOURCE_MIME_TYPE`** — for the `capabilities.extensions` key on the `McpServer` and the negotiated MIME type.

**`_meta` on the other two registration paths.** `registerToolFromSchema` (what `@ttoss/http-server-mcp-openapi` registers through) and `GatedToolDef` accepted no `_meta`, so neither could link a view at all. Both now forward it verbatim, which makes `toolMeta()` usable from every registration path this package offers rather than only `registerTool`.

```typescript
const dashboard = registerAppResource({
  server,
  name: 'weather_dashboard',
  uri: 'ui://weather/dashboard',
  html: dashboardHtml,
  ui: { csp: { connectDomains: ['https://api.openweathermap.org'] }, prefersBorder: true },
});

server.registerTool(
  'get-weather',
  { description: '…', inputSchema: { location: z.string() }, _meta: dashboard.toolMeta() },
  async ({ location }) => ({
    // Text stays meaningful: it is what a host without Apps renders.
    content: [{ type: 'text', text: summarise(forecast) }],
    structuredContent: forecast,
  })
);
```

## One deliberate departure from the spec's example

The spec suggests checking the client's declared capability before registering UI-enabled tools. This package does not, and documents why: that read is only reliable on the `2026-07-28` revision, where the capability arrives in each request's envelope. In the default **stateless** 2025-era mode there is no remembered `initialize`, so a capability-gated registration would silently drop the view for every 2025-era client. Declaring it always is also strictly more compatible — a host without Apps ignores `_meta` and renders the tool's `content`, which is the extension's own graceful-degradation contract.

Item 4 of #1231 needs no code: `capabilities.extensions` is an `McpServer` constructor option and `createMcpRouter` receives an already-constructed server, so exporting the constants is the whole of the package's job. Item 5 (the view side — `@ttoss/ui` conventions, host theming, the `ui/initialize` bridge) stays out of scope and keeps its own issue.

## Testing

- 17 new tests in `tests/unit/tests/registerAppResource.test.ts` cover `resources/read` and `resources/list` on **both** protocol revisions, `_meta.ui` relay and its absence, string and sync/async builder `html`, the returned SDK handle, three rejected non-`ui://` URIs, and `toolMeta` linkage through `registerTool` and `registerToolFromSchema`.
- `_meta` pass-through tests added to `register-tool-from-schema.test.ts` and `createGatedToolRegistrar.test.ts`, each with the negative case (no `_meta` published when none is declared).
- `packages/http-server-mcp`: **150 tests pass**, `registerAppResource.ts` at 100% statements/branches/functions/lines. `coverageThreshold` branches raised 97.6 → 97.8 to match the new actual (97.87).
- Dependents: `@ttoss/http-server-mcp-openapi` 64 tests pass; `examples/http-server-mcp-calculator` `tsc --noEmit` clean.
- `pnpm run -w lint` leaves the committed tree untouched (the `pr.sh` gate), and `syncpack lint` is clean.

`pnpm turbo run test --filter=...@ttoss/http-server-mcp` and `tsdown` builds cannot run in this environment: every tsdown build in the repo dies in `@ttoss/i18n-cli#build-config` with `[BABEL]: request for '@babel/helper-plugin-utils' is from a module not been linked` under Node 22, where the repo requires Node ≥24. Reproduced on a clean tree with these changes stashed, so it is environmental and unrelated to this diff — hence the per-package equivalents above.

Refs #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5W2bZyH3TueukDFg6LzN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5W2bZyH3TueukDFg6LzN8)_